### PR TITLE
fix: better message when someone provides a module that was already included in a snapshot

### DIFF
--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1801,12 +1801,12 @@ impl JsRuntime {
     assert_eq!(
       status,
       v8::ModuleStatus::Instantiated,
-      "{} ({})",
+      "{} {} ({})",
       if status == v8::ModuleStatus::Evaluated {
         "Module already evaluated. Perhaps you've re-provided a module or extension that was already included in the snapshot?"
       } else {
         "Module not instantiated"
-      }
+      },
       module_map_rc
         .borrow()
         .get_info_by_id(id)

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1798,10 +1798,19 @@ impl JsRuntime {
       .map(|handle| v8::Local::new(tc_scope, handle))
       .expect("ModuleInfo not found");
     let mut status = module.get_status();
+    if status != v8::ModuleStatus::Instantiated {
+      let module_info = module_map_rc
+      .borrow()
+      .get_info_by_id(id);
     assert_eq!(
       status,
       v8::ModuleStatus::Instantiated,
-      "Module not instantiated {} ({})",
+      "{} ({})",
+      if status == v8::ModuleStatus::Evaluated {
+        "Module already evaluated. Perhaps you've re-provided a module or extension that was already included in a snapshot?"
+      } else {
+        "Module not instantiated"
+      }
       module_map_rc
         .borrow()
         .get_info_by_id(id)

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1798,10 +1798,6 @@ impl JsRuntime {
       .map(|handle| v8::Local::new(tc_scope, handle))
       .expect("ModuleInfo not found");
     let mut status = module.get_status();
-    if status != v8::ModuleStatus::Instantiated {
-      let module_info = module_map_rc
-      .borrow()
-      .get_info_by_id(id);
     assert_eq!(
       status,
       v8::ModuleStatus::Instantiated,

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1807,7 +1807,7 @@ impl JsRuntime {
       v8::ModuleStatus::Instantiated,
       "{} ({})",
       if status == v8::ModuleStatus::Evaluated {
-        "Module already evaluated. Perhaps you've re-provided a module or extension that was already included in a snapshot?"
+        "Module already evaluated. Perhaps you've re-provided a module or extension that was already included in the snapshot?"
       } else {
         "Module not instantiated"
       }


### PR DESCRIPTION
I accidentally provided an extension again after creating a snapshot and it cost me a bit of time. This might help someone in the future.