### PR TITLE
feat(ops): Benchmark sync ops, support for Option<numeric>, faster strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,7 @@ name = "deno_core"
 version = "0.195.0"
 dependencies = [
  "anyhow",
+ "bencher",
  "bytes",
  "cooked-waker",
  "deno_ast",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,6 +17,7 @@ path = "lib.rs"
 default = ["v8_use_custom_libcxx"]
 v8_use_custom_libcxx = ["v8/use_custom_libcxx"]
 include_js_files_for_snapshotting = []
+unsafe_runtime_options = []
 
 [dependencies]
 anyhow.workspace = true
@@ -54,3 +55,4 @@ bencher.workspace = true
 name = "ops_sync"
 path = "benches/ops/sync.rs"
 harness = false
+required-features = ["unsafe_runtime_options"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -48,3 +48,9 @@ path = "examples/http_bench_json_ops/main.rs"
 [dev-dependencies]
 cooked-waker = "5"
 deno_ast.workspace = true
+bencher.workspace = true
+
+[[bench]]
+name = "ops_sync"
+path = "benches/ops/sync.rs"
+harness = false

--- a/core/benches/ops/sync.rs
+++ b/core/benches/ops/sync.rs
@@ -62,7 +62,6 @@ fn bench_op(
     |err| generic_error(format!("{op} test failed ({call}): {err:?}"));
 
   let args = (0..arg_count)
-    .into_iter()
     .map(|n| format!("arg{n}"))
     .collect::<Vec<_>>()
     .join(", ");

--- a/core/benches/ops/sync.rs
+++ b/core/benches/ops/sync.rs
@@ -1,0 +1,268 @@
+use bencher::*;
+use deno_core::error::generic_error;
+use deno_core::*;
+
+deno_core::extension!(
+  testing,
+  ops = [
+    op_void,
+    op_u32,
+    op_option_u32,
+    op_string,
+    op_string_old,
+    op_string_option_u32,
+  ],
+  state = |state| {
+    state.put(1234u32);
+    state.put(10000u16);
+  }
+);
+
+#[op2(fast)]
+pub fn op_void() {}
+
+#[op2(fast)]
+pub fn op_u32() -> u32 {
+  1
+}
+
+#[op2]
+pub fn op_option_u32() -> Option<u32> {
+  Some(1)
+}
+
+#[op2(fast)]
+pub fn op_string(#[string] s: &str) -> u32 {
+  s.len() as _
+}
+
+#[op(fast)]
+pub fn op_string_old(s: &str) -> u32 {
+  s.len() as _
+}
+
+#[op2]
+pub fn op_string_option_u32(#[string] s: &str) -> Option<u32> {
+  Some(s.len() as _)
+}
+
+fn bench_op(
+  b: &mut Bencher,
+  count: usize,
+  op: &str,
+  arg_count: usize,
+  call: &str,
+) {
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    extensions: vec![testing::init_ops_and_esm()],
+    unsafe_expose_natives_and_gc: true,
+    ..Default::default()
+  });
+  let err_mapper =
+    |err| generic_error(format!("{op} test failed ({call}): {err:?}"));
+
+  let args = (0..arg_count)
+    .into_iter()
+    .map(|n| format!("arg{n}"))
+    .collect::<Vec<_>>()
+    .join(", ");
+
+  // Prime the optimizer
+  runtime
+    .execute_script(
+      "",
+      FastString::Owned(
+        format!(
+          r"
+const LARGE_STRING_1000000 = '*'.repeat(1000000);
+const LARGE_STRING_1000 = '*'.repeat(1000);
+const LARGE_STRING_UTF8_1000000 = '\u1000'.repeat(1000000);
+const LARGE_STRING_UTF8_1000 = '\u1000'.repeat(1000);
+const {{ {op}: op }} = Deno.core.ensureFastOps();
+function {op}({args}) {{
+  op({args});
+}}
+let accum = 0;
+let __index__ = 0;
+%PrepareFunctionForOptimization({op});
+{call};
+%OptimizeFunctionOnNextCall({op});
+{call};
+
+function bench() {{
+  let accum = 0;
+  for (let __index__ = 0; __index__ < {count}; __index__++) {{ {call} }}
+  return accum;
+}}
+%PrepareFunctionForOptimization(bench);
+bench();
+%OptimizeFunctionOnNextCall(bench);
+bench();
+        "
+        )
+        .into(),
+      ),
+    )
+    .map_err(err_mapper)
+    .unwrap();
+
+  b.iter(|| {
+    runtime
+      .execute_script("", ascii_str!("bench()"))
+      .map_err(err_mapper)
+      .unwrap();
+  });
+}
+
+const BENCH_COUNT: usize = 1000;
+const LARGE_BENCH_COUNT: usize = 10;
+
+/// Tests the overhead of execute_script.
+fn baseline(b: &mut Bencher) {
+  bench_op(b, BENCH_COUNT, "op_void", 0, "accum += __index__;");
+}
+
+/// A void function with no return value.
+fn bench_op_void(b: &mut Bencher) {
+  bench_op(b, BENCH_COUNT, "op_void", 0, "op_void()");
+}
+
+/// A function with a numeric return value.
+fn bench_op_u32(b: &mut Bencher) {
+  bench_op(b, BENCH_COUNT, "op_u32", 0, "accum += op_u32();");
+}
+
+/// A function with an optional return value (making it non-fast).
+fn bench_op_option_u32(b: &mut Bencher) {
+  bench_op(
+    b,
+    BENCH_COUNT,
+    "op_option_u32",
+    0,
+    "accum += op_option_u32();",
+  );
+}
+
+/// A string function with a numeric return value.
+fn bench_op_string(b: &mut Bencher) {
+  bench_op(b, BENCH_COUNT, "op_string", 1, "accum += op_string('this is a reasonably long string that we would like to get the length of!');");
+}
+
+/// A string function with a numeric return value.
+fn bench_op_string_large_1000(b: &mut Bencher) {
+  bench_op(
+    b,
+    BENCH_COUNT,
+    "op_string",
+    1,
+    "accum += op_string(LARGE_STRING_1000);",
+  );
+}
+
+/// A string function with a numeric return value.
+fn bench_op_string_large_1000000(b: &mut Bencher) {
+  bench_op(
+    b,
+    LARGE_BENCH_COUNT,
+    "op_string",
+    1,
+    "accum += op_string(LARGE_STRING_1000000);",
+  );
+}
+
+/// A string function with a numeric return value.
+fn bench_op_string_large_utf8_1000(b: &mut Bencher) {
+  bench_op(
+    b,
+    BENCH_COUNT,
+    "op_string",
+    1,
+    "accum += op_string(LARGE_STRING_UTF8_1000);",
+  );
+}
+
+/// A string function with a numeric return value.
+fn bench_op_string_large_utf8_1000000(b: &mut Bencher) {
+  bench_op(
+    b,
+    LARGE_BENCH_COUNT,
+    "op_string",
+    1,
+    "accum += op_string(LARGE_STRING_UTF8_1000000);",
+  );
+}
+
+/// A string function with a numeric return value.
+fn bench_op_string_old(b: &mut Bencher) {
+  bench_op(b, BENCH_COUNT, "op_string_old", 1, "accum += op_string_old('this is a reasonably long string that we would like to get the length of!');");
+}
+
+/// A string function with a numeric return value.
+fn bench_op_string_old_large_1000(b: &mut Bencher) {
+  bench_op(
+    b,
+    BENCH_COUNT,
+    "op_string_old",
+    1,
+    "accum += op_string_old(LARGE_STRING_1000);",
+  );
+}
+
+/// A string function with a numeric return value.
+fn bench_op_string_old_large_1000000(b: &mut Bencher) {
+  bench_op(
+    b,
+    LARGE_BENCH_COUNT,
+    "op_string_old",
+    1,
+    "accum += op_string_old(LARGE_STRING_1000000);",
+  );
+}
+
+/// A string function with a numeric return value.
+fn bench_op_string_old_large_utf8_1000(b: &mut Bencher) {
+  bench_op(
+    b,
+    BENCH_COUNT,
+    "op_string_old",
+    1,
+    "accum += op_string_old(LARGE_STRING_UTF8_1000);",
+  );
+}
+
+/// A string function with a numeric return value.
+fn bench_op_string_old_large_utf8_1000000(b: &mut Bencher) {
+  bench_op(
+    b,
+    LARGE_BENCH_COUNT,
+    "op_string_old",
+    1,
+    "accum += op_string_old(LARGE_STRING_UTF8_1000000);",
+  );
+}
+
+/// A string function with an option numeric return value.
+fn bench_op_string_option_u32(b: &mut Bencher) {
+  bench_op(b, BENCH_COUNT, "op_string_option_u32", 1, "accum += op_string_option_u32('this is a reasonably long string that we would like to get the length of!');");
+}
+
+benchmark_group!(
+  benches,
+  baseline,
+  bench_op_void,
+  bench_op_u32,
+  bench_op_option_u32,
+  bench_op_string,
+  bench_op_string_large_1000,
+  bench_op_string_large_1000000,
+  bench_op_string_large_utf8_1000,
+  bench_op_string_large_utf8_1000000,
+  bench_op_string_old,
+  bench_op_string_old_large_1000,
+  bench_op_string_old_large_1000000,
+  bench_op_string_old_large_utf8_1000,
+  bench_op_string_old_large_utf8_1000000,
+  bench_op_string_option_u32,
+);
+
+benchmark_main!(benches);

--- a/core/benches/ops/sync.rs
+++ b/core/benches/ops/sync.rs
@@ -104,12 +104,13 @@ bench();
     )
     .map_err(err_mapper)
     .unwrap();
-
+  let bench = runtime.execute_script("", ascii_str!("bench")).unwrap();
+  let mut scope = runtime.handle_scope();
+  let bench: v8::Local<v8::Function> =
+    v8::Local::new(&mut scope, bench).try_into().unwrap();
   b.iter(|| {
-    runtime
-      .execute_script("", ascii_str!("bench()"))
-      .map_err(err_mapper)
-      .unwrap();
+    let recv = v8::undefined(&mut scope).try_into().unwrap();
+    bench.call(&mut scope, recv, &[]);
   });
 }
 

--- a/core/benches/ops/sync.rs
+++ b/core/benches/ops/sync.rs
@@ -53,8 +53,15 @@ fn bench_op(
   arg_count: usize,
   call: &str,
 ) {
+  #[cfg(not(feature = "unsafe_runtime_options"))]
+  unreachable!(
+    "This benchmark must be run with --features=unsafe_runtime_options"
+  );
+
   let mut runtime = JsRuntime::new(RuntimeOptions {
     extensions: vec![testing::init_ops_and_esm()],
+    // We need to feature gate this here to prevent IDE errors
+    #[cfg(feature = "unsafe_runtime_options")]
     unsafe_expose_natives_and_gc: true,
     ..Default::default()
   });

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -368,6 +368,7 @@ fn v8_init(
   let predictable_flags = "--predictable --random-seed=42";
   let expose_natives_flags = "--expose_gc --allow_natives_syntax";
 
+  #[allow(clippy::useless_format)]
   let flags = match (predictable, expose_natives) {
     (false, false) => format!("{base_flags}"),
     (true, false) => format!("{base_flags} {predictable_flags}"),

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -19,6 +19,11 @@ use std::option::Option;
 use std::task::Context;
 use std::task::Poll;
 
+/// The default string buffer size on the stack that prevents mallocs in some
+/// string functions. Keep in mind that Windows only offers 1MB stacks by default,
+/// so this is a limited resource!
+pub const STRING_STACK_BUFFER_SIZE: usize = 1024 * 8;
+
 #[inline]
 pub fn queue_fast_async_op<R: serde::Serialize + 'static>(
   ctx: &OpCtx,
@@ -906,6 +911,12 @@ mod tests {
         (3, "'abc'"),
         // Latin-1 (one byte but two UTF-8 chars)
         (2, "'\\u00a0'"),
+        // ASCII
+        (1000, "'a'.repeat(1000)"),
+        // Latin-1
+        (2000, "'\\u00a0'.repeat(1000)"),
+        // 4-byte UTF-8 emoji (1F995 = 🦕)
+        (4000, "'\\u{1F995}'.repeat(1000)"),
         // ASCII
         (10000, "'a'.repeat(10000)"),
         // Latin-1

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -22,7 +22,7 @@ use std::task::Poll;
 /// The default string buffer size on the stack that prevents mallocs in some
 /// string functions. Keep in mind that Windows only offers 1MB stacks by default,
 /// so this is a limited resource!
-pub const STRING_STACK_BUFFER_SIZE: usize = 1024 * 8;
+pub const STRING_STACK_BUFFER_SIZE: usize = 1024;
 
 #[inline]
 pub fn queue_fast_async_op<R: serde::Serialize + 'static>(

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -22,7 +22,7 @@ use std::task::Poll;
 /// The default string buffer size on the stack that prevents mallocs in some
 /// string functions. Keep in mind that Windows only offers 1MB stacks by default,
 /// so this is a limited resource!
-pub const STRING_STACK_BUFFER_SIZE: usize = 1024;
+pub const STRING_STACK_BUFFER_SIZE: usize = 1024 * 8;
 
 #[inline]
 pub fn queue_fast_async_op<R: serde::Serialize + 'static>(

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -336,10 +336,13 @@ pub fn to_str_ptr<'a, const N: usize>(
   buffer: &'a mut [MaybeUninit<u8>; N],
 ) -> Cow<'a, str> {
   let input_buf = string.as_bytes();
+
+  // Per benchmarking results, it's faster to do this check than to copy latin-1 -> utf8
   if input_buf.is_ascii() {
     // SAFETY: We just checked that it was ASCII
     return Cow::Borrowed(unsafe { std::str::from_utf8_unchecked(input_buf) });
   }
+
   let input_len = input_buf.len();
   let output_len = buffer.len();
 

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -358,7 +358,7 @@ fn map_v8_fastcall_arg_to_arg(
     }
     Arg::Special(Special::RefStr) => {
       quote! {
-        let mut #arg_temp: [::std::mem::MaybeUninit<u8>; 1024] = [::std::mem::MaybeUninit::uninit(); 1024];
+        let mut #arg_temp: [::std::mem::MaybeUninit<u8>; #deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); #deno_core::_ops::STRING_STACK_BUFFER_SIZE];
         let #arg_ident = &#deno_core::_ops::to_str_ptr(unsafe { &mut *#arg_ident }, &mut #arg_temp);
       }
     }
@@ -367,7 +367,7 @@ fn map_v8_fastcall_arg_to_arg(
     }
     Arg::Special(Special::CowStr) => {
       quote! {
-        let mut #arg_temp: [::std::mem::MaybeUninit<u8>; 1024] = [::std::mem::MaybeUninit::uninit(); 1024];
+        let mut #arg_temp: [::std::mem::MaybeUninit<u8>; #deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); #deno_core::_ops::STRING_STACK_BUFFER_SIZE];
         let #arg_ident = #deno_core::_ops::to_str_ptr(unsafe { &mut *#arg_ident }, &mut #arg_temp);
       }
     }

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -519,6 +519,20 @@ pub fn return_value_infallible(
         }
       }
     }
+    Arg::OptionNumeric(n) => {
+      *needs_retval = true;
+      *needs_scope = true;
+      // End the generator_state borrow
+      let (result, retval) = (result.clone(), retval.clone());
+      let some = return_value_infallible(generator_state, &Arg::Numeric(*n))?;
+      quote! {
+        if let Some(#result) = #result {
+          #some
+        } else {
+          #retval.set_null();
+        }
+      }
+    }
     Arg::Option(Special::String) => {
       *needs_retval = true;
       *needs_scope = true;

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -272,16 +272,16 @@ pub fn from_arg(
     Arg::Special(Special::RefStr) => {
       *needs_scope = true;
       quote! {
-        // Trade 1024 bytes of stack space for potentially non-allocating strings
-        let mut #arg_temp: [::std::mem::MaybeUninit<u8>; 1024] = [::std::mem::MaybeUninit::uninit(); 1024];
+        // Trade stack space for potentially non-allocating strings
+        let mut #arg_temp: [::std::mem::MaybeUninit<u8>; #deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); #deno_core::_ops::STRING_STACK_BUFFER_SIZE];
         let #arg_ident = &#deno_core::_ops::to_str(&mut #scope, &#arg_ident, &mut #arg_temp);
       }
     }
     Arg::Special(Special::CowStr) => {
       *needs_scope = true;
       quote! {
-        // Trade 1024 bytes of stack space for potentially non-allocating strings
-        let mut #arg_temp: [::std::mem::MaybeUninit<u8>; 1024] = [::std::mem::MaybeUninit::uninit(); 1024];
+        // Trade stack space for potentially non-allocating strings
+        let mut #arg_temp: [::std::mem::MaybeUninit<u8>; #deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); #deno_core::_ops::STRING_STACK_BUFFER_SIZE];
         let #arg_ident = #deno_core::_ops::to_str(&mut #scope, &#arg_ident, &mut #arg_temp);
       }
     }

--- a/ops/op2/test_cases/sync/string_cow.out
+++ b/ops/op2/test_cases/sync/string_cow.out
@@ -34,7 +34,9 @@ impl op_string_cow {
         _: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
     ) -> u32 {
-        let mut arg0_temp: [::std::mem::MaybeUninit<u8>; 1024] = [::std::mem::MaybeUninit::uninit(); 1024];
+        let mut arg0_temp: [::std::mem::MaybeUninit<
+            u8,
+        >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
         let arg0 = deno_core::_ops::to_str_ptr(unsafe { &mut *arg0 }, &mut arg0_temp);
         let result = Self::call(arg0);
         result
@@ -48,7 +50,9 @@ impl op_string_cow {
             &*info
         });
         let arg0 = args.get(0usize as i32);
-        let mut arg0_temp: [::std::mem::MaybeUninit<u8>; 1024] = [::std::mem::MaybeUninit::uninit(); 1024];
+        let mut arg0_temp: [::std::mem::MaybeUninit<
+            u8,
+        >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
         let arg0 = deno_core::_ops::to_str(&mut scope, &arg0, &mut arg0_temp);
         let result = Self::call(arg0);
         rv.set_uint32(result as u32);

--- a/ops/op2/test_cases/sync/string_ref.out
+++ b/ops/op2/test_cases/sync/string_ref.out
@@ -34,7 +34,9 @@ impl op_string_owned {
         _: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
     ) -> u32 {
-        let mut arg0_temp: [::std::mem::MaybeUninit<u8>; 1024] = [::std::mem::MaybeUninit::uninit(); 1024];
+        let mut arg0_temp: [::std::mem::MaybeUninit<
+            u8,
+        >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
         let arg0 = &deno_core::_ops::to_str_ptr(unsafe { &mut *arg0 }, &mut arg0_temp);
         let result = Self::call(arg0);
         result
@@ -48,7 +50,9 @@ impl op_string_owned {
             &*info
         });
         let arg0 = args.get(0usize as i32);
-        let mut arg0_temp: [::std::mem::MaybeUninit<u8>; 1024] = [::std::mem::MaybeUninit::uninit(); 1024];
+        let mut arg0_temp: [::std::mem::MaybeUninit<
+            u8,
+        >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
         let arg0 = &deno_core::_ops::to_str(&mut scope, &arg0, &mut arg0_temp);
         let result = Self::call(arg0);
         rv.set_uint32(result as u32);


### PR DESCRIPTION
Approximately 25% faster strings from `op` -> `op2`.

