### PR TITLE
feat(ops): Basic buffer support for op2 

### DIFF
--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -348,22 +348,22 @@ pub fn serde_v8_to_rust<'a, T: Deserialize<'a>>(
 pub fn to_nonresizable_v8_slice(
   scope: &mut v8::HandleScope,
   input: v8::Local<v8::Value>,
-) -> Result<serde_v8::V8Slice, ()> {
+) -> Result<serde_v8::V8Slice, &'static str> {
   let (buf, offset, length) =
     if let Ok(buf) = v8::Local::<v8::ArrayBufferView>::try_from(input) {
       let Some(buffer) = buf.buffer(scope) else {
-      return Err(());
-    };
+        return Err("buffer missing");
+      };
       (buffer, buf.byte_offset(), buf.byte_length())
     } else if let Ok(buf) = v8::Local::<v8::ArrayBuffer>::try_from(input) {
       (buf, 0, buf.byte_length())
     } else {
-      return Err(());
+      return Err("expected ArrayBuffer or ArrayBufferView");
     };
 
   let store = buf.get_backing_store();
   if store.is_resizable_by_user_javascript() {
-    return Err(());
+    return Err("expected non-resizable buffer");
   }
   let slice =
     unsafe { serde_v8::V8Slice::from_parts(store, offset..(offset + length)) };

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -344,6 +344,7 @@ pub fn serde_v8_to_rust<'a, T: Deserialize<'a>>(
 }
 
 /// Retrieve a [`serde_v8::V8Slice`] from a value.
+#[allow(clippy::result_unit_err)]
 pub fn to_v8_slice(
   scope: &mut v8::HandleScope,
   input: v8::Local<v8::Value>,

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -966,7 +966,7 @@ mod tests {
     Ok(())
   }
 
-  #[op2(core)]
+  #[op2(core, fast)]
   pub fn op_buffer_slice(
     #[buffer] input: &[u8],
     inlen: usize,

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -62,9 +62,15 @@ impl V8FastCallType {
       V8FastCallType::SeqOneByteString => {
         quote!(*mut #deno_core::v8::fast_api::FastApiOneByteString)
       }
-      V8FastCallType::Uint8Array => quote!(*mut #deno_core::v8::fast_api::FastApiTypedArray<u8>),
-      V8FastCallType::Uint32Array => quote!(*mut #deno_core::v8::fast_api::FastApiTypedArray<u32>),
-      V8FastCallType::Float64Array => quote!(*mut #deno_core::v8::fast_api::FastApiTypedArray<f64>),
+      V8FastCallType::Uint8Array => {
+        quote!(*mut #deno_core::v8::fast_api::FastApiTypedArray<u8>)
+      }
+      V8FastCallType::Uint32Array => {
+        quote!(*mut #deno_core::v8::fast_api::FastApiTypedArray<u32>)
+      }
+      V8FastCallType::Float64Array => {
+        quote!(*mut #deno_core::v8::fast_api::FastApiTypedArray<f64>)
+      }
       V8FastCallType::Virtual => unreachable!("invalid virtual argument"),
     }
   }

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -378,6 +378,8 @@ fn map_arg_to_v8_fastcall_type(
   arg: &Arg,
 ) -> Result<Option<V8FastCallType>, V8MappingError> {
   let rv = match arg {
+    // No buffers yet
+    Arg::Buffer(_) => return Ok(None),
     // Virtual OpState arguments
     Arg::RcRefCell(Special::OpState)
     | Arg::Ref(_, Special::OpState)

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -41,8 +41,8 @@ pub(crate) fn generate_dispatch_slow(
     });
   }
 
-  // Collect virtual arguments in a deferred list that we compute at the very end. This allows us to copy
-  // the scope borrow.
+  // Collect virtual arguments in a deferred list that we compute at the very end. This allows us to borrow
+  // the scope/opstate in the intermediate stages.
   let mut deferred = TokenStream::new();
   let mut input_index = 0;
 

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -371,8 +371,7 @@ pub fn from_arg_buffer(
   buffer: &Buffer,
 ) -> Result<TokenStream, V8MappingError> {
   let err = format_ident!("{}_err", arg_ident);
-  let throw_exception =
-    throw_type_error_static_string(generator_state, &err)?;
+  let throw_exception = throw_type_error_static_string(generator_state, &err)?;
 
   let GeneratorState {
     deno_core,

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -370,8 +370,9 @@ pub fn from_arg_buffer(
   arg_ident: &Ident,
   buffer: &Buffer,
 ) -> Result<TokenStream, V8MappingError> {
+  let err = format_ident!("{}_err", arg_ident);
   let throw_exception =
-    throw_type_error(generator_state, "expected buffer".to_string())?;
+    throw_type_error_static_string(generator_state, &err)?;
 
   let GeneratorState {
     deno_core,
@@ -382,9 +383,11 @@ pub fn from_arg_buffer(
 
   *needs_scope = true;
   let make_v8slice = quote! {
-    let #arg_ident = unsafe { #deno_core::_ops::to_nonresizable_v8_slice(&mut #scope, #arg_ident) };
-    let Ok(mut #arg_ident) = #arg_ident else {
-      #throw_exception
+    let mut #arg_ident = match unsafe { #deno_core::_ops::to_nonresizable_v8_slice(&mut #scope, #arg_ident) } {
+      Ok(#arg_ident) => #arg_ident,
+      Err(#err) => {
+        #throw_exception
+      }
     };
   };
 
@@ -664,6 +667,30 @@ fn throw_type_error_string(
     #maybe_scope
     // TODO(mmastrac): This might be allocating too much, even if it's on the error path
     let msg = #deno_core::v8::String::new(&mut #scope, &format!("{}", #deno_core::anyhow::Error::from(#message))).unwrap();
+    let exc = #deno_core::v8::Exception::error(&mut #scope, msg);
+    #scope.throw_exception(exc);
+    return;
+  })
+}
+
+/// Generates code to throw an exception from a string variable, adding required additional dependencies as needed.
+fn throw_type_error_static_string(
+  generator_state: &mut GeneratorState,
+  message: &Ident,
+) -> Result<TokenStream, V8MappingError> {
+  let maybe_scope = if generator_state.needs_scope {
+    quote!()
+  } else {
+    with_scope(generator_state)
+  };
+
+  let GeneratorState {
+    deno_core, scope, ..
+  } = &generator_state;
+
+  Ok(quote! {
+    #maybe_scope
+    let msg = #deno_core::v8::String::new_from_one_byte(&mut #scope, #message.as_bytes(), #deno_core::v8::NewStringType::Normal).unwrap();
     let exc = #deno_core::v8::Exception::error(&mut #scope, msg);
     #scope.throw_exception(exc);
     return;

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -371,7 +371,7 @@ pub fn from_arg_buffer(
   buffer: &Buffer,
 ) -> Result<TokenStream, V8MappingError> {
   let throw_exception =
-    throw_type_error(generator_state, format!("expected buffer"))?;
+    throw_type_error(generator_state, "expected buffer".to_string())?;
 
   let GeneratorState {
     deno_core,

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -382,7 +382,7 @@ pub fn from_arg_buffer(
 
   *needs_scope = true;
   let make_v8slice = quote! {
-    let #arg_ident = unsafe { #deno_core::_ops::to_v8_slice(&mut #scope, #arg_ident) };
+    let #arg_ident = unsafe { #deno_core::_ops::to_nonresizable_v8_slice(&mut #scope, #arg_ident) };
     let Ok(mut #arg_ident) = #arg_ident else {
       #throw_exception
     };

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -17,6 +17,7 @@ use syn2::FnArg;
 use syn2::GenericParam;
 use syn2::Generics;
 use syn2::Pat;
+use syn2::Path;
 use syn2::ReturnType;
 use syn2::Signature;
 use syn2::Type;
@@ -123,6 +124,30 @@ pub enum Special {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Buffer {
+  /// [`&[u8]`], [`&mut [u8]`], [`&[u32]`], etc...
+  Slice(RefType, NumericArg),
+  /// [`*const u8`], [`*mut u8`], [`*const u32`], etc...
+  Ptr(RefType, NumericArg),
+  /// [`Box<[u8]>`], [`Box<[u32]>`], etc...
+  BoxSlice(NumericArg),
+  /// [`Vec<u8>`], [`Vec<u32>`], etc...
+  Vec(NumericArg),
+  /// Owned in `bytes::Bytes`
+  Bytes,
+  /// Owned in `serde_v8::V8Slice`
+  V8Slice,
+  /// Owned in `serde_v8::JSBuffer`
+  JSBuffer,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum External {
+  /// c_void
+  Ptr(RefType),
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum RefType {
   Ref,
   Mut,
@@ -135,12 +160,12 @@ pub enum RefType {
 pub enum Arg {
   Void,
   Special(Special),
+  Buffer(Buffer),
+  External(External),
   Ref(RefType, Special),
   RcRefCell(Special),
   Option(Special),
   OptionNumeric(NumericArg),
-  Slice(RefType, NumericArg),
-  Ptr(RefType, NumericArg),
   OptionV8Local(V8Arg),
   V8Local(V8Arg),
   V8Global(V8Arg),
@@ -214,6 +239,7 @@ impl Arg {
 
 enum ParsedType {
   TSpecial(Special),
+  TBuffer(Buffer),
   TV8(V8Arg),
   // TODO(mmastrac): We need to carry the mut status through somehow
   TV8Mut(V8Arg),
@@ -250,15 +276,32 @@ pub struct ParsedSignature {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum BufferMode {
+  /// Shared buffers that may possibly change on the JavaScript side upon re-entry into
+  /// V8. Rust code should not treat these as traditional buffers.
+  Shared,
+  /// Shared buffers that are copied from V8 unconditionally. May be expensive, but these
+  /// buffers are guaranteed to be owned by Rust.
+  Copy,
+  /// Buffers that are detached and owned purely by Rust. JavaScript will no longer have
+  /// access to these buffers and will see zero-sized buffers rather than the contents
+  /// that were passed in here.
+  Detach,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum AttributeModifier {
   /// #[serde], for serde_v8 types.
   Serde,
-  /// #[smi], for small integers
+  /// #[smi], for non-integral ID types representing small integers (-2³¹ and 2³¹-1 on 64-bit platforms,
+  /// see https://medium.com/fhinkel/v8-internals-how-small-is-a-small-integer-e0badc18b6da).
   Smi,
   /// #[string], for strings.
   String,
-  /// #[state], for automatic OpState extraction
+  /// #[state], for automatic OpState extraction.
   State,
+  /// #[buffer], for buffers.
+  Buffer(BufferMode),
 }
 
 #[derive(Error, Debug)]
@@ -291,6 +334,8 @@ pub enum ArgError {
   InvalidSelf,
   #[error("Invalid argument type: {0}")]
   InvalidType(String),
+  #[error("Invalid numeric argument type: {0}")]
+  InvalidNumericType(String),
   #[error(
     "Invalid argument type path (should this be #[smi] or #[serde]?): {0}"
   )]
@@ -315,6 +360,8 @@ pub enum ArgError {
   MissingStringAttribute,
   #[error("Invalid #[state] type '{0}'")]
   InvalidStateType(String),
+  #[error("Unknown or invalid attribute '{0}'")]
+  InvalidAttribute(String),
 }
 
 #[derive(Copy, Clone, Default)]
@@ -488,10 +535,12 @@ fn parse_generics(
 }
 
 fn parse_attributes(attributes: &[Attribute]) -> Result<Attributes, ArgError> {
-  let attrs = attributes
-    .iter()
-    .filter_map(parse_attribute)
-    .collect::<Vec<_>>();
+  let mut attrs = vec![];
+  for attr in attributes {
+    if let Some(attr) = parse_attribute(attr)? {
+      attrs.push(attr)
+    }
+  }
 
   if attrs.is_empty() {
     return Ok(Attributes::default());
@@ -504,23 +553,33 @@ fn parse_attributes(attributes: &[Attribute]) -> Result<Attributes, ArgError> {
   })
 }
 
+/// Is this a special attribute that we understand?
 pub fn is_attribute_special(attr: &Attribute) -> bool {
-  parse_attribute(attr).is_some()
+  parse_attribute(attr).unwrap_or_default().is_some()
 }
 
-fn parse_attribute(attr: &Attribute) -> Option<AttributeModifier> {
+/// Parses an attribute, returning None if this is an attribute we support but is
+/// otherwise unknown (ie: doc comments).
+fn parse_attribute(
+  attr: &Attribute,
+) -> Result<Option<AttributeModifier>, ArgError> {
   let tokens = attr.into_token_stream();
-  use syn2 as syn;
-  std::panic::catch_unwind(|| {
+  let res = std::panic::catch_unwind(|| {
+    use syn2 as syn;
     rules!(tokens => {
       (#[serde]) => Some(AttributeModifier::Serde),
       (#[smi]) => Some(AttributeModifier::Smi),
       (#[string]) => Some(AttributeModifier::String),
       (#[state]) => Some(AttributeModifier::State),
-      (#[$_attr:meta]) => None,
+      (#[buffer]) => Some(AttributeModifier::Buffer(BufferMode::Shared)),
+      (#[buffer(shared)]) => Some(AttributeModifier::Buffer(BufferMode::Shared)),
+      (#[buffer(copy)]) => Some(AttributeModifier::Buffer(BufferMode::Copy)),
+      (#[buffer(detach)]) => Some(AttributeModifier::Buffer(BufferMode::Detach)),
+      (#[allow ($_rule:path)]) => None,
+      (#[doc = $_attr:literal]) => None,
     })
-  })
-  .expect("Failed to parse an attribute")
+  }).map_err(|_| ArgError::InvalidAttribute(stringify_token(attr)))?;
+  Ok(res)
 }
 
 fn parse_return(
@@ -560,6 +619,19 @@ fn parse_return(
   }
 }
 
+fn parse_numeric_type(tp: &Path) -> Result<NumericArg, ArgError> {
+  if tp.segments.len() == 1 {
+    let segment = tp.segments.first().unwrap().ident.to_string();
+    for numeric in NumericArg::iter() {
+      if Into::<&'static str>::into(numeric) == segment.as_str() {
+        return Ok(numeric);
+      }
+    }
+  }
+
+  Err(ArgError::InvalidNumericType(stringify_token(tp)))
+}
+
 /// Parse a raw type into a container + type, allowing us to simplify the typechecks elsewhere in
 /// this code.
 fn parse_type_path(
@@ -570,13 +642,8 @@ fn parse_type_path(
   use ParsedType::*;
   use ParsedTypeContainer::*;
 
-  if tp.path.segments.len() == 1 {
-    let segment = tp.path.segments.first().unwrap().ident.to_string();
-    for numeric in NumericArg::iter() {
-      if Into::<&'static str>::into(numeric) == segment.as_str() {
-        return Ok(CBare(TNumeric(numeric)));
-      }
-    }
+  if let Ok(numeric) = parse_numeric_type(&tp.path) {
+    return Ok(CBare(TNumeric(numeric)));
   }
 
   use syn2 as syn;
@@ -588,11 +655,26 @@ fn parse_type_path(
         Ok(CBare(TSpecial(Special::String)))
       }
       // Note that the reference is checked below
-      ( $( std :: str  :: )? str ) => {
+      ( $( std :: str :: )? str ) => {
         Ok(CBare(TSpecial(Special::RefStr)))
       }
       ( $( std :: borrow :: )? Cow < str > ) => {
         Ok(CBare(TSpecial(Special::CowStr)))
+      }
+      ( $( std :: vec ::)? Vec < $ty:path > ) => {
+        Ok(CBare(TBuffer(Buffer::Vec(parse_numeric_type(&ty)?))))
+      }
+      ( $( std :: boxed ::)? Box < [ $ty:path ] > ) => {
+        Ok(CBare(TBuffer(Buffer::BoxSlice(parse_numeric_type(&ty)?))))
+      }
+      ( $( serde_v8 :: )? V8Slice ) => {
+        Ok(CBare(TBuffer(Buffer::V8Slice)))
+      }
+      ( $( serde_v8 :: )? JSBuffer ) => {
+        Ok(CBare(TBuffer(Buffer::JSBuffer)))
+      }
+      ( $( bytes :: )? Bytes ) => {
+        Ok(CBare(TBuffer(Buffer::Bytes)))
       }
       ( $( std :: ffi :: )? c_void ) => Ok(CBare(TNumeric(NumericArg::__VOID__))),
       ( OpState ) => Ok(CBare(TSpecial(Special::OpState))),
@@ -606,6 +688,7 @@ fn parse_type_path(
         match parse_type(attrs, &ty)? {
           Arg::Special(special) => Ok(COption(TSpecial(special))),
           Arg::Numeric(numeric) => Ok(COption(TNumeric(numeric))),
+          Arg::Buffer(buffer) => Ok(COption(TBuffer(buffer))),
           Arg::V8Ref(RefType::Ref, v8) => Ok(COption(TV8(v8))),
           Arg::V8Ref(RefType::Mut, v8) => Ok(COption(TV8Mut(v8))),
           Arg::V8Local(v8) => Ok(COptionV8Local(TV8(v8))),
@@ -742,6 +825,9 @@ fn parse_type(attrs: Attributes, ty: &Type) -> Result<Arg, ArgError> {
       AttributeModifier::String => {
         // We handle this as part of the normal parsing process
       }
+      AttributeModifier::Buffer(_) => {
+        // We handle this as part of the normal parsing process
+      }
       AttributeModifier::Smi => {
         return Ok(Arg::Numeric(NumericArg::__SMI__));
       }
@@ -763,7 +849,12 @@ fn parse_type(attrs: Attributes, ty: &Type) -> Result<Arg, ArgError> {
       };
       match &*of.elem {
         Type::Slice(of) => match parse_type(attrs, &of.elem)? {
-          Arg::Numeric(numeric) => Ok(Arg::Slice(mut_type, numeric)),
+          Arg::Numeric(numeric) if numeric == NumericArg::__VOID__ => {
+            Ok(Arg::External(External::Ptr(mut_type)))
+          }
+          Arg::Numeric(numeric) => {
+            Ok(Arg::Buffer(Buffer::Slice(mut_type, numeric)))
+          }
           _ => Err(ArgError::InvalidType(stringify_token(ty))),
         },
         Type::Path(of) => match parse_type_path(attrs, true, of)? {
@@ -786,7 +877,12 @@ fn parse_type(attrs: Attributes, ty: &Type) -> Result<Arg, ArgError> {
       };
       match &*of.elem {
         Type::Path(of) => match parse_type_path(attrs, false, of)? {
-          CBare(TNumeric(numeric)) => Ok(Arg::Ptr(mut_type, numeric)),
+          CBare(TNumeric(numeric)) if numeric == NumericArg::__VOID__ => {
+            Ok(Arg::External(External::Ptr(mut_type)))
+          }
+          CBare(TNumeric(numeric)) => {
+            Ok(Arg::Buffer(Buffer::Ptr(mut_type, numeric)))
+          }
           _ => Err(ArgError::InvalidType(stringify_token(ty))),
         },
         _ => Err(ArgError::InvalidType(stringify_token(ty))),
@@ -795,6 +891,7 @@ fn parse_type(attrs: Attributes, ty: &Type) -> Result<Arg, ArgError> {
     Type::Path(of) => match parse_type_path(attrs, false, of)? {
       CBare(TNumeric(numeric)) => Ok(Arg::Numeric(numeric)),
       CBare(TSpecial(special)) => Ok(Arg::Special(special)),
+      CBare(TBuffer(buffer)) => Ok(Arg::Buffer(buffer)),
       COption(TNumeric(special)) => Ok(Arg::OptionNumeric(special)),
       COption(TSpecial(special)) => Ok(Arg::Option(special)),
       CRcRefCell(TSpecial(special)) => Ok(Arg::RcRefCell(special)),
@@ -917,7 +1014,7 @@ mod tests {
   );
   test!(
     fn op_slices(r#in: &[u8], out: &mut [u8]);
-    (Slice(Ref, u8), Slice(Mut, u8)) -> Infallible(Void)
+    (Buffer(Slice(Ref, u8)), Buffer(Slice(Mut, u8))) -> Infallible(Void)
   );
   test!(
     #[serde] fn op_serde(#[serde] input: package::SerdeInputType) -> Result<package::SerdeReturnType, Error>;
@@ -933,7 +1030,7 @@ mod tests {
   );
   test!(
     fn op_resource(#[smi] rid: ResourceId, buffer: &[u8]);
-    (Numeric(__SMI__), Slice(Ref, u8)) ->  Infallible(Void)
+    (Numeric(__SMI__), Buffer(Slice(Ref, u8))) ->  Infallible(Void)
   );
   test!(
     fn op_option_numeric_result(state: &mut OpState) -> Result<Option<u32>, AnyError>;
@@ -941,7 +1038,7 @@ mod tests {
   );
   test!(
     fn op_ffi_read_f64(state: &mut OpState, ptr: * mut c_void, offset: isize) -> Result <f64, AnyError>;
-    (Ref(Mut, OpState), Ptr(Mut, __VOID__), Numeric(isize)) -> Result(Numeric(f64))
+    (Ref(Mut, OpState), External(Ptr(Mut)), Numeric(isize)) -> Result(Numeric(f64))
   );
   test!(
     fn op_print(#[string] msg: &str, is_err: bool) -> Result<(), Error>;
@@ -983,6 +1080,10 @@ mod tests {
     fn op_state_attr(#[state] something: &Something, #[state] another: Option<&Something>);
     (State(Ref, "Something"), OptionState(Ref, "Something")) -> Infallible(Void)
   );
+  test!(
+    #[buffer] fn op_buffers(#[buffer] a: Vec<u8>, #[buffer] b: Box<[u8]>, #[buffer] c: bytes::Bytes, #[buffer] d: V8Slice, #[buffer] e: JSBuffer) -> Vec<u8>;
+    (Buffer(Vec(u8)), Buffer(BoxSlice(u8)), Buffer(Bytes), Buffer(V8Slice), Buffer(JSBuffer)) -> Infallible(Buffer(Vec(u8)))
+  );
 
   // Args
 
@@ -1000,6 +1101,17 @@ mod tests {
     op_with_bad_string3,
     ArgError("s", MissingStringAttribute),
     fn f(s: Cow<str>) {}
+  );
+  expect_fail!(
+    op_with_bad_attr,
+    RetError(InvalidAttribute("#[badattr]")),
+    #[badattr]
+    fn f() {}
+  );
+  expect_fail!(
+    op_with_bad_attr2,
+    ArgError("a", InvalidAttribute("#[badattr]")),
+    fn f(#[badattr] a: u32) {}
   );
 
   // Generics

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -167,29 +167,29 @@ impl Buffer {
     match self {
       Buffer::Bytes => matches!(
         mode,
-        BufferMode::Copy | BufferMode::Detach | BufferMode::Shared
+        BufferMode::Copy | BufferMode::Detach | BufferMode::Unsafe
       ),
       Buffer::JSBuffer => matches!(
         mode,
-        BufferMode::Copy | BufferMode::Detach | BufferMode::Shared
+        BufferMode::Copy | BufferMode::Detach | BufferMode::Unsafe
       ),
       Buffer::V8Slice => matches!(
         mode,
-        BufferMode::Copy | BufferMode::Detach | BufferMode::Shared
+        BufferMode::Copy | BufferMode::Detach | BufferMode::Unsafe
       ),
       Buffer::Vec(..) => matches!(
         mode,
-        BufferMode::Copy | BufferMode::Detach | BufferMode::Shared
+        BufferMode::Copy | BufferMode::Detach | BufferMode::Unsafe
       ),
       Buffer::BoxSlice(..) => matches!(
         mode,
-        BufferMode::Copy | BufferMode::Detach | BufferMode::Shared
+        BufferMode::Copy | BufferMode::Detach | BufferMode::Unsafe
       ),
       Buffer::Slice(..) => {
-        matches!(mode, BufferMode::Detach | BufferMode::Shared)
+        matches!(mode, BufferMode::Detach | BufferMode::Unsafe)
       }
       Buffer::Ptr(..) => {
-        matches!(mode, BufferMode::Detach | BufferMode::Shared)
+        matches!(mode, BufferMode::Detach | BufferMode::Unsafe)
       }
     }
   }
@@ -331,9 +331,9 @@ pub struct ParsedSignature {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum BufferMode {
-  /// Shared buffers that may possibly change on the JavaScript side upon re-entry into
+  /// Unsafely shared buffers that may possibly change on the JavaScript side upon re-entry into
   /// V8. Rust code should not treat these as traditional buffers.
-  Shared,
+  Unsafe,
   /// Shared buffers that are copied from V8 unconditionally. May be expensive, but these
   /// buffers are guaranteed to be owned by Rust.
   Copy,
@@ -634,8 +634,8 @@ fn parse_attribute(
       (#[smi]) => Some(AttributeModifier::Smi),
       (#[string]) => Some(AttributeModifier::String),
       (#[state]) => Some(AttributeModifier::State),
-      (#[buffer]) => Some(AttributeModifier::Buffer(BufferMode::Shared)),
-      (#[buffer(shared)]) => Some(AttributeModifier::Buffer(BufferMode::Shared)),
+      (#[buffer]) => Some(AttributeModifier::Buffer(BufferMode::Unsafe)),
+      (#[buffer(unsafe)]) => Some(AttributeModifier::Buffer(BufferMode::Unsafe)),
       (#[buffer(copy)]) => Some(AttributeModifier::Buffer(BufferMode::Copy)),
       (#[buffer(detach)]) => Some(AttributeModifier::Buffer(BufferMode::Detach)),
       (#[allow ($_rule:path)]) => None,

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -48,6 +48,27 @@ pub enum NumericArg {
   usize,
 }
 
+impl NumericArg {
+  /// Returns the primary mapping from this primitive to an associated V8 typed array.
+  pub fn v8_array_type(self) -> Option<V8Arg> {
+    use NumericArg::*;
+    use V8Arg::*;
+    Some(match self {
+      i8 => Int8Array,
+      u8 => Uint8Array,
+      i16 => Int16Array,
+      u16 => Uint16Array,
+      i32 => Int32Array,
+      u32 => Uint32Array,
+      i64 => BigInt64Array,
+      u64 => BigUint64Array,
+      f32 => Float32Array,
+      f64 => Float64Array,
+      _ => return None,
+    })
+  }
+}
+
 impl ToTokens for NumericArg {
   fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
     let ident = Ident::new(self.into(), Span::call_site());

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -50,7 +50,9 @@ impl op_buffers {
             &*info
         });
         let arg0 = args.get(0usize as i32);
-        let arg0 = unsafe { deno_core::_ops::to_v8_slice(&mut scope, arg0) };
+        let arg0 = unsafe {
+            deno_core::_ops::to_nonresizable_v8_slice(&mut scope, arg0)
+        };
         let Ok(mut arg0) = arg0 else {
         let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
         let msg = deno_core::v8::String::new_from_one_byte(
@@ -65,7 +67,9 @@ impl op_buffers {
     };
         let arg0 = &mut arg0;
         let arg1 = args.get(1usize as i32);
-        let arg1 = unsafe { deno_core::_ops::to_v8_slice(&mut scope, arg1) };
+        let arg1 = unsafe {
+            deno_core::_ops::to_nonresizable_v8_slice(&mut scope, arg1)
+        };
         let Ok(mut arg1) = arg1 else {
         let msg = deno_core::v8::String::new_from_one_byte(
                 &mut scope,

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -11,7 +11,19 @@ impl deno_core::_ops::Op for op_buffers {
         false,
         2usize as u8,
         Self::v8_fn_ptr as _,
-        None,
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new(
+                &[
+                    Type::V8Value,
+                    Type::TypedArray(CType::Uint8),
+                    Type::TypedArray(CType::Uint8),
+                ],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
     );
 }
 impl op_buffers {
@@ -21,6 +33,16 @@ impl op_buffers {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    fn v8_fn_ptr_fast(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+    ) -> () {
+        let arg0 = unsafe { arg0.as_mut().unwrap() }.get_storage_if_aligned().unwrap();
+        let arg1 = unsafe { arg1.as_mut().unwrap() }.get_storage_if_aligned().unwrap();
+        let result = Self::call(arg0, arg1);
+        result
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -1,0 +1,63 @@
+#[allow(non_camel_case_types)]
+struct op_buffers {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
+impl deno_core::_ops::Op for op_buffers {
+    const NAME: &'static str = stringify!(op_buffers);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_buffers),
+        false,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
+}
+impl op_buffers {
+    pub const fn name() -> &'static str {
+        stringify!(op_buffers)
+    }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let arg0 = args.get(0usize as i32);
+        let arg0 = unsafe { deno_core::_ops::to_v8_slice(&mut scope, arg0) };
+        let Ok(mut arg0) = arg0 else {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let msg = deno_core::v8::String::new_from_one_byte(
+                &mut scope,
+                "expected buffer".as_bytes(),
+                deno_core::v8::NewStringType::Normal,
+            )
+            .unwrap();
+        let exc = deno_core::v8::Exception::error(&mut scope, msg);
+        scope.throw_exception(exc);
+        return;
+    };
+        let arg0 = &mut arg0;
+        let arg1 = args.get(1usize as i32);
+        let arg1 = unsafe { deno_core::_ops::to_v8_slice(&mut scope, arg1) };
+        let Ok(mut arg1) = arg1 else {
+        let msg = deno_core::v8::String::new_from_one_byte(
+                &mut scope,
+                "expected buffer".as_bytes(),
+                deno_core::v8::NewStringType::Normal,
+            )
+            .unwrap();
+        let exc = deno_core::v8::Exception::error(&mut scope, msg);
+        scope.throw_exception(exc);
+        return;
+    };
+        let arg1 = &mut arg1;
+        let result = Self::call(arg0, arg1);
+    }
+    #[inline(always)]
+    fn call(a: &[u8], b: &mut [u8]) {}
+}

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -50,37 +50,41 @@ impl op_buffers {
             &*info
         });
         let arg0 = args.get(0usize as i32);
-        let arg0 = unsafe {
+        let mut arg0 = match unsafe {
             deno_core::_ops::to_nonresizable_v8_slice(&mut scope, arg0)
+        } {
+            Ok(arg0) => arg0,
+            Err(arg0_err) => {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        arg0_err.as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return;
+            }
         };
-        let Ok(mut arg0) = arg0 else {
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let msg = deno_core::v8::String::new_from_one_byte(
-                &mut scope,
-                "expected buffer".as_bytes(),
-                deno_core::v8::NewStringType::Normal,
-            )
-            .unwrap();
-        let exc = deno_core::v8::Exception::error(&mut scope, msg);
-        scope.throw_exception(exc);
-        return;
-    };
         let arg0 = &mut arg0;
         let arg1 = args.get(1usize as i32);
-        let arg1 = unsafe {
+        let mut arg1 = match unsafe {
             deno_core::_ops::to_nonresizable_v8_slice(&mut scope, arg1)
+        } {
+            Ok(arg1) => arg1,
+            Err(arg1_err) => {
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        arg1_err.as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return;
+            }
         };
-        let Ok(mut arg1) = arg1 else {
-        let msg = deno_core::v8::String::new_from_one_byte(
-                &mut scope,
-                "expected buffer".as_bytes(),
-                deno_core::v8::NewStringType::Normal,
-            )
-            .unwrap();
-        let exc = deno_core::v8::Exception::error(&mut scope, msg);
-        scope.throw_exception(exc);
-        return;
-    };
         let arg1 = &mut arg1;
         let result = Self::call(arg0, arg1);
     }

--- a/ops/op2/test_cases/sync/buffers.rs
+++ b/ops/op2/test_cases/sync/buffers.rs
@@ -1,0 +1,5 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+#[op2]
+fn op_buffers(#[buffer] a: &[u8], #[buffer] b: &mut [u8]) {
+}

--- a/ops/op2/test_cases/sync/buffers.rs
+++ b/ops/op2/test_cases/sync/buffers.rs
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-#[op2]
+#[op2(fast)]
 fn op_buffers(#[buffer] a: &[u8], #[buffer] b: &mut [u8]) {
 }

--- a/serde_v8/lib.rs
+++ b/serde_v8/lib.rs
@@ -23,6 +23,7 @@ pub use magic::bytestring::ByteString;
 pub use magic::detached_buffer::DetachedBuffer;
 pub use magic::string_or_buffer::StringOrBuffer;
 pub use magic::u16string::U16String;
+pub use magic::v8slice::V8Slice;
 pub use magic::ExternalPointer;
 pub use magic::Global;
 pub use magic::Value;


### PR DESCRIPTION
Adds:

 - `#[buffer] &[u8]`
 - `#[buffer] &mut [u8]`

TODO:

 - `#[buffer] *const u8` (all primitive types) -- not recommended but used in FFI
 - `#[buffer] *mut u8` (all primitive types)
 - `#[buffer] bytes::Bytes`
 - `#[buffer] JSBuffer`
 - `#[buffer] V8Slice`
 - `#[buffer] Vec<..>`
 - `#[buffer] Box<[..]>`
 
TODO: Alternative buffer modes:

 - `#[buffer(shared)]` (the default)
 - `#[buffer(copy)]` 
 - `#[buffer(detach)]`
