### PR TITLE
refactor: Support specifying specifiers for extension files

### DIFF
--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -190,6 +190,7 @@ macro_rules! extension {
     $(, ops = [ $( $(#[$m:meta])* $( $op:ident )::+ $( < $( $op_param:ident ),* > )?  ),+ $(,)? ] )?
     $(, esm_entry_point = $esm_entry_point:literal )?
     $(, esm = [ $( dir $dir_esm:literal , )? $( $esm:literal ),* $(,)? ] )?
+    $(, esm_with_specifiers = [ $( dir $dir_esm2:literal , )? $( ($esm_specifier:literal, $esm_file:literal) ),* $(,)? ] )?
     $(, js = [ $( dir $dir_js:literal , )? $( $js:literal ),* $(,)? ] )?
     $(, options = { $( $options_id:ident : $options_type:ty ),* $(,)? } )?
     $(, middleware = $middleware_fn:expr )?
@@ -217,6 +218,9 @@ macro_rules! extension {
       fn with_js(ext: &mut $crate::ExtensionBuilder) {
         $( ext.esm(
           $crate::include_js_files!( $name $( dir $dir_esm , )? $( $esm , )* )
+        ); )?
+        $( ext.esm(
+          $crate::include_js_files_with_specifiers!( $name $( dir $dir_esm2 , )? $( ( $esm_specifier, $esm_file) , )* )
         ); )?
         $(
           ext.esm_entry_point($esm_entry_point);
@@ -638,6 +642,36 @@ macro_rules! include_js_files {
         specifier: concat!("ext:", stringify!($name), "/", $file),
         code: $crate::ExtensionFileSourceCode::LoadedFromFsDuringSnapshot(
           std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join($file)
+        ),
+      },)+
+    ]
+  };
+}
+
+#[cfg(not(feature = "include_js_files_for_snapshotting"))]
+#[macro_export]
+macro_rules! include_js_files_with_specifiers {
+  ($name:ident dir $dir:literal, $( ( $specifier:literal , $file:literal ),)+) => {
+    vec![
+      $($crate::ExtensionFileSource {
+        specifier: $specifier,
+        code: $crate::ExtensionFileSourceCode::IncludedInBinary(
+          include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/", $dir, "/", $file))
+        ),
+      },)+
+    ]
+  };
+}
+
+#[cfg(feature = "include_js_files_for_snapshotting")]
+#[macro_export]
+macro_rules! include_js_files_with_specifiers {
+  ($name:ident dir $dir:literal, $( ( $specifier:literal , $file:literal ),)+) => {
+    vec![
+      $($crate::ExtensionFileSource {
+        specifier: $specifier,
+        code: $crate::ExtensionFileSourceCode::LoadedFromFsDuringSnapshot(
+          std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join($dir).join($file)
         ),
       },)+
     ]

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -888,14 +888,10 @@ impl ModuleMap {
   /// Clear the module map, meant to be used after initializing extensions.
   /// Optionally pass a list of exceptions `(old_name, new_name)` representing
   /// specifiers which will be renamed and preserved in the module map.
-  pub fn clear_module_map(
-    &mut self,
-    exceptions: impl Iterator<Item = (&'static str, &'static str)>,
-  ) {
+  pub fn clear_module_map(&mut self, exceptions: &'static [&'static str]) {
     let handles = exceptions
-      .map(|(old_name, new_name)| {
-        (self.get_handle_by_name(old_name).unwrap(), new_name)
-      })
+      .iter()
+      .map(|mod_name| (self.get_handle_by_name(mod_name).unwrap(), mod_name))
       .collect::<Vec<_>>();
     self.clear();
     for (handle, new_name) in handles {

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -404,7 +404,7 @@ pub struct RuntimeOptions {
   /// If provided, the module map will be cleared and left only with the specifiers
   /// in this list, with the new names provided. If not provided, the module map is
   /// left intact.
-  pub rename_modules: Option<Vec<(&'static str, &'static str)>>,
+  pub preserve_snapshotted_modules: Option<&'static [&'static str]>,
 
   /// V8 snapshot that should be loaded on startup.
   pub startup_snapshot: Option<Snapshot>,
@@ -711,11 +711,13 @@ impl JsRuntime {
       .unwrap();
 
     // If the user has requested that we rename modules
-    if let Some(rename_modules) = options.rename_modules {
+    if let Some(preserve_snapshotted_modules) =
+      options.preserve_snapshotted_modules
+    {
       js_runtime
         .module_map
         .borrow_mut()
-        .clear_module_map(rename_modules.into_iter());
+        .clear_module_map(preserve_snapshotted_modules);
     }
 
     js_runtime


### PR DESCRIPTION
Includes changes to support https://github.com/denoland/deno/pull/19680.

`esm_with_specifiers` was added to `extension!` macro as well as
`include_js_files_with_specifiers!` macro.