### PR TITLE
chore: release v0.196.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.195.0"
+version = "0.196.0"
 dependencies = [
  "anyhow",
  "bencher",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.73.0"
+version = "0.74.0"
 dependencies = [
  "deno-proc-macro-rules",
  "lazy-regex",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.106.0"
+version = "0.107.0"
 dependencies = [
  "bencher",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ repository = "https://github.com/denoland/deno"
 v8 = { version = "0.74.2", default-features = false }
 deno_ast = { version = "0.27.0", features = ["transpiling"] }
 
-deno_core = { version = "0.195.0", path = "./core" }
-deno_ops = { version = "0.73.0", path = "./ops" }
-serde_v8 = { version = "0.106.0", path = "./serde_v8" }
+deno_core = { version = "0.196.0", path = "./core" }
+deno_ops = { version = "0.74.0", path = "./ops" }
+serde_v8 = { version = "0.107.0", path = "./serde_v8" }
 
 anyhow = "1.0.57"
 bencher = "0.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_core"
-version = "0.195.0"
+version = "0.196.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/ops/Cargo.toml
+++ b/ops/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "deno_ops"
-version = "0.73.0"
+version = "0.74.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/serde_v8/Cargo.toml
+++ b/serde_v8/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "serde_v8"
-version = "0.106.0"
+version = "0.107.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Sadly the release script is still not working correctly:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.        
remote: error: 4 of 4 required status checks are expected.        
To https://github.com/denoland/deno_core
 ! [remote rejected] HEAD -> main (protected branch hook declined)
error: failed to push some refs to 'https://github.com/denoland/deno_core'
error: Uncaught (in promise) Error: Exited with code: 1
          throw new Error(`Exited with code: ${code}`);
                ^
    at CommandChild.pipedStdoutBuffer (https://deno.land/x/dax@0.30.0/src/command.ts:585:17)
    at eventLoopTick (ext:core/01_core.js:183:11)
```