### PR TITLE
feat(ops): Deprecate decl() in favour of const DECL and remove access for functions

### DIFF
--- a/core/examples/hello_world.rs
+++ b/core/examples/hello_world.rs
@@ -5,6 +5,7 @@
 use deno_core::op;
 use deno_core::Extension;
 use deno_core::JsRuntime;
+use deno_core::Op;
 use deno_core::RuntimeOptions;
 
 // This is a hack to make the `#[op]` macro work with
@@ -27,7 +28,7 @@ fn main() {
       // An op for summing an array of numbers
       // The op-layer automatically deserializes inputs
       // and serializes the returned Result & value
-      op_sum::decl(),
+      op_sum::DECL,
     ])
     .build();
 

--- a/core/examples/http_bench_json_ops/main.rs
+++ b/core/examples/http_bench_json_ops/main.rs
@@ -5,6 +5,7 @@ use deno_core::AsyncRefCell;
 use deno_core::AsyncResult;
 use deno_core::JsBuffer;
 use deno_core::JsRuntimeForSnapshot;
+use deno_core::Op;
 use deno_core::OpState;
 use deno_core::Resource;
 use deno_core::ResourceId;
@@ -96,10 +97,10 @@ impl From<tokio::net::TcpStream> for TcpStream {
 fn create_js_runtime() -> JsRuntimeForSnapshot {
   let ext = deno_core::Extension::builder("my_ext")
     .ops(vec![
-      op_listen::decl(),
-      op_accept::decl(),
-      op_try_write::decl(),
-      op_read_socket::decl(),
+      op_listen::DECL,
+      op_accept::DECL,
+      op_try_write::DECL,
+      op_read_socket::DECL,
     ])
     .build();
 

--- a/core/examples/panik.rs
+++ b/core/examples/panik.rs
@@ -11,6 +11,7 @@
 use deno_core::op;
 use deno_core::Extension;
 use deno_core::JsRuntime;
+use deno_core::Op;
 use deno_core::RuntimeOptions;
 
 // This is a hack to make the `#[op]` macro work with
@@ -25,7 +26,7 @@ fn main() {
   }
 
   let extensions = vec![Extension::builder("my_ext")
-    .ops(vec![op_panik::decl()])
+    .ops(vec![op_panik::DECL])
     .build()];
   let mut rt = JsRuntime::new(RuntimeOptions {
     extensions,

--- a/core/examples/schedule_task.rs
+++ b/core/examples/schedule_task.rs
@@ -4,6 +4,7 @@ use deno_core::anyhow::Error;
 use deno_core::op;
 use deno_core::Extension;
 use deno_core::JsRuntime;
+use deno_core::Op;
 use deno_core::OpState;
 use deno_core::RuntimeOptions;
 use futures::channel::mpsc;
@@ -19,7 +20,7 @@ type Task = Box<dyn FnOnce()>;
 
 fn main() {
   let my_ext = Extension::builder("my_ext")
-    .ops(vec![op_schedule_task::decl()])
+    .ops(vec![op_schedule_task::DECL])
     .event_loop_middleware(|state_rc, cx| {
       let mut state = state_rc.borrow_mut();
       let recv = state.borrow_mut::<mpsc::UnboundedReceiver<Task>>();

--- a/core/examples/wasm.rs
+++ b/core/examples/wasm.rs
@@ -3,6 +3,7 @@
 use deno_core::op;
 use deno_core::Extension;
 use deno_core::JsRuntime;
+use deno_core::Op;
 use deno_core::RuntimeOptions;
 use std::mem::transmute;
 use std::ptr::NonNull;
@@ -52,7 +53,7 @@ fn op_set_wasm_mem(
 fn main() {
   // Build a deno_core::Extension providing custom ops
   let ext = Extension::builder("my_ext")
-    .ops(vec![op_wasm::decl(), op_set_wasm_mem::decl()])
+    .ops(vec![op_wasm::DECL, op_set_wasm_mem::DECL])
     .build();
 
   // Initialize a runtime instance

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -63,6 +63,7 @@ pub use crate::extensions::Extension;
 pub use crate::extensions::ExtensionBuilder;
 pub use crate::extensions::ExtensionFileSource;
 pub use crate::extensions::ExtensionFileSourceCode;
+pub use crate::extensions::Op;
 pub use crate::extensions::OpDecl;
 pub use crate::extensions::OpMiddlewareFn;
 pub use crate::fast_string::FastString;

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 use crate as deno_core;
+use crate::extensions::Op;
 use crate::extensions::OpDecl;
 use crate::runtime::tests::setup;
 use crate::runtime::tests::Mode;
@@ -187,7 +188,7 @@ fn test_op_disabled() {
   }
 
   fn ops() -> Vec<OpDecl> {
-    vec![op_foo::decl().disable()]
+    vec![op_foo::DECL.disable()]
   }
 
   deno_core::extension!(test_ext, ops_fn = ops);

--- a/core/runtime/tests/snapshot.rs
+++ b/core/runtime/tests/snapshot.rs
@@ -1,4 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+use crate::extensions::Op;
 use crate::module_specifier::ModuleSpecifier;
 use crate::modules::AssertedModuleType;
 use crate::modules::ModuleInfo;
@@ -239,7 +240,7 @@ fn es_snapshot() {
     RuntimeOptions {
       module_loader: Some(loader.clone()),
       extensions: vec![Extension::builder("text_ext")
-        .ops(vec![op_test::decl()])
+        .ops(vec![op_test::DECL])
         .build()],
       ..Default::default()
     },
@@ -278,7 +279,7 @@ fn es_snapshot() {
       module_loader: Some(loader.clone()),
       startup_snapshot: Some(Snapshot::JustCreated(snapshot)),
       extensions: vec![Extension::builder("text_ext")
-        .ops(vec![op_test::decl()])
+        .ops(vec![op_test::DECL])
         .build()],
       ..Default::default()
     },
@@ -298,7 +299,7 @@ fn es_snapshot() {
     module_loader: Some(loader),
     startup_snapshot: Some(Snapshot::JustCreated(snapshot2)),
     extensions: vec![Extension::builder("text_ext")
-      .ops(vec![op_test::decl()])
+      .ops(vec![op_test::DECL])
       .build()],
     ..Default::default()
   });

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -132,17 +132,16 @@ impl Op {
 
         impl #generics #core::_ops::Op for #name #generics #where_clause {
           const NAME: &'static str = stringify!(#name);
-          const DECL: #core::OpDecl = #core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: #v8_fn::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: #decl,
-            is_async: #is_async,
-            is_unstable: #is_unstable,
-            is_v8: #is_v8,
+          const DECL: #core::OpDecl = #core::_ops::OpDecl::new_internal(
+            Self::name(),
+            #is_async,
+            #is_unstable,
+            #is_v8,
             // TODO(mmastrac)
-            arg_count: 0,
-          };
+            /*arg_count*/ 0,
+            /*slow*/ #v8_fn::v8_fn_ptr as _,
+            /*fast*/ #decl,
+          );
         }
 
         #[doc(hidden)]
@@ -151,18 +150,9 @@ impl Op {
             stringify!(#name)
           }
 
-          pub const fn decl () -> #core::OpDecl {
-            #core::OpDecl {
-              name: Self::name(),
-              v8_fn_ptr: #v8_fn::v8_fn_ptr as _,
-              enabled: true,
-              fast_fn: #decl,
-              is_async: #is_async,
-              is_unstable: #is_unstable,
-              is_v8: #is_v8,
-              // TODO(mmastrac)
-              arg_count: 0,
-            }
+          #[deprecated(note = "Use the const op::DECL instead")]
+          pub const fn decl() -> #core::_ops::OpDecl {
+            <Self as #core::_ops::Op>::DECL
           }
 
           #[inline]
@@ -203,17 +193,15 @@ impl Op {
 
       impl #generics #core::_ops::Op for #name #generics #where_clause {
         const NAME: &'static str = stringify!(#name);
-        const DECL: #core::OpDecl = #core::OpDecl {
-          name: Self::name(),
-          v8_fn_ptr: Self::v8_fn_ptr as _,
-          enabled: true,
-          fast_fn: #decl,
-          is_async: #is_async,
-          is_unstable: #is_unstable,
-          is_v8: #is_v8,
-          // TODO(mmastrac)
-          arg_count: 0,
-        };
+        const DECL: #core::OpDecl = #core::_ops::OpDecl::new_internal(
+          Self::name(),
+          #is_async,
+          #is_unstable,
+          #is_v8,
+          #arg_count as u8,
+          /*slow*/ Self::v8_fn_ptr as _,
+          /*fast*/ #decl,
+        );
       }
 
       #[doc(hidden)]
@@ -231,17 +219,9 @@ impl Op {
           Self::v8_func(scope, args, rv);
         }
 
-        pub const fn decl () -> #core::OpDecl {
-          #core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: #decl,
-            is_async: #is_async,
-            is_unstable: #is_unstable,
-            is_v8: #is_v8,
-            arg_count: #arg_count as u8,
-          }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> #core::_ops::OpDecl {
+          <Self as #core::_ops::Op>::DECL
         }
 
         #[inline]

--- a/ops/op2/mod.rs
+++ b/ops/op2/mod.rs
@@ -238,16 +238,15 @@ fn generate_op2(
 
     impl <#(#generic : #bound),*> #deno_core::_ops::Op for #name <#(#generic),*> {
       const NAME: &'static str = stringify!(#name);
-      const DECL: #deno_core::_ops::OpDecl = #deno_core::_ops::OpDecl {
-        name: stringify!(#name),
-        v8_fn_ptr: Self::#slow_function as _,
-        enabled: true,
-        fast_fn: #fast_definition,
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: #arg_count as u8,
-      };
+      const DECL: #deno_core::_ops::OpDecl = #deno_core::_ops::OpDecl::new_internal(
+        /*name*/ stringify!(#name),
+        /*is_async*/ false,
+        /*is_unstable*/ false,
+        /*is_v8*/ false,
+        /*arg_count*/ #arg_count as u8,
+        /*v8_fn_ptr*/ Self::#slow_function as _,
+        /*fast_fn*/ #fast_definition,
+      );
     }
 
     impl <#(#generic : #bound),*> #name <#(#generic),*> {
@@ -255,17 +254,9 @@ fn generate_op2(
         stringify!(#name)
       }
 
+      #[deprecated(note = "Use the const op::DECL instead")]
       pub const fn decl() -> #deno_core::_ops::OpDecl {
-        #deno_core::_ops::OpDecl {
-          name: stringify!(#name),
-          v8_fn_ptr: Self::#slow_function as _,
-          enabled: true,
-          fast_fn: #fast_definition,
-          is_async: false,
-          is_unstable: false,
-          is_v8: false,
-          arg_count: #arg_count as u8,
-        }
+        <Self as #deno_core::_ops::Op>::DECL
       }
 
       #fast_fn

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -4,11 +4,14 @@ struct op_add {
 }
 impl deno_core::_ops::Op for op_add {
     const NAME: &'static str = stringify!(op_add);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_add),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: Some({
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_add),
+        false,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new(
@@ -17,35 +20,15 @@ impl deno_core::_ops::Op for op_add {
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 2usize as u8,
-    };
+    );
 }
 impl op_add {
     pub const fn name() -> &'static str {
         stringify!(op_add)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_add),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: Some({
-                use deno_core::v8::fast_api::Type;
-                use deno_core::v8::fast_api::CType;
-                deno_core::v8::fast_api::FastFunction::new(
-                    &[Type::V8Value, Type::Uint32, Type::Uint32],
-                    CType::Uint32,
-                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-                )
-            }),
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 2usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     fn v8_fn_ptr_fast(
         _: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/add_options.out
+++ b/ops/op2/test_cases/sync/add_options.out
@@ -4,32 +4,23 @@ pub struct op_test_add_option {
 }
 impl crate::_ops::Op for op_test_add_option {
     const NAME: &'static str = stringify!(op_test_add_option);
-    const DECL: crate::_ops::OpDecl = crate::_ops::OpDecl {
-        name: stringify!(op_test_add_option),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: None,
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 2usize as u8,
-    };
+    const DECL: crate::_ops::OpDecl = crate::_ops::OpDecl::new_internal(
+        stringify!(op_test_add_option),
+        false,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
 }
 impl op_test_add_option {
     pub const fn name() -> &'static str {
         stringify!(op_test_add_option)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> crate::_ops::OpDecl {
-        crate::_ops::OpDecl {
-            name: stringify!(op_test_add_option),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: None,
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 2usize as u8,
-        }
+        <Self as crate::_ops::Op>::DECL
     }
     extern "C" fn v8_fn_ptr(info: *const crate::v8::FunctionCallbackInfo) {
         let mut rv = crate::v8::ReturnValue::from_function_callback_info(unsafe {

--- a/ops/op2/test_cases/sync/bool.out
+++ b/ops/op2/test_cases/sync/bool.out
@@ -4,11 +4,14 @@ pub struct op_bool {
 }
 impl deno_core::_ops::Op for op_bool {
     const NAME: &'static str = stringify!(op_bool);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_bool),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: Some({
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_bool),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new(
@@ -17,35 +20,15 @@ impl deno_core::_ops::Op for op_bool {
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 1usize as u8,
-    };
+    );
 }
 impl op_bool {
     pub const fn name() -> &'static str {
         stringify!(op_bool)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_bool),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: Some({
-                use deno_core::v8::fast_api::Type;
-                use deno_core::v8::fast_api::CType;
-                deno_core::v8::fast_api::FastFunction::new(
-                    &[Type::V8Value, Type::Bool],
-                    CType::Bool,
-                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-                )
-            }),
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     fn v8_fn_ptr_fast(
         _: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -4,11 +4,14 @@ pub struct op_bool {
 }
 impl deno_core::_ops::Op for op_bool {
     const NAME: &'static str = stringify!(op_bool);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_bool),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: Some({
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_bool),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new(
@@ -17,35 +20,15 @@ impl deno_core::_ops::Op for op_bool {
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 1usize as u8,
-    };
+    );
 }
 impl op_bool {
     pub const fn name() -> &'static str {
         stringify!(op_bool)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_bool),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: Some({
-                use deno_core::v8::fast_api::Type;
-                use deno_core::v8::fast_api::CType;
-                deno_core::v8::fast_api::FastFunction::new(
-                    &[Type::V8Value, Type::Bool, Type::CallbackOptions],
-                    CType::Bool,
-                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-                )
-            }),
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     fn v8_fn_ptr_fast(
         _: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/clippy_allow.out
+++ b/ops/op2/test_cases/sync/clippy_allow.out
@@ -6,11 +6,14 @@ pub struct op_extra_annotation {
 }
 impl deno_core::_ops::Op for op_extra_annotation {
     const NAME: &'static str = stringify!(op_extra_annotation);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_extra_annotation),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: Some({
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_extra_annotation),
+        false,
+        false,
+        false,
+        0usize as u8,
+        Self::v8_fn_ptr as _,
+        Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new(
@@ -19,35 +22,15 @@ impl deno_core::_ops::Op for op_extra_annotation {
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0usize as u8,
-    };
+    );
 }
 impl op_extra_annotation {
     pub const fn name() -> &'static str {
         stringify!(op_extra_annotation)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_extra_annotation),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: Some({
-                use deno_core::v8::fast_api::Type;
-                use deno_core::v8::fast_api::CType;
-                deno_core::v8::fast_api::FastFunction::new(
-                    &[Type::V8Value],
-                    CType::Void,
-                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-                )
-            }),
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 0usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = Self::call();

--- a/ops/op2/test_cases/sync/doc_comment.out
+++ b/ops/op2/test_cases/sync/doc_comment.out
@@ -5,11 +5,14 @@ pub struct op_has_doc_comment {
 }
 impl deno_core::_ops::Op for op_has_doc_comment {
     const NAME: &'static str = stringify!(op_has_doc_comment);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_has_doc_comment),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: Some({
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_has_doc_comment),
+        false,
+        false,
+        false,
+        0usize as u8,
+        Self::v8_fn_ptr as _,
+        Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new(
@@ -18,35 +21,15 @@ impl deno_core::_ops::Op for op_has_doc_comment {
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0usize as u8,
-    };
+    );
 }
 impl op_has_doc_comment {
     pub const fn name() -> &'static str {
         stringify!(op_has_doc_comment)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_has_doc_comment),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: Some({
-                use deno_core::v8::fast_api::Type;
-                use deno_core::v8::fast_api::CType;
-                deno_core::v8::fast_api::FastFunction::new(
-                    &[Type::V8Value],
-                    CType::Void,
-                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-                )
-            }),
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 0usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = Self::call();

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -4,11 +4,14 @@ pub struct op_generics<T> {
 }
 impl<T: Trait> deno_core::_ops::Op for op_generics<T> {
     const NAME: &'static str = stringify!(op_generics);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_generics),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: Some({
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_generics),
+        false,
+        false,
+        false,
+        0usize as u8,
+        Self::v8_fn_ptr as _,
+        Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new(
@@ -17,35 +20,15 @@ impl<T: Trait> deno_core::_ops::Op for op_generics<T> {
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0usize as u8,
-    };
+    );
 }
 impl<T: Trait> op_generics<T> {
     pub const fn name() -> &'static str {
         stringify!(op_generics)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_generics),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: Some({
-                use deno_core::v8::fast_api::Type;
-                use deno_core::v8::fast_api::CType;
-                deno_core::v8::fast_api::FastFunction::new(
-                    &[Type::V8Value],
-                    CType::Void,
-                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-                )
-            }),
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 0usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = Self::call();

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -4,11 +4,14 @@ pub struct op_u32_with_result {
 }
 impl deno_core::_ops::Op for op_u32_with_result {
     const NAME: &'static str = stringify!(op_u32_with_result);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_u32_with_result),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: Some({
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_u32_with_result),
+        false,
+        false,
+        false,
+        0usize as u8,
+        Self::v8_fn_ptr as _,
+        Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new(
@@ -17,35 +20,15 @@ impl deno_core::_ops::Op for op_u32_with_result {
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0usize as u8,
-    };
+    );
 }
 impl op_u32_with_result {
     pub const fn name() -> &'static str {
         stringify!(op_u32_with_result)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_u32_with_result),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: Some({
-                use deno_core::v8::fast_api::Type;
-                use deno_core::v8::fast_api::CType;
-                deno_core::v8::fast_api::FastFunction::new(
-                    &[Type::V8Value, Type::CallbackOptions],
-                    CType::Uint32,
-                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-                )
-            }),
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 0usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     fn v8_fn_ptr_fast(
         _: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/result_scope.out
+++ b/ops/op2/test_cases/sync/result_scope.out
@@ -4,32 +4,23 @@ pub struct op_void_with_result {
 }
 impl deno_core::_ops::Op for op_void_with_result {
     const NAME: &'static str = stringify!(op_void_with_result);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_void_with_result),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: None,
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 1usize as u8,
-    };
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_void_with_result),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
 }
 impl op_void_with_result {
     pub const fn name() -> &'static str {
         stringify!(op_void_with_result)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_void_with_result),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: None,
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -4,11 +4,14 @@ pub struct op_void_with_result {
 }
 impl deno_core::_ops::Op for op_void_with_result {
     const NAME: &'static str = stringify!(op_void_with_result);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_void_with_result),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: Some({
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_void_with_result),
+        false,
+        false,
+        false,
+        0usize as u8,
+        Self::v8_fn_ptr as _,
+        Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new(
@@ -17,35 +20,15 @@ impl deno_core::_ops::Op for op_void_with_result {
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0usize as u8,
-    };
+    );
 }
 impl op_void_with_result {
     pub const fn name() -> &'static str {
         stringify!(op_void_with_result)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_void_with_result),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: Some({
-                use deno_core::v8::fast_api::Type;
-                use deno_core::v8::fast_api::CType;
-                deno_core::v8::fast_api::FastFunction::new(
-                    &[Type::V8Value, Type::CallbackOptions],
-                    CType::Void,
-                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-                )
-            }),
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 0usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     fn v8_fn_ptr_fast(
         _: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/serde_v8.out
+++ b/ops/op2/test_cases/sync/serde_v8.out
@@ -4,32 +4,23 @@ pub struct op_serde_v8 {
 }
 impl deno_core::_ops::Op for op_serde_v8 {
     const NAME: &'static str = stringify!(op_serde_v8);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_serde_v8),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: None,
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 1usize as u8,
-    };
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_serde_v8),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
 }
 impl op_serde_v8 {
     pub const fn name() -> &'static str {
         stringify!(op_serde_v8)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_serde_v8),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: None,
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -4,11 +4,14 @@ struct op_add {
 }
 impl deno_core::_ops::Op for op_add {
     const NAME: &'static str = stringify!(op_add);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_add),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: Some({
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_add),
+        false,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new(
@@ -17,35 +20,15 @@ impl deno_core::_ops::Op for op_add {
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 2usize as u8,
-    };
+    );
 }
 impl op_add {
     pub const fn name() -> &'static str {
         stringify!(op_add)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_add),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: Some({
-                use deno_core::v8::fast_api::Type;
-                use deno_core::v8::fast_api::CType;
-                deno_core::v8::fast_api::FastFunction::new(
-                    &[Type::V8Value, Type::Int32, Type::Uint32],
-                    CType::Uint32,
-                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-                )
-            }),
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 2usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     fn v8_fn_ptr_fast(
         _: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/string_cow.out
+++ b/ops/op2/test_cases/sync/string_cow.out
@@ -4,11 +4,14 @@ struct op_string_cow {
 }
 impl deno_core::_ops::Op for op_string_cow {
     const NAME: &'static str = stringify!(op_string_cow);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_string_cow),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: Some({
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_string_cow),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new(
@@ -17,35 +20,15 @@ impl deno_core::_ops::Op for op_string_cow {
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 1usize as u8,
-    };
+    );
 }
 impl op_string_cow {
     pub const fn name() -> &'static str {
         stringify!(op_string_cow)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_string_cow),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: Some({
-                use deno_core::v8::fast_api::Type;
-                use deno_core::v8::fast_api::CType;
-                deno_core::v8::fast_api::FastFunction::new(
-                    &[Type::V8Value, Type::SeqOneByteString],
-                    CType::Uint32,
-                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-                )
-            }),
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     fn v8_fn_ptr_fast(
         _: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/string_option_return.out
+++ b/ops/op2/test_cases/sync/string_option_return.out
@@ -4,32 +4,23 @@ pub struct op_string_return {
 }
 impl deno_core::_ops::Op for op_string_return {
     const NAME: &'static str = stringify!(op_string_return);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_string_return),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: None,
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0usize as u8,
-    };
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_string_return),
+        false,
+        false,
+        false,
+        0usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
 }
 impl op_string_return {
     pub const fn name() -> &'static str {
         stringify!(op_string_return)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_string_return),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: None,
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 0usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };

--- a/ops/op2/test_cases/sync/string_owned.out
+++ b/ops/op2/test_cases/sync/string_owned.out
@@ -4,11 +4,14 @@ struct op_string_owned {
 }
 impl deno_core::_ops::Op for op_string_owned {
     const NAME: &'static str = stringify!(op_string_owned);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_string_owned),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: Some({
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_string_owned),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new(
@@ -17,35 +20,15 @@ impl deno_core::_ops::Op for op_string_owned {
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 1usize as u8,
-    };
+    );
 }
 impl op_string_owned {
     pub const fn name() -> &'static str {
         stringify!(op_string_owned)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_string_owned),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: Some({
-                use deno_core::v8::fast_api::Type;
-                use deno_core::v8::fast_api::CType;
-                deno_core::v8::fast_api::FastFunction::new(
-                    &[Type::V8Value, Type::SeqOneByteString],
-                    CType::Uint32,
-                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-                )
-            }),
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     fn v8_fn_ptr_fast(
         _: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/string_ref.out
+++ b/ops/op2/test_cases/sync/string_ref.out
@@ -4,11 +4,14 @@ struct op_string_owned {
 }
 impl deno_core::_ops::Op for op_string_owned {
     const NAME: &'static str = stringify!(op_string_owned);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_string_owned),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: Some({
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_string_owned),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new(
@@ -17,35 +20,15 @@ impl deno_core::_ops::Op for op_string_owned {
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 1usize as u8,
-    };
+    );
 }
 impl op_string_owned {
     pub const fn name() -> &'static str {
         stringify!(op_string_owned)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_string_owned),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: Some({
-                use deno_core::v8::fast_api::Type;
-                use deno_core::v8::fast_api::CType;
-                deno_core::v8::fast_api::FastFunction::new(
-                    &[Type::V8Value, Type::SeqOneByteString],
-                    CType::Uint32,
-                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-                )
-            }),
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     fn v8_fn_ptr_fast(
         _: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/string_return.out
+++ b/ops/op2/test_cases/sync/string_return.out
@@ -4,32 +4,23 @@ pub struct op_string_return {
 }
 impl deno_core::_ops::Op for op_string_return {
     const NAME: &'static str = stringify!(op_string_return);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_string_return),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: None,
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0usize as u8,
-    };
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_string_return),
+        false,
+        false,
+        false,
+        0usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
 }
 impl op_string_return {
     pub const fn name() -> &'static str {
         stringify!(op_string_return)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_string_return),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: None,
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 0usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };

--- a/ops/op2/test_cases/sync/v8_handlescope.out
+++ b/ops/op2/test_cases/sync/v8_handlescope.out
@@ -4,32 +4,23 @@ struct op_handlescope {
 }
 impl deno_core::_ops::Op for op_handlescope {
     const NAME: &'static str = stringify!(op_handlescope);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_handlescope),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: None,
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 2usize as u8,
-    };
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_handlescope),
+        false,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
 }
 impl op_handlescope {
     pub const fn name() -> &'static str {
         stringify!(op_handlescope)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_handlescope),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: None,
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 2usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };

--- a/ops/op2/test_cases/sync/v8_lifetime.out
+++ b/ops/op2/test_cases/sync/v8_lifetime.out
@@ -4,32 +4,23 @@ pub struct op_v8_lifetime {
 }
 impl deno_core::_ops::Op for op_v8_lifetime {
     const NAME: &'static str = stringify!(op_v8_lifetime);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_v8_lifetime),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: None,
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 1usize as u8,
-    };
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_v8_lifetime),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
 }
 impl op_v8_lifetime {
     pub const fn name() -> &'static str {
         stringify!(op_v8_lifetime)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_v8_lifetime),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: None,
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -4,11 +4,14 @@ pub struct op_v8_lifetime {
 }
 impl deno_core::_ops::Op for op_v8_lifetime {
     const NAME: &'static str = stringify!(op_v8_lifetime);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_v8_lifetime),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: Some({
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_v8_lifetime),
+        false,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new(
@@ -17,35 +20,15 @@ impl deno_core::_ops::Op for op_v8_lifetime {
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 2usize as u8,
-    };
+    );
 }
 impl op_v8_lifetime {
     pub const fn name() -> &'static str {
         stringify!(op_v8_lifetime)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_v8_lifetime),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: Some({
-                use deno_core::v8::fast_api::Type;
-                use deno_core::v8::fast_api::CType;
-                deno_core::v8::fast_api::FastFunction::new(
-                    &[Type::V8Value, Type::V8Value, Type::V8Value],
-                    CType::Void,
-                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-                )
-            }),
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 2usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     fn v8_fn_ptr_fast(
         _: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/v8_string.out
+++ b/ops/op2/test_cases/sync/v8_string.out
@@ -4,32 +4,23 @@ struct op_v8_string {
 }
 impl deno_core::_ops::Op for op_v8_string {
     const NAME: &'static str = stringify!(op_v8_string);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl {
-        name: stringify!(op_v8_string),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: None,
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 2usize as u8,
-    };
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_v8_string),
+        false,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
 }
 impl op_v8_string {
     pub const fn name() -> &'static str {
         stringify!(op_v8_string)
     }
+    #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
-        deno_core::_ops::OpDecl {
-            name: stringify!(op_v8_string),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: None,
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 2usize as u8,
-        }
+        <Self as deno_core::_ops::Op>::DECL
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {

--- a/ops/optimizer_tests/async_nop.out
+++ b/ops/optimizer_tests/async_nop.out
@@ -8,11 +8,14 @@ pub struct op_void_async {
 }
 impl deno_core::_ops::Op for op_void_async {
     const NAME: &'static str = stringify!(op_void_async);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        true,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for op_void_async {
                 ),
             )
         },
-        is_async: true,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl op_void_async {
@@ -44,27 +43,9 @@ impl op_void_async {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, Int32, CallbackOptions],
-                        CType::Void,
-                        Self::op_void_async_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: true,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/async_result.out
+++ b/ops/optimizer_tests/async_result.out
@@ -8,11 +8,14 @@ pub struct op_async_result {
 }
 impl deno_core::_ops::Op for op_async_result {
     const NAME: &'static str = stringify!(op_async_result);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        true,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for op_async_result {
                 ),
             )
         },
-        is_async: true,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl op_async_result {
@@ -44,27 +43,9 @@ impl op_async_result {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, Int32, Uint32, CallbackOptions],
-                        CType::Void,
-                        Self::op_async_result_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: true,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 2usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/callback_options.out
+++ b/ops/optimizer_tests/callback_options.out
@@ -8,11 +8,14 @@ pub struct op_fallback {
 }
 impl deno_core::_ops::Op for op_fallback {
     const NAME: &'static str = stringify!(op_fallback);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for op_fallback {
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl op_fallback {
@@ -44,27 +43,9 @@ impl op_fallback {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, CallbackOptions],
-                        CType::Void,
-                        Self::op_fallback_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/cow_str.out
+++ b/ops/optimizer_tests/cow_str.out
@@ -8,11 +8,14 @@ pub struct op_cow_str {
 }
 impl deno_core::_ops::Op for op_cow_str {
     const NAME: &'static str = stringify!(op_cow_str);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for op_cow_str {
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl op_cow_str {
@@ -44,27 +43,9 @@ impl op_cow_str {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, SeqOneByteString, CallbackOptions],
-                        CType::Void,
-                        Self::op_cow_str_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/f64_slice.out
+++ b/ops/optimizer_tests/f64_slice.out
@@ -8,11 +8,14 @@ pub struct op_f64_buf {
 }
 impl deno_core::_ops::Op for op_f64_buf {
     const NAME: &'static str = stringify!(op_f64_buf);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for op_f64_buf {
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl op_f64_buf {
@@ -44,27 +43,9 @@ impl op_f64_buf {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, TypedArray(CType::Float64), CallbackOptions],
-                        CType::Void,
-                        Self::op_f64_buf_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/incompatible_1.out
+++ b/ops/optimizer_tests/incompatible_1.out
@@ -8,16 +8,15 @@ pub struct op_sync_serialize_object_with_numbers_as_keys {
 }
 impl deno_core::_ops::Op for op_sync_serialize_object_with_numbers_as_keys {
     const NAME: &'static str = stringify!(op_sync_serialize_object_with_numbers_as_keys);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: None,
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
 }
 #[doc(hidden)]
 impl op_sync_serialize_object_with_numbers_as_keys {
@@ -34,17 +33,9 @@ impl op_sync_serialize_object_with_numbers_as_keys {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: None,
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/issue16934.out
+++ b/ops/optimizer_tests/issue16934.out
@@ -8,16 +8,15 @@ pub struct send_stdin {
 }
 impl deno_core::_ops::Op for send_stdin {
     const NAME: &'static str = stringify!(send_stdin);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: None,
-        is_async: true,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        true,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
 }
 #[doc(hidden)]
 impl send_stdin {
@@ -34,17 +33,9 @@ impl send_stdin {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: None,
-            is_async: true,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 2usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/issue16934_fast.out
+++ b/ops/optimizer_tests/issue16934_fast.out
@@ -8,16 +8,15 @@ pub struct send_stdin {
 }
 impl deno_core::_ops::Op for send_stdin {
     const NAME: &'static str = stringify!(send_stdin);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: None,
-        is_async: true,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        true,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
 }
 #[doc(hidden)]
 impl send_stdin {
@@ -34,17 +33,9 @@ impl send_stdin {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: None,
-            is_async: true,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 2usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/op_blob_revoke_object_url.out
+++ b/ops/optimizer_tests/op_blob_revoke_object_url.out
@@ -8,16 +8,15 @@ pub struct op_blob_revoke_object_url {
 }
 impl deno_core::_ops::Op for op_blob_revoke_object_url {
     const NAME: &'static str = stringify!(op_blob_revoke_object_url);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: None,
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
 }
 #[doc(hidden)]
 impl op_blob_revoke_object_url {
@@ -34,17 +33,9 @@ impl op_blob_revoke_object_url {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: None,
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/op_ffi_ptr_value.out
+++ b/ops/optimizer_tests/op_ffi_ptr_value.out
@@ -8,11 +8,14 @@ pub struct op_ffi_ptr_value {
 }
 impl deno_core::_ops::Op for op_ffi_ptr_value {
     const NAME: &'static str = stringify!(op_ffi_ptr_value);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for op_ffi_ptr_value {
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl op_ffi_ptr_value {
@@ -44,27 +43,9 @@ impl op_ffi_ptr_value {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, Pointer, TypedArray(CType::Uint32), CallbackOptions],
-                        CType::Void,
-                        Self::op_ffi_ptr_value_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 2usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/op_print.out
+++ b/ops/optimizer_tests/op_print.out
@@ -8,16 +8,15 @@ pub struct op_print {
 }
 impl deno_core::_ops::Op for op_print {
     const NAME: &'static str = stringify!(op_print);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: None,
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
 }
 #[doc(hidden)]
 impl op_print {
@@ -34,17 +33,9 @@ impl op_print {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: None,
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 2usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/op_state.out
+++ b/ops/optimizer_tests/op_state.out
@@ -8,11 +8,14 @@ pub struct op_set_exit_code {
 }
 impl deno_core::_ops::Op for op_set_exit_code {
     const NAME: &'static str = stringify!(op_set_exit_code);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for op_set_exit_code {
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl op_set_exit_code {
@@ -44,27 +43,9 @@ impl op_set_exit_code {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, Int32, CallbackOptions],
-                        CType::Void,
-                        Self::op_set_exit_code_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/op_state_basic1.out
+++ b/ops/optimizer_tests/op_state_basic1.out
@@ -8,11 +8,14 @@ pub struct foo {
 }
 impl deno_core::_ops::Op for foo {
     const NAME: &'static str = stringify!(foo);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for foo {
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl foo {
@@ -44,27 +43,9 @@ impl foo {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, Uint32, Uint32, CallbackOptions],
-                        CType::Uint32,
-                        Self::foo_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 2usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/op_state_generics.out
+++ b/ops/optimizer_tests/op_state_generics.out
@@ -11,11 +11,14 @@ where
     SP: SomePermission + 'static,
 {
     const NAME: &'static str = stringify!(op_foo);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        0usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -26,11 +29,7 @@ where
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl<SP> op_foo<SP>
@@ -50,27 +49,9 @@ where
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, CallbackOptions],
-                        CType::Void,
-                        Self::op_foo_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 0usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/op_state_result.out
+++ b/ops/optimizer_tests/op_state_result.out
@@ -8,11 +8,14 @@ pub struct foo {
 }
 impl deno_core::_ops::Op for foo {
     const NAME: &'static str = stringify!(foo);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for foo {
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl foo {
@@ -44,27 +43,9 @@ impl foo {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, Uint32, Uint32, CallbackOptions],
-                        CType::Uint32,
-                        Self::foo_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 2usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/op_state_warning.out
+++ b/ops/optimizer_tests/op_state_warning.out
@@ -8,11 +8,14 @@ pub struct op_listen {
 }
 impl deno_core::_ops::Op for op_listen {
     const NAME: &'static str = stringify!(op_listen);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        0usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for op_listen {
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl op_listen {
@@ -44,27 +43,9 @@ impl op_listen {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, CallbackOptions],
-                        CType::Uint32,
-                        Self::op_listen_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 0usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/op_state_with_transforms.out
+++ b/ops/optimizer_tests/op_state_with_transforms.out
@@ -11,11 +11,14 @@ where
     TP: TimersPermission + 'static,
 {
     const NAME: &'static str = stringify!(op_now);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -26,11 +29,7 @@ where
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl<TP> op_now<TP>
@@ -50,27 +49,9 @@ where
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, TypedArray(CType::Uint8), CallbackOptions],
-                        CType::Void,
-                        Self::op_now_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/opstate_with_arity.out
+++ b/ops/optimizer_tests/opstate_with_arity.out
@@ -8,11 +8,14 @@ pub struct op_add_4 {
 }
 impl deno_core::_ops::Op for op_add_4 {
     const NAME: &'static str = stringify!(op_add_4);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        4usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for op_add_4 {
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl op_add_4 {
@@ -44,27 +43,9 @@ impl op_add_4 {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, Uint32, Uint32, Uint32, Uint32, CallbackOptions],
-                        CType::Uint32,
-                        Self::op_add_4_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 4usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/option_arg.out
+++ b/ops/optimizer_tests/option_arg.out
@@ -8,16 +8,15 @@ pub struct op_try_close {
 }
 impl deno_core::_ops::Op for op_try_close {
     const NAME: &'static str = stringify!(op_try_close);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: None,
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
 }
 #[doc(hidden)]
 impl op_try_close {
@@ -34,17 +33,9 @@ impl op_try_close {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: None,
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/owned_string.out
+++ b/ops/optimizer_tests/owned_string.out
@@ -8,11 +8,14 @@ pub struct op_string_length {
 }
 impl deno_core::_ops::Op for op_string_length {
     const NAME: &'static str = stringify!(op_string_length);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for op_string_length {
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl op_string_length {
@@ -44,27 +43,9 @@ impl op_string_length {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, SeqOneByteString, CallbackOptions],
-                        CType::Uint32,
-                        Self::op_string_length_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/param_mut_binding_warning.out
+++ b/ops/optimizer_tests/param_mut_binding_warning.out
@@ -8,16 +8,15 @@ pub struct op_read_sync {
 }
 impl deno_core::_ops::Op for op_read_sync {
     const NAME: &'static str = stringify!(op_read_sync);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: None,
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
 }
 #[doc(hidden)]
 impl op_read_sync {
@@ -34,17 +33,9 @@ impl op_read_sync {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: None,
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 2usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/raw_ptr.out
+++ b/ops/optimizer_tests/raw_ptr.out
@@ -11,11 +11,14 @@ where
     FP: FfiPermissions + 'static,
 {
     const NAME: &'static str = stringify!(op_ffi_ptr_of);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -31,11 +34,7 @@ where
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl<FP> op_ffi_ptr_of<FP>
@@ -55,32 +54,9 @@ where
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[
-                            V8Value,
-                            TypedArray(CType::Uint8),
-                            TypedArray(CType::Uint32),
-                            CallbackOptions,
-                        ],
-                        CType::Void,
-                        Self::op_ffi_ptr_of_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 2usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/serde_v8_value.out
+++ b/ops/optimizer_tests/serde_v8_value.out
@@ -8,11 +8,14 @@ pub struct op_is_proxy {
 }
 impl deno_core::_ops::Op for op_is_proxy {
     const NAME: &'static str = stringify!(op_is_proxy);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for op_is_proxy {
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl op_is_proxy {
@@ -44,27 +43,9 @@ impl op_is_proxy {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, V8Value],
-                        CType::Bool,
-                        Self::op_is_proxy_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/strings.out
+++ b/ops/optimizer_tests/strings.out
@@ -8,11 +8,14 @@ pub struct op_string_length {
 }
 impl deno_core::_ops::Op for op_string_length {
     const NAME: &'static str = stringify!(op_string_length);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for op_string_length {
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl op_string_length {
@@ -44,27 +43,9 @@ impl op_string_length {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, SeqOneByteString, CallbackOptions],
-                        CType::Uint32,
-                        Self::op_string_length_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/strings_result.out
+++ b/ops/optimizer_tests/strings_result.out
@@ -8,16 +8,15 @@ pub struct op_string_length {
 }
 impl deno_core::_ops::Op for op_string_length {
     const NAME: &'static str = stringify!(op_string_length);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: None,
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
 }
 #[doc(hidden)]
 impl op_string_length {
@@ -34,17 +33,9 @@ impl op_string_length {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: None,
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/u64_result.out
+++ b/ops/optimizer_tests/u64_result.out
@@ -8,16 +8,15 @@ pub struct op_bench_now {
 }
 impl deno_core::_ops::Op for op_bench_now {
     const NAME: &'static str = stringify!(op_bench_now);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: None,
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        0usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
 }
 #[doc(hidden)]
 impl op_bench_now {
@@ -34,17 +33,9 @@ impl op_bench_now {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: None,
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 0usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/uint8array.out
+++ b/ops/optimizer_tests/uint8array.out
@@ -8,11 +8,14 @@ pub struct op_import_spki_x25519 {
 }
 impl deno_core::_ops::Op for op_import_spki_x25519 {
     const NAME: &'static str = stringify!(op_import_spki_x25519);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for op_import_spki_x25519 {
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl op_import_spki_x25519 {
@@ -44,27 +43,9 @@ impl op_import_spki_x25519 {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, TypedArray(CType::Uint8), TypedArray(CType::Uint8)],
-                        CType::Bool,
-                        Self::op_import_spki_x25519_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 2usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/unit_result.out
+++ b/ops/optimizer_tests/unit_result.out
@@ -8,11 +8,14 @@ pub struct op_unit_result {
 }
 impl deno_core::_ops::Op for op_unit_result {
     const NAME: &'static str = stringify!(op_unit_result);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        0usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for op_unit_result {
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl op_unit_result {
@@ -44,27 +43,9 @@ impl op_unit_result {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, CallbackOptions],
-                        CType::Void,
-                        Self::op_unit_result_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 0usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/unit_result2.out
+++ b/ops/optimizer_tests/unit_result2.out
@@ -8,11 +8,14 @@ pub struct op_set_nodelay {
 }
 impl deno_core::_ops::Op for op_set_nodelay {
     const NAME: &'static str = stringify!(op_set_nodelay);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for op_set_nodelay {
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl op_set_nodelay {
@@ -44,27 +43,9 @@ impl op_set_nodelay {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, Uint32, Bool, CallbackOptions],
-                        CType::Void,
-                        Self::op_set_nodelay_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 2usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/unit_ret.out
+++ b/ops/optimizer_tests/unit_ret.out
@@ -8,11 +8,14 @@ pub struct op_unit {
 }
 impl deno_core::_ops::Op for op_unit {
     const NAME: &'static str = stringify!(op_unit);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        0usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for op_unit {
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl op_unit {
@@ -44,27 +43,9 @@ impl op_unit {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value],
-                        CType::Void,
-                        Self::op_unit_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 0usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]

--- a/ops/optimizer_tests/wasm_op.out
+++ b/ops/optimizer_tests/wasm_op.out
@@ -8,11 +8,14 @@ pub struct op_wasm {
 }
 impl deno_core::_ops::Op for op_wasm {
     const NAME: &'static str = stringify!(op_wasm);
-    const DECL: deno_core::OpDecl = deno_core::OpDecl {
-        name: Self::name(),
-        v8_fn_ptr: Self::v8_fn_ptr as _,
-        enabled: true,
-        fast_fn: {
+    const DECL: deno_core::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        Self::name(),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        {
             use deno_core::v8::fast_api::CType;
             use deno_core::v8::fast_api::Type::*;
             Some(
@@ -23,11 +26,7 @@ impl deno_core::_ops::Op for op_wasm {
                 ),
             )
         },
-        is_async: false,
-        is_unstable: false,
-        is_v8: false,
-        arg_count: 0,
-    };
+    );
 }
 #[doc(hidden)]
 impl op_wasm {
@@ -44,27 +43,9 @@ impl op_wasm {
         let rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
         Self::v8_func(scope, args, rv);
     }
-    pub const fn decl() -> deno_core::OpDecl {
-        deno_core::OpDecl {
-            name: Self::name(),
-            v8_fn_ptr: Self::v8_fn_ptr as _,
-            enabled: true,
-            fast_fn: {
-                use deno_core::v8::fast_api::CType;
-                use deno_core::v8::fast_api::Type::*;
-                Some(
-                    deno_core::v8::fast_api::FastFunction::new(
-                        &[V8Value, CallbackOptions],
-                        CType::Void,
-                        Self::op_wasm_fast_fn as *const ::std::ffi::c_void,
-                    ),
-                )
-            },
-            is_async: false,
-            is_unstable: false,
-            is_v8: false,
-            arg_count: 1usize as u8,
-        }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
     }
     #[inline]
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
Allowing embedders to access fast and slow functions was a footgun -- code was copying the slow function without copying the fast function as well. 

Fixes #24