### PR TITLE
feat(core): Implement v8::XXX args and return

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,12 +1021,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.1.25"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
 dependencies = [
  "proc-macro2",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -332,6 +332,7 @@ mod tests {
       op_test_v8_option_string,
       op_test_v8_type_return,
       op_test_v8_type_return_option,
+      op_test_v8_type_handle_scope,
     ]
   );
 
@@ -680,6 +681,15 @@ mod tests {
     s
   }
 
+  #[op2(core)]
+  pub fn op_test_v8_type_handle_scope<'s>(
+    scope: &mut v8::HandleScope<'s>,
+    s: &v8::String,
+  ) -> v8::Local<'s, v8::String> {
+    let s = s.to_rust_string_lossy(scope);
+    v8::String::new(scope, &s).unwrap()
+  }
+
   #[tokio::test]
   pub async fn test_op_v8_types() -> Result<(), Box<dyn std::error::Error>> {
     for (a, b) in [("a", 1), ("b", 2), ("c", 3)] {
@@ -689,21 +699,16 @@ mod tests {
         &format!("assert(op_test_v8_types('{a}', 'a', 'b') == {b})"),
       )?;
     }
-    run_test2(
-      1,
-      "op_test_v8_type_return",
-      "assert(op_test_v8_type_return('xyz') == 'xyz')",
-    )?;
-    run_test2(
-      1,
-      "op_test_v8_type_return_option",
-      "assert(op_test_v8_type_return_option('xyz') == 'xyz')",
-    )?;
-    run_test2(
-      1,
-      "op_test_v8_type_return_option",
-      "assert(op_test_v8_type_return_option(null) == null)",
-    )?;
+    for (a, b, c) in [
+      ("op_test_v8_type_return", "'xyz'", "'xyz'"),
+      ("op_test_v8_option_string", "'xyz'", "3"),
+      ("op_test_v8_option_string", "null", "-1"),
+      ("op_test_v8_type_return_option", "'xyz'", "'xyz'"),
+      ("op_test_v8_type_return_option", "null", "null"),
+      ("op_test_v8_type_handle_scope", "'xyz'", "'xyz'"),
+    ] {
+      run_test2(1, a, &format!("assert({a}({b}) == {c})"))?;
+    }
     Ok(())
   }
 }

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -333,6 +333,7 @@ mod tests {
       op_test_v8_type_return,
       op_test_v8_type_return_option,
       op_test_v8_type_handle_scope,
+      op_test_v8_type_handle_scope_obj,
     ]
   );
 
@@ -690,6 +691,16 @@ mod tests {
     v8::String::new(scope, &s).unwrap()
   }
 
+  /// Extract whatever lives in "key" from the object.
+  #[op2(core)]
+  pub fn op_test_v8_type_handle_scope_obj<'s>(
+    scope: &mut v8::HandleScope<'s>,
+    o: &v8::Object,
+  ) -> Option<v8::Local<'s, v8::Value>> {
+    let key = v8::String::new(scope, &"key").unwrap().into();
+    o.get(scope, key)
+  }
+
   #[tokio::test]
   pub async fn test_op_v8_types() -> Result<(), Box<dyn std::error::Error>> {
     for (a, b) in [("a", 1), ("b", 2), ("c", 3)] {
@@ -706,6 +717,17 @@ mod tests {
       ("op_test_v8_type_return_option", "'xyz'", "'xyz'"),
       ("op_test_v8_type_return_option", "null", "null"),
       ("op_test_v8_type_handle_scope", "'xyz'", "'xyz'"),
+      ("op_test_v8_type_handle_scope_obj", "{'key': 1}", "1"),
+      (
+        "op_test_v8_type_handle_scope_obj",
+        "{'key': 'abc'}",
+        "'abc'",
+      ),
+      (
+        "op_test_v8_type_handle_scope_obj",
+        "{'no_key': 'abc'}",
+        "null",
+      ),
     ] {
       run_test2(1, a, &format!("assert({a}({b}) == {c})"))?;
     }

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -329,6 +329,7 @@ mod tests {
       op_test_string_roundtrip,
       op_test_generics<String>,
       op_test_v8_types,
+      op_test_v8_option_string,
       op_test_v8_type_return,
       op_test_v8_type_return_option,
     ]
@@ -649,6 +650,15 @@ mod tests {
       2
     } else {
       3
+    }
+  }
+
+  #[op2(core)]
+  pub fn op_test_v8_option_string(s: Option<&v8::String>) -> i32 {
+    if let Some(s) = s {
+      s.length() as i32
+    } else {
+      -1
     }
   }
 

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -697,7 +697,7 @@ mod tests {
     scope: &mut v8::HandleScope<'s>,
     o: &v8::Object,
   ) -> Option<v8::Local<'s, v8::Value>> {
-    let key = v8::String::new(scope, &"key").unwrap().into();
+    let key = v8::String::new(scope, "key").unwrap().into();
     o.get(scope, key)
   }
 

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -636,6 +636,7 @@ mod tests {
   pub fn op_test_generics<T: Clone>() {}
 
   /// Tests v8 types without a handle scope
+  #[allow(clippy::needless_lifetimes)]
   #[op2(core)]
   pub fn op_test_v8_types<'s>(
     s: &v8::String,
@@ -653,6 +654,7 @@ mod tests {
 
   /// Tests v8 types without a handle scope
   #[op2(core)]
+  #[allow(clippy::needless_lifetimes)]
   pub fn op_test_v8_type_return<'s>(
     s: v8::Local<'s, v8::String>,
   ) -> v8::Local<'s, v8::String> {
@@ -661,6 +663,7 @@ mod tests {
 
   /// Tests v8 types without a handle scope
   #[op2(core)]
+  #[allow(clippy::needless_lifetimes)]
   pub fn op_test_v8_type_return_option<'s>(
     s: Option<v8::Local<'s, v8::String>>,
   ) -> Option<v8::Local<'s, v8::String>> {
@@ -679,17 +682,17 @@ mod tests {
     run_test2(
       1,
       "op_test_v8_type_return",
-      &format!("assert(op_test_v8_type_return('xyz') == 'xyz')"),
+      "assert(op_test_v8_type_return('xyz') == 'xyz')",
     )?;
     run_test2(
       1,
       "op_test_v8_type_return_option",
-      &format!("assert(op_test_v8_type_return_option('xyz') == 'xyz')"),
+      "assert(op_test_v8_type_return_option('xyz') == 'xyz')",
     )?;
     run_test2(
       1,
       "op_test_v8_type_return_option",
-      &format!("assert(op_test_v8_type_return_option(null) == null)"),
+      "assert(op_test_v8_type_return_option(null) == null)",
     )?;
     Ok(())
   }

--- a/ops/Cargo.toml
+++ b/ops/Cargo.toml
@@ -32,6 +32,6 @@ v8.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true
-prettyplease = "0.1.21"
+prettyplease = "0.2.9"
 testing_macros = "0.2.7"
 trybuild = "1.0.71"

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -1013,7 +1013,7 @@ mod tests {
     println!("-----Raw tokens-----\n{}----------\n", actual);
 
     // Validate syntax tree.
-    let tree = syn::parse2(actual).unwrap();
+    let tree = syn2::parse2(actual).unwrap();
     let actual = prettyplease::unparse(&tree);
     if update_expected {
       std::fs::write(input.with_extension("out"), actual)

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -268,6 +268,12 @@ fn map_arg_to_v8_fastcall_type(
 ) -> Result<Option<V8FastCallType>, V8MappingError> {
   let rv = match arg {
     Arg::OptionNumeric(_) | Arg::SerdeV8(_) => return Ok(None),
+    // We don't support v8 type arguments
+    Arg::V8Ref(..)
+    | Arg::V8Global(_)
+    | Arg::V8Local(_)
+    | Arg::OptionV8Local(_) => return Ok(None),
+
     Arg::Numeric(NumericArg::bool) => V8FastCallType::Bool,
     Arg::Numeric(NumericArg::u32)
     | Arg::Numeric(NumericArg::u16)
@@ -316,6 +322,11 @@ fn map_retval_to_v8_fastcall_type(
     // We don't return special return types
     Arg::Option(_) => return Ok(None),
     Arg::Special(_) => return Ok(None),
+    // We don't support returning v8 types
+    Arg::V8Ref(..)
+    | Arg::V8Global(_)
+    | Arg::V8Local(_)
+    | Arg::OptionV8Local(_) => return Ok(None),
     _ => {
       return Err(V8MappingError::NoMapping(
         "a fast return value",

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -267,7 +267,7 @@ fn map_arg_to_v8_fastcall_type(
   arg: &Arg,
 ) -> Result<Option<V8FastCallType>, V8MappingError> {
   let rv = match arg {
-    Arg::OptionNumeric(_) | Arg::SerdeV8(_) => return Ok(None),
+    Arg::OptionNumeric(_) | Arg::SerdeV8(_) | Arg::Ref(..) => return Ok(None),
     // We don't support v8 type arguments
     Arg::V8Ref(..)
     | Arg::V8Global(_)

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -272,7 +272,8 @@ fn map_arg_to_v8_fastcall_type(
     Arg::V8Ref(..)
     | Arg::V8Global(_)
     | Arg::V8Local(_)
-    | Arg::OptionV8Local(_) => return Ok(None),
+    | Arg::OptionV8Local(_)
+    | Arg::OptionV8Ref(..) => return Ok(None),
 
     Arg::Numeric(NumericArg::bool) => V8FastCallType::Bool,
     Arg::Numeric(NumericArg::u32)
@@ -326,7 +327,8 @@ fn map_retval_to_v8_fastcall_type(
     Arg::V8Ref(..)
     | Arg::V8Global(_)
     | Arg::V8Local(_)
-    | Arg::OptionV8Local(_) => return Ok(None),
+    | Arg::OptionV8Local(_)
+    | Arg::OptionV8Ref(..) => return Ok(None),
     _ => {
       return Err(V8MappingError::NoMapping(
         "a fast return value",

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -55,6 +55,7 @@ impl ToTokens for NumericArg {
   Copy, Clone, Debug, Eq, PartialEq, IntoStaticStr, EnumString, EnumIter,
 )]
 pub enum V8Arg {
+  Value,
   External,
   Object,
   Array,

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -143,6 +143,7 @@ pub enum Arg {
 impl Arg {
   /// Is this argument virtual? ie: does it come from the æther rather than a concrete JavaScript input
   /// argument?
+  #[allow(clippy::match_like_matches_macro)]
   pub fn is_virtual(&self) -> bool {
     match self {
       Self::Special(

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -386,6 +386,10 @@ fn parse_attributes(attributes: &[Attribute]) -> Result<Attributes, ArgError> {
   })
 }
 
+pub fn is_attribute_special(attr: &Attribute) -> bool {
+  parse_attribute(attr).is_some()
+}
+
 fn parse_attribute(attr: &Attribute) -> Option<AttributeModifier> {
   let tokens = attr.into_token_stream();
   use syn2 as syn;

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -117,6 +117,9 @@ pub enum RefType {
   Mut,
 }
 
+/// Args are not a 1:1 mapping with Rust types, rather they represent broad classes of types that
+/// tend to have similar argument handling characteristics. This may need one more level of indirection
+/// given how many of these types have option variants, however.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Arg {
   Void,
@@ -127,9 +130,27 @@ pub enum Arg {
   OptionNumeric(NumericArg),
   Slice(RefType, NumericArg),
   Ptr(RefType, NumericArg),
+  OptionV8Local(V8Arg),
   V8Local(V8Arg),
+  V8Global(V8Arg),
+  V8Ref(RefType, V8Arg),
   Numeric(NumericArg),
   SerdeV8(String),
+}
+
+enum ParsedType {
+  TSpecial(Special),
+  TV8(V8Arg),
+  TNumeric(NumericArg),
+}
+
+enum ParsedTypeContainer {
+  CBare(ParsedType),
+  COption(ParsedType),
+  CRcRefCell(ParsedType),
+  COptionV8Local(ParsedType),
+  CV8Local(ParsedType),
+  CV8Global(ParsedType),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -196,8 +217,14 @@ pub enum ArgError {
   InvalidTypePath(String),
   #[error("Too many attributes")]
   TooManyAttributes,
+  #[error("The type {0} cannot be a reference")]
+  InvalidReference(String),
+  #[error("The type {0} must be a reference")]
+  MissingReference(String),
   #[error("Invalid #[serde] type: {0}")]
   InvalidSerdeType(String),
+  #[error("Invalid #[string] type: {0}")]
+  InvalidStringType(String),
   #[error("Cannot use #[serde] for type: {0}")]
   InvalidSerdeAttributeType(String),
   #[error("Invalid v8 type: {0}")]
@@ -410,12 +437,21 @@ fn parse_return(
   }
 }
 
-fn parse_type_path(attrs: Attributes, tp: &TypePath) -> Result<Arg, ArgError> {
+/// Parse a raw type into a container + type, allowing us to simplify the typechecks elsewhere in
+/// this code.
+fn parse_type_path(
+  attrs: Attributes,
+  is_ref: bool,
+  tp: &TypePath,
+) -> Result<ParsedTypeContainer, ArgError> {
+  use ParsedType::*;
+  use ParsedTypeContainer::*;
+
   if tp.path.segments.len() == 1 {
     let segment = tp.path.segments.first().unwrap().ident.to_string();
     for numeric in NumericArg::iter() {
       if Into::<&'static str>::into(numeric) == segment.as_str() {
-        return Ok(Arg::Numeric(numeric));
+        return Ok(CBare(TNumeric(numeric)));
       }
     }
   }
@@ -423,42 +459,70 @@ fn parse_type_path(attrs: Attributes, tp: &TypePath) -> Result<Arg, ArgError> {
   use syn2 as syn;
 
   let tokens = tp.clone().into_token_stream();
-  std::panic::catch_unwind(|| {
+  let res = std::panic::catch_unwind(|| {
     rules!(tokens => {
       ( $( std :: str  :: )? String ) => {
-        if attrs.primary == Some(AttributeModifier::String) {
-          Ok(Arg::Special(Special::String))
-        } else {
-          Err(ArgError::MissingStringAttribute)
-        }
+        Ok(CBare(TSpecial(Special::String)))
       }
+      // Note that the reference is checked below
       ( $( std :: str  :: )? str ) => {
-        // We should not hit this path with a #[string] argument
-        Err(ArgError::MissingStringAttribute)
+        Ok(CBare(TSpecial(Special::RefStr)))
       }
       ( $( std :: borrow :: )? Cow < str > ) => {
-        if attrs.primary == Some(AttributeModifier::String) {
-          Ok(Arg::Special(Special::CowStr))
-        } else {
-          Err(ArgError::MissingStringAttribute)
-        }
+        Ok(CBare(TSpecial(Special::CowStr)))
       }
-      ( $( std :: ffi :: )? c_void ) => Ok(Arg::Numeric(NumericArg::__VOID__)),
-      ( OpState ) => Ok(Arg::Special(Special::OpState)),
-      ( v8 :: HandleScope ) => Ok(Arg::Special(Special::HandleScope)),
-      ( v8 :: FastApiCallbackOptions ) => Ok(Arg::Special(Special::FastApiCallbackOptions)),
-      ( v8 :: Local < $( $_scope:lifetime , )? v8 :: $v8:ident >) => Ok(Arg::V8Local(parse_v8_type(&v8)?)),
-      ( Rc < RefCell < $ty:ty > > ) => Ok(Arg::RcRefCell(parse_type_special(attrs, &ty)?)),
+      ( $( std :: ffi :: )? c_void ) => Ok(CBare(TNumeric(NumericArg::__VOID__))),
+      ( OpState ) => Ok(CBare(TSpecial(Special::OpState))),
+      ( v8 :: HandleScope ) => Ok(CBare(TSpecial(Special::HandleScope))),
+      ( v8 :: FastApiCallbackOptions ) => Ok(CBare(TSpecial(Special::FastApiCallbackOptions))),
+      ( v8 :: Local < $( $_scope:lifetime , )? v8 :: $v8:ident >) => Ok(CV8Local(TV8(parse_v8_type(&v8)?))),
+      ( v8 :: Global < $( $_scope:lifetime , )? v8 :: $v8:ident >) => Ok(CV8Global(TV8(parse_v8_type(&v8)?))),
+      ( v8 :: $v8:ident ) => Ok(CBare(TV8(parse_v8_type(&v8)?))),
+      ( Rc < RefCell < $ty:ty > > ) => Ok(CRcRefCell(TSpecial(parse_type_special(attrs, &ty)?))),
       ( Option < $ty:ty > ) => {
         match parse_type(attrs, &ty)? {
-          Arg::Special(special) => Ok(Arg::Option(special)),
-          Arg::Numeric(numeric) => Ok(Arg::OptionNumeric(numeric)),
+          Arg::Special(special) => Ok(COption(TSpecial(special))),
+          Arg::Numeric(numeric) => Ok(COption(TNumeric(numeric))),
+          Arg::V8Local(v8) => Ok(COptionV8Local(TV8(v8))),
           _ => Err(ArgError::InvalidType(stringify_token(ty)))
         }
       }
       ( $any:ty ) => Err(ArgError::InvalidTypePath(stringify_token(any))),
     })
-  }).map_err(|e| ArgError::InternalError(format!("parse_type_path {e:?}")))?
+  }).map_err(|e| ArgError::InternalError(format!("parse_type_path {e:?}")))??;
+
+  // Ensure that we have the correct reference state. This is a bit awkward but it's
+  // the easiest way to work with the 'rules!' macro above.
+  match res {
+    CBare(TSpecial(Special::RefStr | Special::OpState) | TV8(_)) => {
+      if !is_ref {
+        return Err(ArgError::MissingReference(stringify_token(tp)));
+      }
+    }
+    _ => {
+      if is_ref {
+        return Err(ArgError::InvalidReference(stringify_token(tp)));
+      }
+    }
+  }
+
+  match res {
+    CBare(TSpecial(Special::RefStr | Special::CowStr | Special::String)) => {
+      if attrs.primary != Some(AttributeModifier::String) {
+        return Err(ArgError::MissingStringAttribute);
+      }
+    }
+    CBare(_) => {
+      if attrs.primary == Some(AttributeModifier::String) {
+        return Err(ArgError::InvalidStringType(stringify_token(tp)));
+      }
+    }
+    _ => {
+      // Ignore for other containers
+    }
+  }
+
+  Ok(res)
 }
 
 fn parse_v8_type(v8: &Ident) -> Result<V8Arg, ArgError> {
@@ -477,12 +541,15 @@ fn parse_type_special(
 }
 
 fn parse_type(attrs: Attributes, ty: &Type) -> Result<Arg, ArgError> {
+  use ParsedType::*;
+  use ParsedTypeContainer::*;
+
   if let Some(primary) = attrs.primary {
     match primary {
       AttributeModifier::Serde => match ty {
         Type::Path(of) => {
           // If this type will parse without #[serde], it is illegal to use this type with #[serde]
-          if parse_type_path(Attributes::default(), of).is_ok() {
+          if parse_type_path(Attributes::default(), false, of).is_ok() {
             return Err(ArgError::InvalidSerdeAttributeType(stringify_token(
               ty,
             )));
@@ -491,25 +558,9 @@ fn parse_type(attrs: Attributes, ty: &Type) -> Result<Arg, ArgError> {
         }
         _ => return Err(ArgError::InvalidSerdeType(stringify_token(ty))),
       },
-      AttributeModifier::String => match ty {
-        Type::Path(of) => {
-          return parse_type_path(attrs, of);
-        }
-        Type::Reference(of) => {
-          let mut_type = if of.mutability.is_some() {
-            RefType::Mut
-          } else {
-            RefType::Ref
-          };
-          let tokens = of.elem.clone().into_token_stream();
-          use syn2 as syn;
-          return rules!(tokens => {
-            (str) => Ok(Arg::Special(Special::RefStr)),
-            ($_ty:ty) => Ok(Arg::Ref(mut_type, parse_type_special(attrs, &of.elem)?)),
-          });
-        }
-        _ => return Err(ArgError::InvalidSerdeType(stringify_token(ty))),
-      },
+      AttributeModifier::String => {
+        // We handle this as part of the normal parsing process
+      }
       AttributeModifier::Smi => {
         return Ok(Arg::Numeric(NumericArg::__SMI__));
       }
@@ -534,8 +585,13 @@ fn parse_type(attrs: Attributes, ty: &Type) -> Result<Arg, ArgError> {
           Arg::Numeric(numeric) => Ok(Arg::Slice(mut_type, numeric)),
           _ => Err(ArgError::InvalidType(stringify_token(ty))),
         },
-        Type::Path(of) => match parse_type_path(attrs, of)? {
-          Arg::Special(special) => Ok(Arg::Ref(mut_type, special)),
+        Type::Path(of) => match parse_type_path(attrs, true, of)? {
+          CBare(TSpecial(Special::RefStr)) => Ok(Arg::Special(Special::RefStr)),
+          COption(TSpecial(Special::RefStr)) => {
+            Ok(Arg::Option(Special::RefStr))
+          }
+          CBare(TV8(v8)) => Ok(Arg::V8Ref(mut_type, v8)),
+          CBare(TSpecial(special)) => Ok(Arg::Ref(mut_type, special)),
           _ => Err(ArgError::InvalidType(stringify_token(ty))),
         },
         _ => Err(ArgError::InvalidType(stringify_token(ty))),
@@ -548,14 +604,24 @@ fn parse_type(attrs: Attributes, ty: &Type) -> Result<Arg, ArgError> {
         RefType::Ref
       };
       match &*of.elem {
-        Type::Path(of) => match parse_type_path(attrs, of)? {
-          Arg::Numeric(numeric) => Ok(Arg::Ptr(mut_type, numeric)),
+        Type::Path(of) => match parse_type_path(attrs, false, of)? {
+          CBare(TNumeric(numeric)) => Ok(Arg::Ptr(mut_type, numeric)),
           _ => Err(ArgError::InvalidType(stringify_token(ty))),
         },
         _ => Err(ArgError::InvalidType(stringify_token(ty))),
       }
     }
-    Type::Path(of) => parse_type_path(attrs, of),
+    Type::Path(of) => match parse_type_path(attrs, false, of)? {
+      CBare(TNumeric(numeric)) => Ok(Arg::Numeric(numeric)),
+      CBare(TSpecial(special)) => Ok(Arg::Special(special)),
+      COption(TNumeric(special)) => Ok(Arg::OptionNumeric(special)),
+      COption(TSpecial(special)) => Ok(Arg::Option(special)),
+      CRcRefCell(TSpecial(special)) => Ok(Arg::RcRefCell(special)),
+      COptionV8Local(TV8(v8)) => Ok(Arg::OptionV8Local(v8)),
+      CV8Local(TV8(v8)) => Ok(Arg::V8Local(v8)),
+      CV8Global(TV8(v8)) => Ok(Arg::V8Global(v8)),
+      _ => Err(ArgError::InvalidType(stringify_token(ty))),
+    },
     _ => Err(ArgError::InvalidType(stringify_token(ty))),
   }
 }
@@ -693,6 +759,14 @@ mod tests {
     (Special(RefStr), Numeric(bool)) -> Result(Void)
   );
   test!(
+    #[string] fn op_lots_of_strings(#[string] s: String, #[string] s2: Option<String>, #[string] s3: Cow<str>) -> String;
+    (Special(String), Option(String), Special(CowStr)) -> Infallible(Special(String))
+  );
+  test!(
+    #[string] fn op_lots_of_option_strings(#[string] s: Option<String>, #[string] s2: Option<&str>, #[string] s3: Option<Cow<str>>) -> Option<String>;
+    (Option(String), Option(RefStr), Option(CowStr)) -> Infallible(Option(String))
+  );
+  test!(
     fn op_scope<'s>(#[string] msg: &'s str);
     <'s> (Special(RefStr)) -> Infallible(Void)
   );
@@ -700,6 +774,30 @@ mod tests {
     fn op_scope_and_generics<'s, AB, BC>(#[string] msg: &'s str) where AB: some::Trait, BC: OtherTrait;
     <'s, AB: some::Trait, BC: OtherTrait> (Special(RefStr)) -> Infallible(Void)
   );
+  test!(
+    fn op_v8_types(s: &mut v8::String, s2: v8::Local<v8::String>, s3: v8::Global<v8::String>);
+    (V8Ref(Mut, String), V8Local(String), V8Global(String)) -> Infallible(Void)
+  );
+
+  // Args
+
+  expect_fail!(
+    op_with_bad_string1,
+    ArgError("s", MissingStringAttribute),
+    fn f(s: &str) {}
+  );
+  expect_fail!(
+    op_with_bad_string2,
+    ArgError("s", MissingStringAttribute),
+    fn f(s: String) {}
+  );
+  expect_fail!(
+    op_with_bad_string3,
+    ArgError("s", MissingStringAttribute),
+    fn f(s: Cow<str>) {}
+  );
+
+  // Generics
 
   expect_fail!(op_with_two_lifetimes, TooManyLifetimes, fn f<'a, 'b>() {});
   expect_fail!(

--- a/ops/op2/test_cases/sync/clippy_allow.out
+++ b/ops/op2/test_cases/sync/clippy_allow.out
@@ -1,12 +1,13 @@
 #[allow(non_camel_case_types)]
 /// This is a doc comment.
-pub struct op_has_doc_comment {
+#[allow(clippy::some_annotation)]
+pub struct op_extra_annotation {
     _unconstructable: ::std::marker::PhantomData<()>,
 }
-impl deno_core::_ops::Op for op_has_doc_comment {
-    const NAME: &'static str = stringify!(op_has_doc_comment);
+impl deno_core::_ops::Op for op_extra_annotation {
+    const NAME: &'static str = stringify!(op_extra_annotation);
     const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_has_doc_comment),
+        name: stringify!(op_extra_annotation),
         v8_fn_ptr: Self::v8_fn_ptr as _,
         enabled: true,
         fast_fn: Some({
@@ -24,13 +25,13 @@ impl deno_core::_ops::Op for op_has_doc_comment {
         arg_count: 0usize as u8,
     };
 }
-impl op_has_doc_comment {
+impl op_extra_annotation {
     pub const fn name() -> &'static str {
-        stringify!(op_has_doc_comment)
+        stringify!(op_extra_annotation)
     }
     pub const fn decl() -> deno_core::_ops::OpDecl {
         deno_core::_ops::OpDecl {
-            name: stringify!(op_has_doc_comment),
+            name: stringify!(op_extra_annotation),
             v8_fn_ptr: Self::v8_fn_ptr as _,
             enabled: true,
             fast_fn: Some({
@@ -57,5 +58,6 @@ impl op_has_doc_comment {
     }
     #[inline(always)]
     /// This is a doc comment.
+    #[allow(clippy::some_annotation)]
     pub fn call() -> () {}
 }

--- a/ops/op2/test_cases/sync/clippy_allow.rs
+++ b/ops/op2/test_cases/sync/clippy_allow.rs
@@ -1,0 +1,6 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+/// This is a doc comment.
+#[op2(fast)]
+#[allow(clippy::some_annotation)]
+pub fn op_extra_annotation() -> () {}

--- a/ops/op2/test_cases/sync/v8_handlescope.out
+++ b/ops/op2/test_cases/sync/v8_handlescope.out
@@ -1,0 +1,65 @@
+#[allow(non_camel_case_types)]
+struct op_handlescope {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
+impl deno_core::_ops::Op for op_handlescope {
+    const NAME: &'static str = stringify!(op_handlescope);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
+        name: stringify!(op_handlescope),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: None,
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 2usize as u8,
+    };
+}
+impl op_handlescope {
+    pub const fn name() -> &'static str {
+        stringify!(op_handlescope)
+    }
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        deno_core::_ops::OpDecl {
+            name: stringify!(op_handlescope),
+            v8_fn_ptr: Self::v8_fn_ptr as _,
+            enabled: true,
+            fast_fn: None,
+            is_async: false,
+            is_unstable: false,
+            is_v8: false,
+            arg_count: 2usize as u8,
+        }
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let scope = &mut unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+            &*info
+        });
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let arg1 = args.get(0usize as i32);
+        let Ok(mut arg1) = deno_core::v8::Local::<
+            deno_core::v8::String,
+        >::try_from(arg1) else {
+        let msg = deno_core::v8::String::new_from_one_byte(
+                scope,
+                "expected v8::String".as_bytes(),
+                deno_core::v8::NewStringType::Normal,
+            )
+            .unwrap();
+        let exc = deno_core::v8::Exception::error(scope, msg);
+        scope.throw_exception(exc);
+        return;
+    };
+        let arg0 = scope;
+        let result = Self::call(arg0, arg1);
+        rv.set(result.into())
+    }
+    #[inline(always)]
+    fn call(
+        scope: &v8::HandleScope,
+        str2: v8::Local<v8::String>,
+    ) -> v8::Local<v8::String> {}
+}

--- a/ops/op2/test_cases/sync/v8_handlescope.rs
+++ b/ops/op2/test_cases/sync/v8_handlescope.rs
@@ -1,0 +1,5 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+#[op2]
+fn op_handlescope(scope: &v8::HandleScope, str2: v8::Local<v8::String>) -> v8::Local<v8::String> {
+}

--- a/ops/op2/test_cases/sync/v8_lifetime.out
+++ b/ops/op2/test_cases/sync/v8_lifetime.out
@@ -40,7 +40,7 @@ impl op_v8_lifetime {
             &*info
         });
         let arg0 = args.get(0usize as i32);
-        let Ok(arg0) = deno_core::v8::Local::<
+        let Ok(mut arg0) = deno_core::v8::Local::<
             deno_core::v8::String,
         >::try_from(arg0) else {
         let msg = deno_core::v8::String::new_from_one_byte(

--- a/ops/op2/test_cases/sync/v8_lifetime.out
+++ b/ops/op2/test_cases/sync/v8_lifetime.out
@@ -1,0 +1,61 @@
+#[allow(non_camel_case_types)]
+pub struct op_v8_lifetime {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
+impl deno_core::_ops::Op for op_v8_lifetime {
+    const NAME: &'static str = stringify!(op_v8_lifetime);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
+        name: stringify!(op_v8_lifetime),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: None,
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 1usize as u8,
+    };
+}
+impl op_v8_lifetime {
+    pub const fn name() -> &'static str {
+        stringify!(op_v8_lifetime)
+    }
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        deno_core::_ops::OpDecl {
+            name: stringify!(op_v8_lifetime),
+            v8_fn_ptr: Self::v8_fn_ptr as _,
+            enabled: true,
+            fast_fn: None,
+            is_async: false,
+            is_unstable: false,
+            is_v8: false,
+            arg_count: 1usize as u8,
+        }
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let scope = &mut unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+            &*info
+        });
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let arg0 = args.get(0usize as i32);
+        let Ok(arg0) = deno_core::v8::Local::<
+            deno_core::v8::String,
+        >::try_from(arg0) else {
+        let msg = deno_core::v8::String::new_from_one_byte(
+                scope,
+                "expected v8::String".as_bytes(),
+                deno_core::v8::NewStringType::Normal,
+            )
+            .unwrap();
+        let exc = deno_core::v8::Exception::error(scope, msg);
+        scope.throw_exception(exc);
+        return;
+    };
+        let result = Self::call(arg0);
+        rv.set(result.into())
+    }
+    #[inline(always)]
+    pub fn call<'s>(s: v8::Local<'s, v8::String>) -> v8::Local<'s, v8::String> {}
+}

--- a/ops/op2/test_cases/sync/v8_lifetime.rs
+++ b/ops/op2/test_cases/sync/v8_lifetime.rs
@@ -1,0 +1,4 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+#[op2]
+pub fn op_v8_lifetime<'s>(s: v8::Local<'s, v8::String>) -> v8::Local<'s, v8::String> {}

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -1,0 +1,83 @@
+#[allow(non_camel_case_types)]
+pub struct op_v8_lifetime {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
+impl deno_core::_ops::Op for op_v8_lifetime {
+    const NAME: &'static str = stringify!(op_v8_lifetime);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
+        name: stringify!(op_v8_lifetime),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: None,
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 2usize as u8,
+    };
+}
+impl op_v8_lifetime {
+    pub const fn name() -> &'static str {
+        stringify!(op_v8_lifetime)
+    }
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        deno_core::_ops::OpDecl {
+            name: stringify!(op_v8_lifetime),
+            v8_fn_ptr: Self::v8_fn_ptr as _,
+            enabled: true,
+            fast_fn: None,
+            is_async: false,
+            is_unstable: false,
+            is_v8: false,
+            arg_count: 2usize as u8,
+        }
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let scope = &mut unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let arg0 = args.get(0usize as i32);
+        let arg0 = if arg0.is_null_or_undefined() {
+            None
+        } else {
+            let Ok(mut arg0) = deno_core::v8::Local::<
+                deno_core::v8::String,
+            >::try_from(arg0) else {
+            let msg = deno_core::v8::String::new_from_one_byte(
+                    scope,
+                    "expected v8::String".as_bytes(),
+                    deno_core::v8::NewStringType::Normal,
+                )
+                .unwrap();
+            let exc = deno_core::v8::Exception::error(scope, msg);
+            scope.throw_exception(exc);
+            return;
+        };
+            Some(arg0)
+        };
+        let arg0 = arg0.as_ref().map(|v| ::std::ops::Deref::deref(v));
+        let arg1 = args.get(1usize as i32);
+        let arg1 = if arg1.is_null_or_undefined() {
+            None
+        } else {
+            let Ok(mut arg1) = deno_core::v8::Local::<
+                deno_core::v8::String,
+            >::try_from(arg1) else {
+            let msg = deno_core::v8::String::new_from_one_byte(
+                    scope,
+                    "expected v8::String".as_bytes(),
+                    deno_core::v8::NewStringType::Normal,
+                )
+                .unwrap();
+            let exc = deno_core::v8::Exception::error(scope, msg);
+            scope.throw_exception(exc);
+            return;
+        };
+            Some(arg1)
+        };
+        let arg1 = arg1.as_mut().map(|v| ::std::ops::DerefMut::deref_mut(v));
+        let result = Self::call(arg0, arg1);
+    }
+    #[inline(always)]
+    pub fn call<'s>(s: Option<&v8::String>, s2: Option<&mut v8::String>) {}
+}

--- a/ops/op2/test_cases/sync/v8_ref_option.rs
+++ b/ops/op2/test_cases/sync/v8_ref_option.rs
@@ -1,0 +1,5 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+#[op2]
+pub fn op_v8_lifetime<'s>(s: Option<&v8::String>, s2: Option<&mut v8::String>) {}
+

--- a/ops/op2/test_cases/sync/v8_string.out
+++ b/ops/op2/test_cases/sync/v8_string.out
@@ -40,7 +40,7 @@ impl op_v8_string {
             &*info
         });
         let arg0 = args.get(0usize as i32);
-        let Ok(arg0) = deno_core::v8::Local::<
+        let Ok(mut arg0) = deno_core::v8::Local::<
             deno_core::v8::String,
         >::try_from(arg0) else {
         let msg = deno_core::v8::String::new_from_one_byte(
@@ -55,7 +55,7 @@ impl op_v8_string {
     };
         let arg0 = &arg0;
         let arg1 = args.get(1usize as i32);
-        let Ok(arg1) = deno_core::v8::Local::<
+        let Ok(mut arg1) = deno_core::v8::Local::<
             deno_core::v8::String,
         >::try_from(arg1) else {
         let msg = deno_core::v8::String::new_from_one_byte(

--- a/ops/op2/test_cases/sync/v8_string.out
+++ b/ops/op2/test_cases/sync/v8_string.out
@@ -1,0 +1,75 @@
+#[allow(non_camel_case_types)]
+struct op_v8_string {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
+impl deno_core::_ops::Op for op_v8_string {
+    const NAME: &'static str = stringify!(op_v8_string);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
+        name: stringify!(op_v8_string),
+        v8_fn_ptr: Self::v8_fn_ptr as _,
+        enabled: true,
+        fast_fn: None,
+        is_async: false,
+        is_unstable: false,
+        is_v8: false,
+        arg_count: 2usize as u8,
+    };
+}
+impl op_v8_string {
+    pub const fn name() -> &'static str {
+        stringify!(op_v8_string)
+    }
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        deno_core::_ops::OpDecl {
+            name: stringify!(op_v8_string),
+            v8_fn_ptr: Self::v8_fn_ptr as _,
+            enabled: true,
+            fast_fn: None,
+            is_async: false,
+            is_unstable: false,
+            is_v8: false,
+            arg_count: 2usize as u8,
+        }
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let scope = &mut unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+            &*info
+        });
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let arg0 = args.get(0usize as i32);
+        let Ok(arg0) = &deno_core::v8::Local::<
+            deno_core::v8::String,
+        >::try_from(arg0) else {
+        let msg = deno_core::v8::String::new_from_one_byte(
+                scope,
+                "expected v8::String".as_bytes(),
+                deno_core::v8::NewStringType::Normal,
+            )
+            .unwrap();
+        let exc = deno_core::v8::Exception::error(scope, msg);
+        scope.throw_exception(exc);
+        return;
+    };
+        let arg1 = args.get(1usize as i32);
+        let Ok(arg1) = deno_core::v8::Local::<
+            deno_core::v8::String,
+        >::try_from(arg1) else {
+        let msg = deno_core::v8::String::new_from_one_byte(
+                scope,
+                "expected v8::String".as_bytes(),
+                deno_core::v8::NewStringType::Normal,
+            )
+            .unwrap();
+        let exc = deno_core::v8::Exception::error(scope, msg);
+        scope.throw_exception(exc);
+        return;
+    };
+        let result = Self::call(arg0, arg1);
+        rv.set(result.into())
+    }
+    #[inline(always)]
+    fn call(str1: &v8::String, str2: v8::Local<v8::String>) -> v8::Local<v8::String> {}
+}

--- a/ops/op2/test_cases/sync/v8_string.out
+++ b/ops/op2/test_cases/sync/v8_string.out
@@ -40,7 +40,7 @@ impl op_v8_string {
             &*info
         });
         let arg0 = args.get(0usize as i32);
-        let Ok(arg0) = &deno_core::v8::Local::<
+        let Ok(arg0) = deno_core::v8::Local::<
             deno_core::v8::String,
         >::try_from(arg0) else {
         let msg = deno_core::v8::String::new_from_one_byte(
@@ -53,6 +53,7 @@ impl op_v8_string {
         scope.throw_exception(exc);
         return;
     };
+        let arg0 = &arg0;
         let arg1 = args.get(1usize as i32);
         let Ok(arg1) = deno_core::v8::Local::<
             deno_core::v8::String,

--- a/ops/op2/test_cases/sync/v8_string.rs
+++ b/ops/op2/test_cases/sync/v8_string.rs
@@ -1,0 +1,5 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+#[op2]
+fn op_v8_string(str1: &v8::String, str2: v8::Local<v8::String>) -> v8::Local<v8::String> {
+}


### PR DESCRIPTION
`op2` support for `v8::Value` and related types. Functions may take arguments of the form `&v8::String` (or `&mut v8::String`), `v8::Local<v8::String>`, or an `Option<...>` of any of these. Under the hood, the op system will check the type of the argument and automatically throw a type error if it does not match.

Implements:

 - [x] v8::Local<v8::XXX> for arguments (including automatic casting so `v8::String` will work)
 - [x] v8::Local<v8::XXX> for return types
 - [x] Option<v8::Local<...>> for arguments and returns
 - [x] &v8::XXX and Option<&v8:XXX> for arguments (ie: pass a `&mut v8::String` without a handle)
 - [x] HandleScope

Additional changes:

 - [x] Fixes clippy attributes on ops
 - [x] Refactoring of signature parser to be slightly less tied to our final arg/return types
 - [x] Ensures that lifetimes are properly added to `call`


