### PR TITLE
fix(realms): Call the right realm's format exception callback for promise rejections

### DIFF
--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -208,12 +208,13 @@ impl JsRealmInner {
 
   pub(crate) fn check_promise_rejections(
     &self,
-    scope: &mut v8::HandleScope,
+    isolate: &mut v8::Isolate,
   ) -> Result<(), Error> {
     let Some((_, handle)) = self.context_state.borrow_mut().pending_promise_rejections.pop_front() else {
       return Ok(());
     };
 
+    let scope = &mut self.handle_scope(isolate);
     let exception = v8::Local::new(scope, handle);
     let state_rc = JsRuntime::state_from(scope);
     let state = state_rc.borrow();

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1810,11 +1810,11 @@ impl JsRuntime {
   }
 
   fn check_promise_rejections(&mut self) -> Result<(), Error> {
-    let state = self.inner.state.clone();
-    let scope = &mut self.handle_scope();
-    let state = state.borrow();
+    let state_rc = self.inner.state.clone();
+    let isolate = &mut self.v8_isolate();
+    let state = state_rc.borrow();
     for realm in &state.known_realms {
-      realm.check_promise_rejections(scope)?;
+      realm.check_promise_rejections(isolate)?;
     }
     Ok(())
   }


### PR DESCRIPTION
The `JsRuntime::check_promise_rejection` method takes care of failing the event loop run if it detects any rejected promise in any realm. It does so by delegating to `JsRealmInner::check_promise_rejection` for every realm; however, the scope it passes to that method is `runtime.handle_scope()` – that is, the main realm's scope. The `JsRealmInner` method in turn uses this scope, which results in the main realm's format exception callback being called, rather than the actual realm's.

This patch fixes this by changing `JsRealmInner::check_promise_rejection` to take a `&mut v8::Isolate` rather than a `&mut v8::HandleScope`, and to call `Self::handle_scope` to create a scope in the realm, as the rest of `JsRealm` and `JsRealmInner` methods do. It also adds realm-specific tests for the format exception callback.
