### PR TITLE
fix(ops): Terminate scope of args and temporaries in op2 to avoid borrow errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "3c65c2ffdafc1564565200967edc4851c7b55422d3913466688907efd05ea26f"
 dependencies = [
  "deno-proc-macro-rules-macros",
  "proc-macro2",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -248,7 +248,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -342,7 +342,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "syn 1.0.109",
- "syn 2.0.22",
+ "syn 2.0.26",
  "testing_macros",
  "thiserror",
  "v8",
@@ -359,7 +359,7 @@ dependencies = [
  "prettyplease",
  "rustversion",
  "serde",
- "syn 2.0.22",
+ "syn 2.0.26",
  "testing_macros",
  "trybuild",
 ]
@@ -508,7 +508,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -974,7 +974,7 @@ checksum = "d1fef411b303e3e12d534fb6e7852de82da56edd937d895125821fb7c09436c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1008,7 +1008,7 @@ checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1037,12 +1037,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
+checksum = "92139198957b410250d43fad93e630d956499a625c527eda65175c8680f83387"
 dependencies = [
  "proc-macro2",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1251,7 +1251,7 @@ checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1442,7 +1442,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1799,9 +1799,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1831,7 +1831,7 @@ dependencies = [
  "quote",
  "regex",
  "relative-path",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1860,7 +1860,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1906,7 +1906,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -1946,7 +1946,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ url = { version = "2.3.1", features = ["serde", "expose_internals"] }
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }
-syn2 = { package = "syn", version = "=2.0.22", features = ["full", "extra-traits"] }
+syn2 = { package = "syn", version = "2.0", features = ["full", "extra-traits"] }
 # Temporary fork while we wait for a more modern version to be published
 deno-proc-macro-rules = "0.3.2"
 

--- a/ops/Cargo.toml
+++ b/ops/Cargo.toml
@@ -32,5 +32,5 @@ v8.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true
-prettyplease = "0.2.9"
+prettyplease = "0.2.10"
 testing_macros = "0.2.11"

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -275,8 +275,10 @@ pub fn generate_dispatch_fast(
     ) -> #output_type {
       #with_fast_api_callback_options
       #with_opctx
-      #(#call_args)*
-      let #result = Self::call(#(#call_names),*);
+      let #result = {
+        #(#call_args)*
+        Self::call(#(#call_names),*)
+      };
       #handle_error
       #result
     }

--- a/ops/op2/test_cases/async/async_arg_return.out
+++ b/ops/op2/test_cases/async/async_arg_return.out
@@ -34,9 +34,11 @@ impl op_async {
             &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
                 as *const deno_core::_ops::OpCtx)
         };
-        let arg0 = args.get(1usize as i32);
-        let arg0 = deno_core::_ops::to_i32(&arg0) as _;
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = args.get(1usize as i32);
+            let arg0 = deno_core::_ops::to_i32(&arg0) as _;
+            Self::call(arg0)
+        };
         let promise_id = deno_core::_ops::to_i32(&args.get(0));
         if let Some(result)
             = deno_core::_ops::map_async_op_infallible(

--- a/ops/op2/test_cases/async/async_arg_return_result.out
+++ b/ops/op2/test_cases/async/async_arg_return_result.out
@@ -34,9 +34,11 @@ impl op_async {
             &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
                 as *const deno_core::_ops::OpCtx)
         };
-        let arg0 = args.get(1usize as i32);
-        let arg0 = deno_core::_ops::to_i32(&arg0) as _;
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = args.get(1usize as i32);
+            let arg0 = deno_core::_ops::to_i32(&arg0) as _;
+            Self::call(arg0)
+        };
         let promise_id = deno_core::_ops::to_i32(&args.get(0));
         if let Some(result)
             = deno_core::_ops::map_async_op_fallible(

--- a/ops/op2/test_cases/async/async_opstate.out
+++ b/ops/op2/test_cases/async/async_opstate.out
@@ -35,8 +35,10 @@ impl op_async_opstate {
                 as *const deno_core::_ops::OpCtx)
         };
         let opstate = &opctx.state;
-        let arg0 = opstate.clone();
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = opstate.clone();
+            Self::call(arg0)
+        };
         let promise_id = deno_core::_ops::to_i32(&args.get(0));
         if let Some(result)
             = deno_core::_ops::map_async_op_fallible(

--- a/ops/op2/test_cases/async/async_result.out
+++ b/ops/op2/test_cases/async/async_result.out
@@ -34,7 +34,7 @@ impl op_async {
             &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
                 as *const deno_core::_ops::OpCtx)
         };
-        let result = Self::call();
+        let result = { Self::call() };
         let promise_id = deno_core::_ops::to_i32(&args.get(0));
         if let Some(result)
             = deno_core::_ops::map_async_op_fallible(

--- a/ops/op2/test_cases/async/async_result_impl.out
+++ b/ops/op2/test_cases/async/async_result_impl.out
@@ -34,9 +34,11 @@ impl op_async_result_impl {
             &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
                 as *const deno_core::_ops::OpCtx)
         };
-        let arg0 = args.get(1usize as i32);
-        let arg0 = deno_core::_ops::to_i32(&arg0) as _;
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = args.get(1usize as i32);
+            let arg0 = deno_core::_ops::to_i32(&arg0) as _;
+            Self::call(arg0)
+        };
         let result = match result {
             Ok(result) => result,
             Err(err) => {

--- a/ops/op2/test_cases/async/async_void.out
+++ b/ops/op2/test_cases/async/async_void.out
@@ -34,7 +34,7 @@ impl op_async {
             &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
                 as *const deno_core::_ops::OpCtx)
         };
-        let result = Self::call();
+        let result = { Self::call() };
         let promise_id = deno_core::_ops::to_i32(&args.get(0));
         if let Some(result)
             = deno_core::_ops::map_async_op_infallible(

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -35,9 +35,11 @@ impl op_add {
         arg0: u32,
         arg1: u32,
     ) -> u32 {
-        let arg0 = arg0 as _;
-        let arg1 = arg1 as _;
-        let result = Self::call(arg0, arg1);
+        let result = {
+            let arg0 = arg0 as _;
+            let arg1 = arg1 as _;
+            Self::call(arg0, arg1)
+        };
         result
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
@@ -47,11 +49,13 @@ impl op_add {
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
-        let arg0 = args.get(0usize as i32);
-        let arg0 = deno_core::_ops::to_u32(&arg0) as _;
-        let arg1 = args.get(1usize as i32);
-        let arg1 = deno_core::_ops::to_u32(&arg1) as _;
-        let result = Self::call(arg0, arg1);
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let arg0 = deno_core::_ops::to_u32(&arg0) as _;
+            let arg1 = args.get(1usize as i32);
+            let arg1 = deno_core::_ops::to_u32(&arg1) as _;
+            Self::call(arg0, arg1)
+        };
         rv.set_uint32(result as u32);
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/add_options.out
+++ b/ops/op2/test_cases/sync/add_options.out
@@ -29,16 +29,18 @@ impl op_test_add_option {
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
-        let arg0 = args.get(0usize as i32);
-        let arg0 = deno_core::_ops::to_u32(&arg0) as _;
-        let arg1 = args.get(1usize as i32);
-        let arg1 = if arg1.is_null_or_undefined() {
-            None
-        } else {
-            let arg1 = deno_core::_ops::to_u32(&arg1) as _;
-            Some(arg1)
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let arg0 = deno_core::_ops::to_u32(&arg0) as _;
+            let arg1 = args.get(1usize as i32);
+            let arg1 = if arg1.is_null_or_undefined() {
+                None
+            } else {
+                let arg1 = deno_core::_ops::to_u32(&arg1) as _;
+                Some(arg1)
+            };
+            Self::call(arg0, arg1)
         };
-        let result = Self::call(arg0, arg1);
         rv.set_uint32(result as u32);
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/bool.out
+++ b/ops/op2/test_cases/sync/bool.out
@@ -34,8 +34,10 @@ impl op_bool {
         _: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: bool,
     ) -> bool {
-        let arg0 = arg0 as _;
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = arg0 as _;
+            Self::call(arg0)
+        };
         result
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
@@ -45,9 +47,11 @@ impl op_bool {
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
-        let arg0 = args.get(0usize as i32);
-        let arg0 = arg0.is_true();
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let arg0 = arg0.is_true();
+            Self::call(arg0)
+        };
         rv.set_bool(result as bool);
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -42,8 +42,10 @@ impl op_bool {
             >::cast(unsafe { fast_api_callback_options.data.data })
                 .value() as *const deno_core::_ops::OpCtx)
         };
-        let arg0 = arg0 as _;
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = arg0 as _;
+            Self::call(arg0)
+        };
         let result = match result {
             Ok(result) => result,
             Err(err) => {
@@ -79,9 +81,11 @@ impl op_bool {
             scope.throw_exception(exception);
             return;
         }
-        let arg0 = args.get(0usize as i32);
-        let arg0 = arg0.is_true();
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let arg0 = arg0.is_true();
+            Self::call(arg0)
+        };
         match result {
             Ok(result) => {
                 rv.set_bool(result as bool);

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -39,9 +39,15 @@ impl op_buffers {
         arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
         arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
     ) -> () {
-        let arg0 = unsafe { arg0.as_mut().unwrap() }.get_storage_if_aligned().unwrap();
-        let arg1 = unsafe { arg1.as_mut().unwrap() }.get_storage_if_aligned().unwrap();
-        let result = Self::call(arg0, arg1);
+        let result = {
+            let arg0 = unsafe { arg0.as_mut().unwrap() }
+                .get_storage_if_aligned()
+                .unwrap();
+            let arg1 = unsafe { arg1.as_mut().unwrap() }
+                .get_storage_if_aligned()
+                .unwrap();
+            Self::call(arg0, arg1)
+        };
         result
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
@@ -52,44 +58,50 @@ impl op_buffers {
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
-        let arg0 = args.get(0usize as i32);
-        let mut arg0 = match unsafe {
-            deno_core::_ops::to_v8_slice::<deno_core::v8::Uint8Array>(&mut scope, arg0)
-        } {
-            Ok(arg0) => arg0,
-            Err(arg0_err) => {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        arg0_err.as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return;
-            }
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let mut arg0 = match unsafe {
+                deno_core::_ops::to_v8_slice::<
+                    deno_core::v8::Uint8Array,
+                >(&mut scope, arg0)
+            } {
+                Ok(arg0) => arg0,
+                Err(arg0_err) => {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            arg0_err.as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return;
+                }
+            };
+            let arg0 = &mut arg0;
+            let arg1 = args.get(1usize as i32);
+            let mut arg1 = match unsafe {
+                deno_core::_ops::to_v8_slice::<
+                    deno_core::v8::Uint8Array,
+                >(&mut scope, arg1)
+            } {
+                Ok(arg1) => arg1,
+                Err(arg1_err) => {
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            arg1_err.as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return;
+                }
+            };
+            let arg1 = &mut arg1;
+            Self::call(arg0, arg1)
         };
-        let arg0 = &mut arg0;
-        let arg1 = args.get(1usize as i32);
-        let mut arg1 = match unsafe {
-            deno_core::_ops::to_v8_slice::<deno_core::v8::Uint8Array>(&mut scope, arg1)
-        } {
-            Ok(arg1) => arg1,
-            Err(arg1_err) => {
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        arg1_err.as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return;
-            }
-        };
-        let arg1 = &mut arg1;
-        let result = Self::call(arg0, arg1);
         rv.set_null();
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -41,21 +41,23 @@ impl op_buffers {
         arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
         arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
     ) -> () {
-        let arg0 = unsafe { arg0.as_mut().unwrap() }
-            .get_storage_if_aligned()
-            .unwrap()
-            .to_vec();
-        let arg1 = unsafe { arg1.as_mut().unwrap() }
-            .get_storage_if_aligned()
-            .unwrap()
-            .to_vec()
-            .into_boxed_slice();
-        let arg2 = unsafe { arg2.as_mut().unwrap() }
-            .get_storage_if_aligned()
-            .unwrap()
-            .to_vec()
-            .into();
-        let result = Self::call(arg0, arg1, arg2);
+        let result = {
+            let arg0 = unsafe { arg0.as_mut().unwrap() }
+                .get_storage_if_aligned()
+                .unwrap()
+                .to_vec();
+            let arg1 = unsafe { arg1.as_mut().unwrap() }
+                .get_storage_if_aligned()
+                .unwrap()
+                .to_vec()
+                .into_boxed_slice();
+            let arg2 = unsafe { arg2.as_mut().unwrap() }
+                .get_storage_if_aligned()
+                .unwrap()
+                .to_vec()
+                .into();
+            Self::call(arg0, arg1, arg2)
+        };
         result
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
@@ -66,62 +68,70 @@ impl op_buffers {
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
-        let arg0 = args.get(0usize as i32);
-        let mut arg0 = match unsafe {
-            deno_core::_ops::to_v8_slice::<deno_core::v8::Uint8Array>(&mut scope, arg0)
-        } {
-            Ok(arg0) => arg0,
-            Err(arg0_err) => {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        arg0_err.as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return;
-            }
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let mut arg0 = match unsafe {
+                deno_core::_ops::to_v8_slice::<
+                    deno_core::v8::Uint8Array,
+                >(&mut scope, arg0)
+            } {
+                Ok(arg0) => arg0,
+                Err(arg0_err) => {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            arg0_err.as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return;
+                }
+            };
+            let arg0 = arg0.to_vec();
+            let arg1 = args.get(1usize as i32);
+            let mut arg1 = match unsafe {
+                deno_core::_ops::to_v8_slice::<
+                    deno_core::v8::Uint8Array,
+                >(&mut scope, arg1)
+            } {
+                Ok(arg1) => arg1,
+                Err(arg1_err) => {
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            arg1_err.as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return;
+                }
+            };
+            let arg1 = arg1.to_boxed_slice();
+            let arg2 = args.get(2usize as i32);
+            let mut arg2 = match unsafe {
+                deno_core::_ops::to_v8_slice::<
+                    deno_core::v8::Uint8Array,
+                >(&mut scope, arg2)
+            } {
+                Ok(arg2) => arg2,
+                Err(arg2_err) => {
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            arg2_err.as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return;
+                }
+            };
+            let arg2 = arg2.to_vec().into();
+            Self::call(arg0, arg1, arg2)
         };
-        let arg0 = arg0.to_vec();
-        let arg1 = args.get(1usize as i32);
-        let mut arg1 = match unsafe {
-            deno_core::_ops::to_v8_slice::<deno_core::v8::Uint8Array>(&mut scope, arg1)
-        } {
-            Ok(arg1) => arg1,
-            Err(arg1_err) => {
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        arg1_err.as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return;
-            }
-        };
-        let arg1 = arg1.to_boxed_slice();
-        let arg2 = args.get(2usize as i32);
-        let mut arg2 = match unsafe {
-            deno_core::_ops::to_v8_slice::<deno_core::v8::Uint8Array>(&mut scope, arg2)
-        } {
-            Ok(arg2) => arg2,
-            Err(arg2_err) => {
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        arg2_err.as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return;
-            }
-        };
-        let arg2 = arg2.to_vec().into();
-        let result = Self::call(arg0, arg1, arg2);
         rv.set_null();
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/clippy_allow.out
+++ b/ops/op2/test_cases/sync/clippy_allow.out
@@ -33,14 +33,14 @@ impl op_extra_annotation {
         <Self as deno_core::_ops::Op>::DECL
     }
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
-        let result = Self::call();
+        let result = { Self::call() };
         result
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let result = Self::call();
+        let result = { Self::call() };
         rv.set_null();
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/doc_comment.out
+++ b/ops/op2/test_cases/sync/doc_comment.out
@@ -32,14 +32,14 @@ impl op_has_doc_comment {
         <Self as deno_core::_ops::Op>::DECL
     }
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
-        let result = Self::call();
+        let result = { Self::call() };
         result
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let result = Self::call();
+        let result = { Self::call() };
         rv.set_null();
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -31,14 +31,14 @@ impl<T: Trait> op_generics<T> {
         <Self as deno_core::_ops::Op>::DECL
     }
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
-        let result = Self::call();
+        let result = { Self::call() };
         result
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let result = Self::call();
+        let result = { Self::call() };
         rv.set_null();
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/nofast.out
+++ b/ops/op2/test_cases/sync/nofast.out
@@ -29,11 +29,13 @@ impl op_nofast {
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
-        let arg0 = args.get(0usize as i32);
-        let arg0 = deno_core::_ops::to_u32(&arg0) as _;
-        let arg1 = args.get(1usize as i32);
-        let arg1 = deno_core::_ops::to_u32(&arg1) as _;
-        let result = Self::call(arg0, arg1);
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let arg0 = deno_core::_ops::to_u32(&arg0) as _;
+            let arg1 = args.get(1usize as i32);
+            let arg1 = deno_core::_ops::to_u32(&arg1) as _;
+            Self::call(arg0, arg1)
+        };
         rv.set_uint32(result as u32);
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/op_state_attr.out
+++ b/ops/op2/test_cases/sync/op_state_attr.out
@@ -41,11 +41,13 @@ impl op_state_rc {
             >::cast(unsafe { fast_api_callback_options.data.data })
                 .value() as *const deno_core::_ops::OpCtx)
         };
-        let arg0 = opctx.state.borrow();
-        let arg0 = arg0.borrow::<Something>();
-        let arg1 = opctx.state.borrow();
-        let arg1 = arg1.try_borrow::<Something>();
-        let result = Self::call(arg0, arg1);
+        let result = {
+            let arg0 = opctx.state.borrow();
+            let arg0 = arg0.borrow::<Something>();
+            let arg1 = opctx.state.borrow();
+            let arg1 = arg1.try_borrow::<Something>();
+            Self::call(arg0, arg1)
+        };
         result
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
@@ -60,11 +62,13 @@ impl op_state_rc {
                 as *const deno_core::_ops::OpCtx)
         };
         let opstate = &opctx.state;
-        let arg0 = opstate.borrow();
-        let arg0 = arg0.borrow::<Something>();
-        let arg1 = opstate.borrow();
-        let arg1 = arg1.try_borrow::<Something>();
-        let result = Self::call(arg0, arg1);
+        let result = {
+            let arg0 = opstate.borrow();
+            let arg0 = arg0.borrow::<Something>();
+            let arg1 = opstate.borrow();
+            let arg1 = arg1.try_borrow::<Something>();
+            Self::call(arg0, arg1)
+        };
         rv.set_null();
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/op_state_rc.out
+++ b/ops/op2/test_cases/sync/op_state_rc.out
@@ -41,8 +41,10 @@ impl op_state_rc {
             >::cast(unsafe { fast_api_callback_options.data.data })
                 .value() as *const deno_core::_ops::OpCtx)
         };
-        let arg0 = opctx.state.clone();
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = opctx.state.clone();
+            Self::call(arg0)
+        };
         result
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
@@ -57,8 +59,10 @@ impl op_state_rc {
                 as *const deno_core::_ops::OpCtx)
         };
         let opstate = &opctx.state;
-        let arg0 = opstate.clone();
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = opstate.clone();
+            Self::call(arg0)
+        };
         rv.set_null();
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -41,8 +41,10 @@ impl op_state_rc {
             >::cast(unsafe { fast_api_callback_options.data.data })
                 .value() as *const deno_core::_ops::OpCtx)
         };
-        let arg0 = &opctx.state.borrow();
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = &opctx.state.borrow();
+            Self::call(arg0)
+        };
         result
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
@@ -57,8 +59,10 @@ impl op_state_rc {
                 as *const deno_core::_ops::OpCtx)
         };
         let opstate = &opctx.state;
-        let arg0 = &opstate.borrow();
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = &opstate.borrow();
+            Self::call(arg0)
+        };
         rv.set_null();
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -41,7 +41,7 @@ impl op_u32_with_result {
             >::cast(unsafe { fast_api_callback_options.data.data })
                 .value() as *const deno_core::_ops::OpCtx)
         };
-        let result = Self::call();
+        let result = { Self::call() };
         let result = match result {
             Ok(result) => result,
             Err(err) => {
@@ -80,7 +80,7 @@ impl op_u32_with_result {
             scope.throw_exception(exception);
             return;
         }
-        let result = Self::call();
+        let result = { Self::call() };
         match result {
             Ok(result) => {
                 rv.set_uint32(result as u32);

--- a/ops/op2/test_cases/sync/result_scope.out
+++ b/ops/op2/test_cases/sync/result_scope.out
@@ -30,8 +30,10 @@ impl op_void_with_result {
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
-        let arg0 = &mut scope;
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = &mut scope;
+            Self::call(arg0)
+        };
         match result {
             Ok(result) => {
                 rv.set_null();

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -41,7 +41,7 @@ impl op_void_with_result {
             >::cast(unsafe { fast_api_callback_options.data.data })
                 .value() as *const deno_core::_ops::OpCtx)
         };
-        let result = Self::call();
+        let result = { Self::call() };
         let result = match result {
             Ok(result) => result,
             Err(err) => {
@@ -80,7 +80,7 @@ impl op_void_with_result {
             scope.throw_exception(exception);
             return;
         }
-        let result = Self::call();
+        let result = { Self::call() };
         match result {
             Ok(result) => {
                 rv.set_null();

--- a/ops/op2/test_cases/sync/serde_v8.out
+++ b/ops/op2/test_cases/sync/serde_v8.out
@@ -30,21 +30,23 @@ impl op_serde_v8 {
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
-        let arg0 = args.get(0usize as i32);
-        let arg0 = match deno_core::_ops::serde_v8_to_rust(&mut scope, arg0) {
-            Ok(t) => t,
-            Err(arg0_err) => {
-                let msg = deno_core::v8::String::new(
-                        &mut scope,
-                        &format!("{}", deno_core::anyhow::Error::from(arg0_err)),
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return;
-            }
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let arg0 = match deno_core::_ops::serde_v8_to_rust(&mut scope, arg0) {
+                Ok(t) => t,
+                Err(arg0_err) => {
+                    let msg = deno_core::v8::String::new(
+                            &mut scope,
+                            &format!("{}", deno_core::anyhow::Error::from(arg0_err)),
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return;
+                }
+            };
+            Self::call(arg0)
         };
-        let result = Self::call(arg0);
         let result = match deno_core::_ops::serde_rust_to_v8(&mut scope, result) {
             Ok(t) => t,
             Err(rv_err) => {

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -35,9 +35,11 @@ impl op_add {
         arg0: i32,
         arg1: u32,
     ) -> u32 {
-        let arg0 = arg0 as _;
-        let arg1 = arg1 as _;
-        let result = Self::call(arg0, arg1);
+        let result = {
+            let arg0 = arg0 as _;
+            let arg1 = arg1 as _;
+            Self::call(arg0, arg1)
+        };
         result
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
@@ -47,11 +49,13 @@ impl op_add {
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
-        let arg0 = args.get(0usize as i32);
-        let arg0 = deno_core::_ops::to_i32(&arg0) as _;
-        let arg1 = args.get(1usize as i32);
-        let arg1 = deno_core::_ops::to_u32(&arg1) as _;
-        let result = Self::call(arg0, arg1);
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let arg0 = deno_core::_ops::to_i32(&arg0) as _;
+            let arg1 = args.get(1usize as i32);
+            let arg1 = deno_core::_ops::to_u32(&arg1) as _;
+            Self::call(arg0, arg1)
+        };
         rv.set_uint32(result as u32);
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/string_cow.out
+++ b/ops/op2/test_cases/sync/string_cow.out
@@ -34,11 +34,16 @@ impl op_string_cow {
         _: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
     ) -> u32 {
-        let mut arg0_temp: [::std::mem::MaybeUninit<
-            u8,
-        >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
-        let arg0 = deno_core::_ops::to_str_ptr(unsafe { &mut *arg0 }, &mut arg0_temp);
-        let result = Self::call(arg0);
+        let result = {
+            let mut arg0_temp: [::std::mem::MaybeUninit<
+                u8,
+            >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
+            let arg0 = deno_core::_ops::to_str_ptr(
+                unsafe { &mut *arg0 },
+                &mut arg0_temp,
+            );
+            Self::call(arg0)
+        };
         result
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
@@ -53,12 +58,14 @@ impl op_string_cow {
                 as *const deno_core::_ops::OpCtx)
         };
         let mut scope = unsafe { &mut *opctx.isolate };
-        let arg0 = args.get(0usize as i32);
-        let mut arg0_temp: [::std::mem::MaybeUninit<
-            u8,
-        >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
-        let arg0 = deno_core::_ops::to_str(&mut scope, &arg0, &mut arg0_temp);
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let mut arg0_temp: [::std::mem::MaybeUninit<
+                u8,
+            >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
+            let arg0 = deno_core::_ops::to_str(&mut scope, &arg0, &mut arg0_temp);
+            Self::call(arg0)
+        };
         rv.set_uint32(result as u32);
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/string_option_return.out
+++ b/ops/op2/test_cases/sync/string_option_return.out
@@ -30,13 +30,15 @@ impl op_string_return {
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
-        let arg0 = args.get(0usize as i32);
-        let arg0 = if arg0.is_null_or_undefined() {
-            None
-        } else {
-            Some(deno_core::_ops::to_string(&mut scope, &arg0))
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let arg0 = if arg0.is_null_or_undefined() {
+                None
+            } else {
+                Some(deno_core::_ops::to_string(&mut scope, &arg0))
+            };
+            Self::call(arg0)
         };
-        let result = Self::call(arg0);
         if let Some(result) = result {
             if result.is_empty() {
                 rv.set_empty_string();

--- a/ops/op2/test_cases/sync/string_owned.out
+++ b/ops/op2/test_cases/sync/string_owned.out
@@ -34,8 +34,10 @@ impl op_string_owned {
         _: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
     ) -> u32 {
-        let arg0 = deno_core::_ops::to_string_ptr(unsafe { &mut *arg0 });
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = deno_core::_ops::to_string_ptr(unsafe { &mut *arg0 });
+            Self::call(arg0)
+        };
         result
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
@@ -50,9 +52,11 @@ impl op_string_owned {
                 as *const deno_core::_ops::OpCtx)
         };
         let mut scope = unsafe { &mut *opctx.isolate };
-        let arg0 = args.get(0usize as i32);
-        let arg0 = deno_core::_ops::to_string(&mut scope, &arg0);
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let arg0 = deno_core::_ops::to_string(&mut scope, &arg0);
+            Self::call(arg0)
+        };
         rv.set_uint32(result as u32);
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/string_ref.out
+++ b/ops/op2/test_cases/sync/string_ref.out
@@ -34,11 +34,16 @@ impl op_string_owned {
         _: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
     ) -> u32 {
-        let mut arg0_temp: [::std::mem::MaybeUninit<
-            u8,
-        >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
-        let arg0 = &deno_core::_ops::to_str_ptr(unsafe { &mut *arg0 }, &mut arg0_temp);
-        let result = Self::call(arg0);
+        let result = {
+            let mut arg0_temp: [::std::mem::MaybeUninit<
+                u8,
+            >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
+            let arg0 = &deno_core::_ops::to_str_ptr(
+                unsafe { &mut *arg0 },
+                &mut arg0_temp,
+            );
+            Self::call(arg0)
+        };
         result
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
@@ -53,12 +58,14 @@ impl op_string_owned {
                 as *const deno_core::_ops::OpCtx)
         };
         let mut scope = unsafe { &mut *opctx.isolate };
-        let arg0 = args.get(0usize as i32);
-        let mut arg0_temp: [::std::mem::MaybeUninit<
-            u8,
-        >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
-        let arg0 = &deno_core::_ops::to_str(&mut scope, &arg0, &mut arg0_temp);
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let mut arg0_temp: [::std::mem::MaybeUninit<
+                u8,
+            >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
+            let arg0 = &deno_core::_ops::to_str(&mut scope, &arg0, &mut arg0_temp);
+            Self::call(arg0)
+        };
         rv.set_uint32(result as u32);
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/string_return.out
+++ b/ops/op2/test_cases/sync/string_return.out
@@ -27,7 +27,7 @@ impl op_string_return {
         let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let result = Self::call();
+        let result = { Self::call() };
         if result.is_empty() {
             rv.set_empty_string();
         } else {

--- a/ops/op2/test_cases/sync/v8_global.out
+++ b/ops/op2/test_cases/sync/v8_global.out
@@ -34,23 +34,25 @@ impl op_global {
                 as *const deno_core::_ops::OpCtx)
         };
         let mut scope = unsafe { &mut *opctx.isolate };
-        let arg0 = args.get(0usize as i32);
-        let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
-            deno_core::v8::String,
-        >(arg0) else {
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let msg = deno_core::v8::String::new_from_one_byte(
-                &mut scope,
-                "expected String".as_bytes(),
-                deno_core::v8::NewStringType::Normal,
-            )
-            .unwrap();
-        let exc = deno_core::v8::Exception::error(&mut scope, msg);
-        scope.throw_exception(exc);
-        return;
-    };
-        let arg0 = deno_core::v8::Global::new(&mut scope, arg0);
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
+                deno_core::v8::String,
+            >(arg0) else {
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let msg = deno_core::v8::String::new_from_one_byte(
+                    &mut scope,
+                    "expected String".as_bytes(),
+                    deno_core::v8::NewStringType::Normal,
+                )
+                .unwrap();
+            let exc = deno_core::v8::Exception::error(&mut scope, msg);
+            scope.throw_exception(exc);
+            return;
+        };
+            let arg0 = deno_core::v8::Global::new(&mut scope, arg0);
+            Self::call(arg0)
+        };
         rv.set_null();
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/v8_handlescope.out
+++ b/ops/op2/test_cases/sync/v8_handlescope.out
@@ -30,23 +30,25 @@ impl op_handlescope {
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
-        let arg1 = args.get(0usize as i32);
-        let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
-            deno_core::v8::String,
-        >(arg1) else {
-        let msg = deno_core::v8::String::new_from_one_byte(
-                &mut scope,
-                "expected String".as_bytes(),
-                deno_core::v8::NewStringType::Normal,
-            )
-            .unwrap();
-        let exc = deno_core::v8::Exception::error(&mut scope, msg);
-        scope.throw_exception(exc);
-        return;
-    };
-        let arg1 = arg1;
-        let arg0 = &mut scope;
-        let result = Self::call(arg0, arg1);
+        let result = {
+            let arg1 = args.get(0usize as i32);
+            let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
+                deno_core::v8::String,
+            >(arg1) else {
+            let msg = deno_core::v8::String::new_from_one_byte(
+                    &mut scope,
+                    "expected String".as_bytes(),
+                    deno_core::v8::NewStringType::Normal,
+                )
+                .unwrap();
+            let exc = deno_core::v8::Exception::error(&mut scope, msg);
+            scope.throw_exception(exc);
+            return;
+        };
+            let arg1 = arg1;
+            let arg0 = &mut scope;
+            Self::call(arg0, arg1)
+        };
         rv.set(result.into())
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/v8_lifetime.out
+++ b/ops/op2/test_cases/sync/v8_lifetime.out
@@ -29,23 +29,25 @@ impl op_v8_lifetime {
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
-        let arg0 = args.get(0usize as i32);
-        let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
-            deno_core::v8::String,
-        >(arg0) else {
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let msg = deno_core::v8::String::new_from_one_byte(
-                &mut scope,
-                "expected String".as_bytes(),
-                deno_core::v8::NewStringType::Normal,
-            )
-            .unwrap();
-        let exc = deno_core::v8::Exception::error(&mut scope, msg);
-        scope.throw_exception(exc);
-        return;
-    };
-        let arg0 = arg0;
-        let result = Self::call(arg0);
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
+                deno_core::v8::String,
+            >(arg0) else {
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let msg = deno_core::v8::String::new_from_one_byte(
+                    &mut scope,
+                    "expected String".as_bytes(),
+                    deno_core::v8::NewStringType::Normal,
+                )
+                .unwrap();
+            let exc = deno_core::v8::Exception::error(&mut scope, msg);
+            scope.throw_exception(exc);
+            return;
+        };
+            let arg0 = arg0;
+            Self::call(arg0)
+        };
         rv.set(result.into())
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -37,25 +37,27 @@ impl op_v8_lifetime {
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let Ok(mut arg0) = deno_core::_ops::v8_try_convert_option::<
-            deno_core::v8::String,
-        >(arg0) else { fast_api_callback_options.fallback = true;
-        return ::std::default::Default::default();
-    };
-        let arg0 = match &arg0 {
-            None => None,
-            Some(v) => Some(::std::ops::Deref::deref(v)),
+        let result = {
+            let Ok(mut arg0) = deno_core::_ops::v8_try_convert_option::<
+                deno_core::v8::String,
+            >(arg0) else { fast_api_callback_options.fallback = true;
+            return ::std::default::Default::default();
         };
-        let Ok(mut arg1) = deno_core::_ops::v8_try_convert_option::<
-            deno_core::v8::String,
-        >(arg1) else { fast_api_callback_options.fallback = true;
-        return ::std::default::Default::default();
-    };
-        let arg1 = match &arg1 {
-            None => None,
-            Some(v) => Some(::std::ops::Deref::deref(v)),
+            let arg0 = match &arg0 {
+                None => None,
+                Some(v) => Some(::std::ops::Deref::deref(v)),
+            };
+            let Ok(mut arg1) = deno_core::_ops::v8_try_convert_option::<
+                deno_core::v8::String,
+            >(arg1) else { fast_api_callback_options.fallback = true;
+            return ::std::default::Default::default();
         };
-        let result = Self::call(arg0, arg1);
+            let arg1 = match &arg1 {
+                None => None,
+                Some(v) => Some(::std::ops::Deref::deref(v)),
+            };
+            Self::call(arg0, arg1)
+        };
         result
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
@@ -65,45 +67,47 @@ impl op_v8_lifetime {
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
-        let arg0 = args.get(0usize as i32);
-        let Ok(mut arg0) = deno_core::_ops::v8_try_convert_option::<
-            deno_core::v8::String,
-        >(arg0) else {
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let msg = deno_core::v8::String::new_from_one_byte(
-                &mut scope,
-                "expected String".as_bytes(),
-                deno_core::v8::NewStringType::Normal,
-            )
-            .unwrap();
-        let exc = deno_core::v8::Exception::error(&mut scope, msg);
-        scope.throw_exception(exc);
-        return;
-    };
-        let arg0 = match &arg0 {
-            None => None,
-            Some(v) => Some(::std::ops::Deref::deref(v)),
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let Ok(mut arg0) = deno_core::_ops::v8_try_convert_option::<
+                deno_core::v8::String,
+            >(arg0) else {
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let msg = deno_core::v8::String::new_from_one_byte(
+                    &mut scope,
+                    "expected String".as_bytes(),
+                    deno_core::v8::NewStringType::Normal,
+                )
+                .unwrap();
+            let exc = deno_core::v8::Exception::error(&mut scope, msg);
+            scope.throw_exception(exc);
+            return;
         };
-        let arg1 = args.get(1usize as i32);
-        let Ok(mut arg1) = deno_core::_ops::v8_try_convert_option::<
-            deno_core::v8::String,
-        >(arg1) else {
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let msg = deno_core::v8::String::new_from_one_byte(
-                &mut scope,
-                "expected String".as_bytes(),
-                deno_core::v8::NewStringType::Normal,
-            )
-            .unwrap();
-        let exc = deno_core::v8::Exception::error(&mut scope, msg);
-        scope.throw_exception(exc);
-        return;
-    };
-        let arg1 = match &arg1 {
-            None => None,
-            Some(v) => Some(::std::ops::Deref::deref(v)),
+            let arg0 = match &arg0 {
+                None => None,
+                Some(v) => Some(::std::ops::Deref::deref(v)),
+            };
+            let arg1 = args.get(1usize as i32);
+            let Ok(mut arg1) = deno_core::_ops::v8_try_convert_option::<
+                deno_core::v8::String,
+            >(arg1) else {
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let msg = deno_core::v8::String::new_from_one_byte(
+                    &mut scope,
+                    "expected String".as_bytes(),
+                    deno_core::v8::NewStringType::Normal,
+                )
+                .unwrap();
+            let exc = deno_core::v8::Exception::error(&mut scope, msg);
+            scope.throw_exception(exc);
+            return;
         };
-        let result = Self::call(arg0, arg1);
+            let arg1 = match &arg1 {
+                None => None,
+                Some(v) => Some(::std::ops::Deref::deref(v)),
+            };
+            Self::call(arg0, arg1)
+        };
         rv.set_null();
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/v8_string.out
+++ b/ops/op2/test_cases/sync/v8_string.out
@@ -29,39 +29,41 @@ impl op_v8_string {
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
-        let arg0 = args.get(0usize as i32);
-        let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
-            deno_core::v8::String,
-        >(arg0) else {
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let msg = deno_core::v8::String::new_from_one_byte(
-                &mut scope,
-                "expected String".as_bytes(),
-                deno_core::v8::NewStringType::Normal,
-            )
-            .unwrap();
-        let exc = deno_core::v8::Exception::error(&mut scope, msg);
-        scope.throw_exception(exc);
-        return;
-    };
-        let arg0 = &arg0;
-        let arg1 = args.get(1usize as i32);
-        let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
-            deno_core::v8::String,
-        >(arg1) else {
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let msg = deno_core::v8::String::new_from_one_byte(
-                &mut scope,
-                "expected String".as_bytes(),
-                deno_core::v8::NewStringType::Normal,
-            )
-            .unwrap();
-        let exc = deno_core::v8::Exception::error(&mut scope, msg);
-        scope.throw_exception(exc);
-        return;
-    };
-        let arg1 = arg1;
-        let result = Self::call(arg0, arg1);
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
+                deno_core::v8::String,
+            >(arg0) else {
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let msg = deno_core::v8::String::new_from_one_byte(
+                    &mut scope,
+                    "expected String".as_bytes(),
+                    deno_core::v8::NewStringType::Normal,
+                )
+                .unwrap();
+            let exc = deno_core::v8::Exception::error(&mut scope, msg);
+            scope.throw_exception(exc);
+            return;
+        };
+            let arg0 = &arg0;
+            let arg1 = args.get(1usize as i32);
+            let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
+                deno_core::v8::String,
+            >(arg1) else {
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let msg = deno_core::v8::String::new_from_one_byte(
+                    &mut scope,
+                    "expected String".as_bytes(),
+                    deno_core::v8::NewStringType::Normal,
+                )
+                .unwrap();
+            let exc = deno_core::v8::Exception::error(&mut scope, msg);
+            scope.throw_exception(exc);
+            return;
+        };
+            let arg1 = arg1;
+            Self::call(arg0, arg1)
+        };
         rv.set(result.into())
     }
     #[inline(always)]


### PR DESCRIPTION
Instead of:

```rust
let arg0 = ...;
let arg1 = ...;
let result = Self::call(...);
```

We now do:

```rust
let result = {
  let arg0 = ...;
  let arg1 = ...;
  Self::call(...)
}
```

This ensures that the scope of all args and temporaries ends after the call to `Self::call`.