### PR TITLE
refactor: migrate some ops_builtin_v8 to op2 macro

### DIFF
--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -356,12 +356,12 @@ fn op_is_proxy(value: serde_v8::Value) -> bool {
   value.v8_value.is_proxy()
 }
 
-#[op(v8)]
-fn op_str_byte_length(
+#[op2(core)]
+pub fn op_str_byte_length(
   scope: &mut v8::HandleScope,
-  value: serde_v8::Value,
+  value: v8::Local<v8::Value>,
 ) -> u32 {
-  if let Ok(string) = v8::Local::<v8::String>::try_from(value.v8_value) {
+  if let Ok(string) = v8::Local::<v8::String>::try_from(value) {
     string.utf8_length(scope) as u32
   } else {
     0

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -346,9 +346,10 @@ async fn op_shutdown(
   resource.shutdown().await
 }
 
-#[op]
-fn op_format_file_name(file_name: String) -> String {
-  format_file_name(&file_name)
+#[op2(core)]
+#[string]
+fn op_format_file_name(#[string] file_name: &str) -> String {
+  format_file_name(file_name)
 }
 
 #[op(fast)]
@@ -357,7 +358,7 @@ fn op_is_proxy(value: serde_v8::Value) -> bool {
 }
 
 #[op2(core)]
-pub fn op_str_byte_length(
+fn op_str_byte_length(
   scope: &mut v8::HandleScope,
   value: v8::Local<v8::Value>,
 ) -> u32 {

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -48,7 +48,7 @@ pub fn op_unref_op(scope: &mut v8::HandleScope, promise_id: i32) {
 pub fn op_set_promise_reject_callback<'a>(
   scope: &mut v8::HandleScope<'a>,
   cb: v8::Local<'a, v8::Function>,
-) -> Option<v8::Local<'a, v8::Value>> {
+) -> Option<v8::Local<'a, v8::Function>> {
   let cb = v8::Global::new(scope, cb);
   let context_state_rc = JsRealm::state_from_scope(scope);
   let old = context_state_rc
@@ -57,7 +57,6 @@ pub fn op_set_promise_reject_callback<'a>(
     .replace(Rc::new(cb));
   old
     .map(|v| v8::Local::new(scope, &*v))
-    .map(|func| func.into())
 }
 
 #[op2(core)]
@@ -149,11 +148,10 @@ pub fn op_queue_microtask(
 #[op2(core)]
 pub fn op_create_host_object<'a>(
   scope: &mut v8::HandleScope<'a>,
-) -> v8::Local<'a, v8::Value> {
+) -> v8::Local<'a, v8::Object> {
   let template = v8::ObjectTemplate::new(scope);
   template.set_internal_field_count(1);
-  let object = template.new_instance(scope).unwrap();
-  object.into()
+  template.new_instance(scope).unwrap()
 }
 
 #[op(v8)]

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -145,14 +145,14 @@ pub fn op_queue_microtask(
   scope.enqueue_microtask(cb);
 }
 
-#[op(v8)]
-fn op_create_host_object<'a>(
+#[op2(core)]
+pub fn op_create_host_object<'a>(
   scope: &mut v8::HandleScope<'a>,
-) -> serde_v8::Value<'a> {
+) -> v8::Local<'a, v8::Value> {
   let template = v8::ObjectTemplate::new(scope);
   template.set_internal_field_count(1);
   let object = template.new_instance(scope).unwrap();
-  from_v8(scope, object.into()).unwrap()
+  object.into()
 }
 
 #[op(v8)]

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -64,8 +64,8 @@ pub fn op_run_microtasks(scope: &mut v8::HandleScope) {
   scope.perform_microtask_checkpoint();
 }
 
-#[op(v8)]
-fn op_has_tick_scheduled(scope: &mut v8::HandleScope) -> bool {
+#[op2(core)]
+pub fn op_has_tick_scheduled(scope: &mut v8::HandleScope) -> bool {
   let state_rc = JsRuntime::state_from(scope);
   let state = state_rc.borrow();
   state.has_tick_scheduled
@@ -867,8 +867,8 @@ pub fn op_set_format_exception_callback<'a>(
   old.map(|func| func.into())
 }
 
-#[op(v8)]
-fn op_event_loop_has_more_work(scope: &mut v8::HandleScope) -> bool {
+#[op2(core)]
+pub fn op_event_loop_has_more_work(scope: &mut v8::HandleScope) -> bool {
   JsRuntime::event_loop_pending_state_from_scope(scope).is_pending()
 }
 
@@ -900,16 +900,14 @@ pub fn op_remove_pending_promise_rejection(
     .retain(|(key, _)| key != &promise_global);
 }
 
-#[op(v8)]
-fn op_has_pending_promise_rejection<'a>(
-  scope: &mut v8::HandleScope<'a>,
-  promise: serde_v8::Value<'a>,
+#[op2(core)]
+pub fn op_has_pending_promise_rejection(
+  scope: &mut v8::HandleScope,
+  promise: v8::Local<v8::Promise>,
 ) -> bool {
   let context_state_rc = JsRealm::state_from_scope(scope);
   let context_state = context_state_rc.borrow();
-  let promise_value =
-    v8::Local::<v8::Promise>::try_from(promise.v8_value).unwrap();
-  let promise_global = v8::Global::new(scope, promise_value);
+  let promise_global = v8::Global::new(scope, promise);
   context_state
     .pending_promise_rejections
     .iter()

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -873,18 +873,16 @@ fn op_event_loop_has_more_work(scope: &mut v8::HandleScope) -> bool {
   JsRuntime::event_loop_pending_state_from_scope(scope).is_pending()
 }
 
-#[op(v8)]
-fn op_store_pending_promise_rejection<'a>(
-  scope: &mut v8::HandleScope<'a>,
-  promise: serde_v8::Value<'a>,
-  reason: serde_v8::Value<'a>,
+#[op2(core)]
+pub fn op_store_pending_promise_rejection(
+  scope: &mut v8::HandleScope,
+  promise: v8::Local<v8::Promise>,
+  reason: v8::Local<v8::Value>,
 ) {
   let context_state_rc = JsRealm::state_from_scope(scope);
   let mut context_state = context_state_rc.borrow_mut();
-  let promise_value =
-    v8::Local::<v8::Promise>::try_from(promise.v8_value).unwrap();
-  let promise_global = v8::Global::new(scope, promise_value);
-  let error_global = v8::Global::new(scope, reason.v8_value);
+  let promise_global = v8::Global::new(scope, promise);
+  let error_global = v8::Global::new(scope, reason);
   context_state
     .pending_promise_rejections
     .push_back((promise_global, error_global));

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -55,8 +55,7 @@ pub fn op_set_promise_reject_callback<'a>(
     .borrow_mut()
     .js_promise_reject_cb
     .replace(Rc::new(cb));
-  old
-    .map(|v| v8::Local::new(scope, &*v))
+  old.map(|v| v8::Local::new(scope, &*v))
 }
 
 #[op2(core)]

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -49,13 +49,15 @@ pub fn op_set_promise_reject_callback<'a>(
   scope: &mut v8::HandleScope<'a>,
   cb: v8::Local<'a, v8::Function>,
 ) -> Option<v8::Local<'a, v8::Value>> {
-  let cb =v8::Global::new(scope, cb);
+  let cb = v8::Global::new(scope, cb);
   let context_state_rc = JsRealm::state_from_scope(scope);
   let old = context_state_rc
     .borrow_mut()
     .js_promise_reject_cb
     .replace(Rc::new(cb));
-  old.map(|v| v8::Local::new(scope, &*v)).map(|func| func.into())
+  old
+    .map(|v| v8::Local::new(scope, &*v))
+    .map(|func| func.into())
 }
 
 #[op2(core)]

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -162,6 +162,7 @@ pub fn op_encode<'a>(
   Ok(u8array)
 }
 
+// TODO(bartlomieju): migration to op2 blocked by buffer support
 #[op(v8)]
 fn op_decode<'a>(
   scope: &mut v8::HandleScope<'a>,
@@ -352,6 +353,7 @@ struct SerializeDeserializeOptions<'a> {
   for_storage: bool,
 }
 
+// TODO(bartlomieju): migration to op2 blocked by buffer support
 #[op(v8)]
 fn op_serialize(
   scope: &mut v8::HandleScope,
@@ -440,6 +442,7 @@ fn op_serialize(
   }
 }
 
+// TODO(bartlomieju): migration to op2 blocked by buffer support
 #[op(v8)]
 fn op_deserialize<'a>(
   scope: &mut v8::HandleScope<'a>,
@@ -515,6 +518,7 @@ fn op_deserialize<'a>(
 #[derive(Serialize)]
 struct PromiseDetails<'s>(u32, Option<serde_v8::Value<'s>>);
 
+// TODO(bartlomieju): migration to op2 blocked by tuple support
 #[op(v8)]
 fn op_get_promise_details<'a>(
   scope: &mut v8::HandleScope<'a>,
@@ -583,6 +587,8 @@ pub fn op_set_promise_hooks(
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// TODO(bartlomieju): migration to op2 blocked by tuple support
 #[op(v8)]
 fn op_get_proxy_details<'a>(
   scope: &mut v8::HandleScope<'a>,


### PR DESCRIPTION
These are all the ops I managed to migrate to `op2` macro.