### PR TITLE
fix: ignore already evaluated extension modules

### DIFF
--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -901,6 +901,16 @@ impl JsRuntime {
               panic!("{} not present in the module map", specifier)
             })
         };
+        {
+          let module_map_rc = self.module_map.clone();
+          let module_map = module_map_rc.borrow();
+          let handle = module_map.handles.get(mod_id).unwrap().clone();
+          let mut scope = realm.handle_scope(self.v8_isolate());
+          let handle = v8::Local::new(&mut scope, handle);
+          if handle.get_status() == v8::ModuleStatus::Evaluated {
+            continue;
+          }
+        }
         let receiver = self.mod_evaluate(mod_id);
         self.run_event_loop(false).await?;
         receiver

--- a/core/runtime/tests.rs
+++ b/core/runtime/tests.rs
@@ -2394,3 +2394,25 @@ fn ops_in_js_have_proper_names() {
   "#;
   runtime.execute_script_static("test", src).unwrap();
 }
+
+#[test]
+fn duplicate_extension_esm_specifier() {
+  let ext1 = Extension::builder("ext1")
+    .esm(vec![ExtensionFileSource {
+      specifier: "file:///foo.js",
+      code: ExtensionFileSourceCode::IncludedInBinary(""),
+    }])
+    .esm_entry_point("file:///foo.js")
+    .build();
+  let ext2 = Extension::builder("ext2")
+    .esm(vec![ExtensionFileSource {
+      specifier: "file:///foo.js",
+      code: ExtensionFileSourceCode::IncludedInBinary(""),
+    }])
+    .esm_entry_point("file:///foo.js")
+    .build();
+  JsRuntime::new(RuntimeOptions {
+    extensions: vec![ext1, ext2],
+    ..Default::default()
+  });
+}


### PR DESCRIPTION
Pulled from https://github.com/denoland/deno/pull/19519. This is pretty much all it takes to replace `init_ops()` calls with `init_ops_and_esm()` without error, so snapshotting embedders can just use the latter whether they are creating a snapshot or consuming it.

(Using that _might_ be a footgun without the rest of the changes from that PR because it leaves the JS source paths in the extensions list and if any were mistakenly omitted from the snapshot, the program will attempt to load them at runtime in production. That's what I attempted to address with the `exclude_js_sources` feature. But it was too complex and introduced differences in the test build. Maybe we can find a different safety for that which doesn't rely on conditional compilation.)