### PR TITLE
refactor(core): Introduce a StaticModuleLoader

### DIFF
--- a/core/fast_string.rs
+++ b/core/fast_string.rs
@@ -83,6 +83,16 @@ impl FastString {
     }
   }
 
+  /// If this [`FastString`] is cheaply cloneable, returns a clone.
+  pub fn try_clone(&self) -> Option<Self> {
+    match self {
+      Self::Static(s) => Some(Self::Static(s)),
+      Self::StaticAscii(s) => Some(Self::StaticAscii(s)),
+      Self::Arc(s) => Some(Self::Arc(s.clone())),
+      Self::Owned(_s) => None,
+    }
+  }
+
   pub const fn try_static_ascii(&self) -> Option<&'static [u8]> {
     match self {
       Self::StaticAscii(s) => Some(s.as_bytes()),

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -92,6 +92,7 @@ pub use crate::modules::ModuleSourceFuture;
 pub use crate::modules::ModuleType;
 pub use crate::modules::NoopModuleLoader;
 pub use crate::modules::ResolutionKind;
+pub use crate::modules::StaticModuleLoader;
 pub use crate::normalize_path::normalize_path;
 pub use crate::ops::OpCall;
 pub use crate::ops::OpError;

--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -27,11 +27,19 @@ mod map;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+pub use loaders::CountingModuleLoader;
+#[cfg(test)]
+pub use loaders::LoggingModuleLoader;
+#[cfg(test)]
+pub use loaders::ModuleLoadEventCounts;
+
 pub(crate) use loaders::ExtModuleLoader;
 pub use loaders::ExtModuleLoaderCb;
 pub use loaders::FsModuleLoader;
 pub use loaders::ModuleLoader;
 pub use loaders::NoopModuleLoader;
+pub use loaders::StaticModuleLoader;
 pub(crate) use map::ModuleMap;
 #[cfg(test)]
 pub(crate) use map::SymbolicModule;

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -885,7 +885,6 @@ impl JsRealm {
       .borrow_mut()
       .pending_mod_evaluate
       .take();
-
     if maybe_module_evaluation.is_none() {
       return;
     }
@@ -897,7 +896,6 @@ impl JsRealm {
     let promise_global = module_evaluation.promise.clone().unwrap();
     let promise = promise_global.open(scope);
     let promise_state = promise.state();
-
     match promise_state {
       v8::PromiseState::Pending => {
         // NOTE: `poll_event_loop` will decide if

--- a/core/runtime/tests/jsrealm.rs
+++ b/core/runtime/tests/jsrealm.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 use crate as deno_core;
 use crate::modules::ModuleCode;
+use crate::modules::StaticModuleLoader;
 use crate::*;
 use anyhow::Error;
 use deno_ops::op;
@@ -15,6 +16,7 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::task::Context;
 use std::task::Poll;
+use url::Url;
 
 #[tokio::test]
 async fn test_set_promise_reject_callback_realms() {
@@ -542,45 +544,20 @@ async fn test_realm_modules() {
 
 #[tokio::test]
 async fn test_cross_realm_imports() {
-  struct Loader;
-  impl ModuleLoader for Loader {
-    fn resolve(
-      &self,
-      specifier: &str,
-      referrer: &str,
-      _kind: ResolutionKind,
-    ) -> Result<ModuleSpecifier, Error> {
-      assert_eq!(specifier, "file:///test.js");
-      assert_eq!(referrer, "");
-      let s = crate::resolve_import(specifier, referrer).unwrap();
-      Ok(s)
-    }
+  let loader: Rc<dyn ModuleLoader> = Rc::new(StaticModuleLoader::with(
+    Url::parse("file:///test.js").unwrap(),
+    ascii_str!("export default globalThis;"),
+  ));
 
-    fn load(
-      &self,
-      _module_specifier: &ModuleSpecifier,
-      _maybe_referrer: Option<&ModuleSpecifier>,
-      _is_dyn_import: bool,
-    ) -> Pin<Box<ModuleSourceFuture>> {
-      async {
-        Ok(ModuleSource::for_test(
-          "export default globalThis;",
-          "file:///test.js",
-        ))
-      }
-      .boxed_local()
-    }
-  }
-
-  let loader = Rc::new(Loader);
+  let loader = Rc::new(loader);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    module_loader: Some(loader.clone()),
+    module_loader: Some(Rc::clone(&loader)),
     ..Default::default()
   });
   let main_realm = runtime.main_realm();
   let other_realm = runtime
     .create_realm(CreateRealmOptions {
-      module_loader: Some(loader),
+      module_loader: Some(Rc::clone(&loader)),
     })
     .unwrap();
 
@@ -650,35 +627,10 @@ async fn test_cross_realm_imports() {
 // different realms at the same time works.
 #[tokio::test]
 async fn test_realms_concurrent_module_evaluations() {
-  struct Loader;
-  impl ModuleLoader for Loader {
-    fn resolve(
-      &self,
-      specifier: &str,
-      referrer: &str,
-      _kind: ResolutionKind,
-    ) -> Result<ModuleSpecifier, Error> {
-      assert_eq!(specifier, "file:///test.js");
-      assert_eq!(referrer, ".");
-      let s = crate::resolve_import(specifier, referrer).unwrap();
-      Ok(s)
-    }
-
-    fn load(
-      &self,
-      _module_specifier: &ModuleSpecifier,
-      _maybe_referrer: Option<&ModuleSpecifier>,
-      _is_dyn_import: bool,
-    ) -> Pin<Box<ModuleSourceFuture>> {
-      async {
-        Ok(ModuleSource::for_test(
-          r#"await Deno.core.opAsync("op_wait");"#,
-          "file:///test.js",
-        ))
-      }
-      .boxed_local()
-    }
-  }
+  let loader: Rc<dyn ModuleLoader> = Rc::new(StaticModuleLoader::with(
+    Url::parse("file:///test.js").unwrap(),
+    ascii_str!(r#"await Deno.core.opAsync("op_wait");"#),
+  ));
 
   #[op]
   async fn op_wait(op_state: Rc<RefCell<OpState>>) {
@@ -693,7 +645,7 @@ async fn test_realms_concurrent_module_evaluations() {
 
   let mut runtime = JsRuntime::new(RuntimeOptions {
     extensions: vec![test_ext::init_ops()],
-    module_loader: Some(Rc::new(Loader)),
+    module_loader: Some(Rc::clone(&loader)),
     ..Default::default()
   });
   runtime
@@ -704,7 +656,7 @@ async fn test_realms_concurrent_module_evaluations() {
   let main_realm = runtime.main_realm();
   let other_realm = runtime
     .create_realm(CreateRealmOptions {
-      module_loader: Some(Rc::new(Loader)),
+      module_loader: Some(loader),
     })
     .unwrap();
 
@@ -757,35 +709,10 @@ async fn test_realms_concurrent_module_evaluations() {
 // realms at the same time works.
 #[tokio::test]
 async fn test_realm_concurrent_dynamic_imports() {
-  struct Loader;
-  impl ModuleLoader for Loader {
-    fn resolve(
-      &self,
-      specifier: &str,
-      referrer: &str,
-      _kind: ResolutionKind,
-    ) -> Result<ModuleSpecifier, Error> {
-      assert_eq!(specifier, "file:///test.js");
-      assert_eq!(referrer, "");
-      let s = crate::resolve_import(specifier, referrer).unwrap();
-      Ok(s)
-    }
-
-    fn load(
-      &self,
-      _module_specifier: &ModuleSpecifier,
-      _maybe_referrer: Option<&ModuleSpecifier>,
-      _is_dyn_import: bool,
-    ) -> Pin<Box<ModuleSourceFuture>> {
-      async {
-        Ok(ModuleSource::for_test(
-          r#"await Deno.core.opAsync("op_wait");"#,
-          "file:///test.js",
-        ))
-      }
-      .boxed_local()
-    }
-  }
+  let loader = Rc::new(StaticModuleLoader::with(
+    Url::parse("file:///test.js").unwrap(),
+    ascii_str!(r#"await Deno.core.opAsync("op_wait");"#),
+  ));
 
   #[op]
   async fn op_wait(op_state: Rc<RefCell<OpState>>) {
@@ -800,7 +727,7 @@ async fn test_realm_concurrent_dynamic_imports() {
 
   let mut runtime = JsRuntime::new(RuntimeOptions {
     extensions: vec![test_ext::init_ops()],
-    module_loader: Some(Rc::new(Loader)),
+    module_loader: Some(loader.clone()),
     ..Default::default()
   });
   runtime
@@ -811,7 +738,7 @@ async fn test_realm_concurrent_dynamic_imports() {
   let main_realm = runtime.main_realm();
   let other_realm = runtime
     .create_realm(CreateRealmOptions {
-      module_loader: Some(Rc::new(Loader)),
+      module_loader: Some(loader.clone()),
     })
     .unwrap();
 

--- a/core/runtime/tests/misc.rs
+++ b/core/runtime/tests/misc.rs
@@ -1,13 +1,9 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 use crate as deno_core;
-use crate::error::generic_error;
+
 use crate::error::AnyError;
 use crate::error::JsError;
-use crate::module_specifier::ModuleSpecifier;
-use crate::modules::ModuleLoader;
-use crate::modules::ModuleSource;
-use crate::modules::ModuleSourceFuture;
-use crate::modules::ResolutionKind;
+use crate::modules::StaticModuleLoader;
 use crate::runtime::tests::setup;
 use crate::runtime::tests::Mode;
 use crate::*;
@@ -17,8 +13,6 @@ use cooked_waker::Wake;
 use cooked_waker::WakeRef;
 use deno_ops::op;
 use futures::future::poll_fn;
-use futures::FutureExt;
-use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI8;
@@ -28,6 +22,7 @@ use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 use std::time::Duration;
+use url::Url;
 
 #[test]
 fn test_execute_script_return_value() {
@@ -379,36 +374,8 @@ fn inspector() {
 
 #[test]
 fn test_get_module_namespace() {
-  #[derive(Default)]
-  struct ModsLoader;
-
-  impl ModuleLoader for ModsLoader {
-    fn resolve(
-      &self,
-      specifier: &str,
-      referrer: &str,
-      _kind: ResolutionKind,
-    ) -> Result<ModuleSpecifier, Error> {
-      assert_eq!(specifier, "file:///main.js");
-      assert_eq!(referrer, ".");
-      let s = crate::resolve_import(specifier, referrer).unwrap();
-      Ok(s)
-    }
-
-    fn load(
-      &self,
-      _module_specifier: &ModuleSpecifier,
-      _maybe_referrer: Option<&ModuleSpecifier>,
-      _is_dyn_import: bool,
-    ) -> Pin<Box<ModuleSourceFuture>> {
-      async { Err(generic_error("Module loading is not supported")) }
-        .boxed_local()
-    }
-  }
-
-  let loader = std::rc::Rc::new(ModsLoader);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    module_loader: Some(loader),
+    module_loader: Some(Rc::new(NoopModuleLoader)),
     ..Default::default()
   });
 
@@ -744,41 +711,8 @@ fn test_has_tick_scheduled() {
 
 #[test]
 fn terminate_during_module_eval() {
-  #[derive(Default)]
-  struct ModsLoader;
-
-  impl ModuleLoader for ModsLoader {
-    fn resolve(
-      &self,
-      specifier: &str,
-      referrer: &str,
-      _kind: ResolutionKind,
-    ) -> Result<ModuleSpecifier, Error> {
-      assert_eq!(specifier, "file:///main.js");
-      assert_eq!(referrer, ".");
-      let s = crate::resolve_import(specifier, referrer).unwrap();
-      Ok(s)
-    }
-
-    fn load(
-      &self,
-      _module_specifier: &ModuleSpecifier,
-      _maybe_referrer: Option<&ModuleSpecifier>,
-      _is_dyn_import: bool,
-    ) -> Pin<Box<ModuleSourceFuture>> {
-      async move {
-        Ok(ModuleSource::for_test(
-          "console.log('hello world');",
-          "file:///main.js",
-        ))
-      }
-      .boxed_local()
-    }
-  }
-
-  let loader = std::rc::Rc::new(ModsLoader);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    module_loader: Some(loader),
+    module_loader: Some(Rc::new(NoopModuleLoader)),
     ..Default::default()
   });
 
@@ -886,43 +820,21 @@ async fn test_set_promise_reject_callback_top_level_await() {
 
   deno_core::extension!(test_ext, ops = [op_promise_reject]);
 
-  #[derive(Default)]
-  struct ModsLoader;
-
-  impl ModuleLoader for ModsLoader {
-    fn resolve(
-      &self,
-      specifier: &str,
-      referrer: &str,
-      _kind: ResolutionKind,
-    ) -> Result<ModuleSpecifier, Error> {
-      assert_eq!(specifier, "file:///main.js");
-      assert_eq!(referrer, ".");
-      let s = crate::resolve_import(specifier, referrer).unwrap();
-      Ok(s)
-    }
-
-    fn load(
-      &self,
-      _module_specifier: &ModuleSpecifier,
-      _maybe_referrer: Option<&ModuleSpecifier>,
-      _is_dyn_import: bool,
-    ) -> Pin<Box<ModuleSourceFuture>> {
-      let code = r#"
-      Deno.core.ops.op_set_promise_reject_callback((type, promise, reason) => {
-        Deno.core.ops.op_promise_reject();
-      });
-      throw new Error('top level throw');
-      "#;
-
-      async move { Ok(ModuleSource::for_test(code, "file:///main.js")) }
-        .boxed_local()
-    }
-  }
+  let loader = StaticModuleLoader::with(
+    Url::parse("file:///main.js").unwrap(),
+    ascii_str!(
+      r#"
+  Deno.core.ops.op_set_promise_reject_callback((type, promise, reason) => {
+    Deno.core.ops.op_promise_reject();
+  });
+  throw new Error('top level throw');
+  "#
+    ),
+  );
 
   let mut runtime = JsRuntime::new(RuntimeOptions {
     extensions: vec![test_ext::init_ops()],
-    module_loader: Some(Rc::new(ModsLoader)),
+    module_loader: Some(Rc::new(loader)),
     ..Default::default()
   });
 
@@ -961,40 +873,14 @@ fn test_array_by_copy() {
 // realm other than the main one.
 #[tokio::test]
 async fn test_stalled_tla() {
-  struct Loader;
-  impl ModuleLoader for Loader {
-    fn resolve(
-      &self,
-      specifier: &str,
-      referrer: &str,
-      _kind: ResolutionKind,
-    ) -> Result<ModuleSpecifier, Error> {
-      assert_eq!(specifier, "file:///test.js");
-      assert_eq!(referrer, ".");
-      let s = crate::resolve_import(specifier, referrer).unwrap();
-      Ok(s)
-    }
-
-    fn load(
-      &self,
-      _module_specifier: &ModuleSpecifier,
-      _maybe_referrer: Option<&ModuleSpecifier>,
-      _is_dyn_import: bool,
-    ) -> Pin<Box<ModuleSourceFuture>> {
-      async {
-        Ok(ModuleSource::for_test(
-          r#"await new Promise(() => {});"#,
-          "file:///test.js",
-        ))
-      }
-      .boxed_local()
-    }
-  }
-
+  let loader = StaticModuleLoader::with(
+    Url::parse("file:///test.js").unwrap(),
+    ascii_str!("await new Promise(() => {});"),
+  );
   let mut runtime = JsRuntime::new(Default::default());
   let realm = runtime
     .create_realm(CreateRealmOptions {
-      module_loader: Some(Rc::new(Loader)),
+      module_loader: Some(Rc::new(loader)),
     })
     .unwrap();
 
@@ -1022,94 +908,4 @@ async fn test_stalled_tla() {
   );
   assert_eq!(js_error.frames[0].line_number, Some(1));
   assert_eq!(js_error.frames[0].column_number, Some(1));
-}
-
-/// Test that `RuntimeOptions::preserve_snapshotted_modules` also works without
-/// a snapshot.
-#[test]
-fn non_snapshot_preserve_snapshotted_modules() {
-  let extension = Extension::builder("esm_extension")
-    .esm(vec![
-      ExtensionFileSource {
-        specifier: "test:preserved",
-        code: ExtensionFileSourceCode::IncludedInBinary(
-          "export const TEST = 'foo';",
-        ),
-      },
-      ExtensionFileSource {
-        specifier: "test:not-preserved",
-        code: ExtensionFileSourceCode::IncludedInBinary(
-          "import 'test:preserved'; export const TEST = 'bar';",
-        ),
-      },
-    ])
-    .esm_entry_point("test:not-preserved")
-    .build();
-
-  struct Loader;
-
-  impl ModuleLoader for Loader {
-    fn resolve(
-      &self,
-      specifier: &str,
-      referrer: &str,
-      _kind: ResolutionKind,
-    ) -> Result<ModuleSpecifier, Error> {
-      Ok(resolve_import(specifier, referrer)?)
-    }
-
-    fn load(
-      &self,
-      module_specifier: &ModuleSpecifier,
-      _maybe_referrer: Option<&ModuleSpecifier>,
-      _is_dyn_import: bool,
-    ) -> Pin<Box<ModuleSourceFuture>> {
-      assert_eq!(module_specifier.as_str(), "test:not-preserved");
-      futures::future::ready(Err(error::generic_error("Couldn't load module")))
-        .boxed_local()
-    }
-  }
-
-  let mut runtime = JsRuntime::new(RuntimeOptions {
-    module_loader: Some(Rc::new(Loader)),
-    extensions: vec![extension],
-    preserve_snapshotted_modules: Some(&["test:preserved"]),
-    ..Default::default()
-  });
-
-  // We can't import "test:not-preserved"
-  {
-    let dyn_import_promise = runtime
-      .execute_script_static("", "import('test:not-preserved')")
-      .unwrap();
-    let dyn_import_result =
-      futures::executor::block_on(runtime.resolve_value(dyn_import_promise));
-    assert!(dyn_import_result.is_err());
-    assert_eq!(
-      dyn_import_result.err().unwrap().to_string().as_str(),
-      "Uncaught TypeError: Couldn't load module"
-    );
-  }
-
-  // But we can import "test:preserved"
-  {
-    let dyn_import_promise = runtime
-      .execute_script_static(
-        "",
-        "import('test:preserved').then(module => module.TEST)",
-      )
-      .unwrap();
-    let dyn_import_result =
-      futures::executor::block_on(runtime.resolve_value(dyn_import_promise))
-        .unwrap();
-    let scope = &mut runtime.handle_scope();
-    assert!(dyn_import_result.open(scope).is_string());
-    assert_eq!(
-      dyn_import_result
-        .open(scope)
-        .to_rust_string_lossy(scope)
-        .as_str(),
-      "foo"
-    );
-  }
 }

--- a/core/runtime/tests/snapshot.rs
+++ b/core/runtime/tests/snapshot.rs
@@ -1,20 +1,16 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 use crate::extensions::Op;
-use crate::module_specifier::ModuleSpecifier;
 use crate::modules::AssertedModuleType;
+use crate::modules::LoggingModuleLoader;
 use crate::modules::ModuleInfo;
 use crate::modules::ModuleLoadId;
-use crate::modules::ModuleLoader;
-use crate::modules::ModuleSourceFuture;
 use crate::modules::ModuleType;
-use crate::modules::ResolutionKind;
 use crate::modules::SymbolicModule;
 use crate::*;
 use anyhow::Error;
 use deno_ops::op;
-use futures::FutureExt;
-use std::pin::Pin;
 use std::rc::Rc;
+use url::Url;
 
 #[test]
 fn will_snapshot() {
@@ -135,31 +131,6 @@ fn test_from_boxed_snapshot() {
 
 #[test]
 fn es_snapshot() {
-  #[derive(Default)]
-  struct ModsLoader;
-
-  impl ModuleLoader for ModsLoader {
-    fn resolve(
-      &self,
-      specifier: &str,
-      referrer: &str,
-      _kind: ResolutionKind,
-    ) -> Result<ModuleSpecifier, Error> {
-      let s = crate::resolve_import(specifier, referrer).unwrap();
-      Ok(s)
-    }
-
-    fn load(
-      &self,
-      _module_specifier: &ModuleSpecifier,
-      _maybe_referrer: Option<&ModuleSpecifier>,
-      _is_dyn_import: bool,
-    ) -> Pin<Box<ModuleSourceFuture>> {
-      eprintln!("load() should not be called");
-      unreachable!()
-    }
-  }
-
   fn create_module(
     runtime: &mut JsRuntime,
     i: usize,
@@ -237,10 +208,8 @@ fn es_snapshot() {
     Ok(String::from("test"))
   }
 
-  let loader = Rc::new(ModsLoader);
   let mut runtime = JsRuntimeForSnapshot::new(
     RuntimeOptions {
-      module_loader: Some(loader.clone()),
       extensions: vec![Extension::builder("text_ext")
         .ops(vec![op_test::DECL])
         .build()],
@@ -278,7 +247,6 @@ fn es_snapshot() {
 
   let mut runtime2 = JsRuntimeForSnapshot::new(
     RuntimeOptions {
-      module_loader: Some(loader.clone()),
       startup_snapshot: Some(Snapshot::JustCreated(snapshot)),
       extensions: vec![Extension::builder("text_ext")
         .ops(vec![op_test::DECL])
@@ -298,7 +266,6 @@ fn es_snapshot() {
   let snapshot2 = runtime2.snapshot();
 
   let mut runtime3 = JsRuntime::new(RuntimeOptions {
-    module_loader: Some(loader),
     startup_snapshot: Some(Snapshot::JustCreated(snapshot2)),
     extensions: vec![Extension::builder("text_ext")
       .ops(vec![op_test::DECL])
@@ -363,16 +330,24 @@ fn es_snapshot_without_runtime_module_loader() {
     );
   }
 
-  // Make sure we can't import the module.
+  // We can still import a module that was registered manually
   let dyn_import_promise = runtime
     .execute_script_static("", "import('ext:module_snapshot/test.js')")
+    .unwrap();
+  let dyn_import_result =
+    futures::executor::block_on(runtime.resolve_value(dyn_import_promise));
+  assert!(dyn_import_result.is_ok());
+
+  // But not a new one
+  let dyn_import_promise = runtime
+    .execute_script_static("", "import('ext:module_snapshot/test2.js')")
     .unwrap();
   let dyn_import_result =
     futures::executor::block_on(runtime.resolve_value(dyn_import_promise));
   assert!(dyn_import_result.is_err());
   assert_eq!(
     dyn_import_result.err().unwrap().to_string().as_str(),
-    r#"Uncaught TypeError: Module loading is not supported; attempted to resolve: "ext:module_snapshot/test.js" from """#
+    r#"Uncaught TypeError: Module loading is not supported; attempted to load: "ext:module_snapshot/test2.js" from "(no referrer)""#
   );
 }
 
@@ -408,32 +383,10 @@ fn preserve_snapshotted_modules() {
     runtime.snapshot()
   };
 
-  struct Loader;
-
-  impl ModuleLoader for Loader {
-    fn resolve(
-      &self,
-      specifier: &str,
-      referrer: &str,
-      _kind: ResolutionKind,
-    ) -> Result<ModuleSpecifier, Error> {
-      Ok(resolve_import(specifier, referrer)?)
-    }
-
-    fn load(
-      &self,
-      module_specifier: &ModuleSpecifier,
-      _maybe_referrer: Option<&ModuleSpecifier>,
-      _is_dyn_import: bool,
-    ) -> Pin<Box<ModuleSourceFuture>> {
-      assert_eq!(module_specifier.as_str(), "test:not-preserved");
-      futures::future::ready(Err(error::generic_error("Couldn't load module")))
-        .boxed_local()
-    }
-  }
+  let loader = Rc::new(LoggingModuleLoader::new(NoopModuleLoader));
 
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    module_loader: Some(Rc::new(Loader)),
+    module_loader: Some(loader.clone()),
     startup_snapshot: Some(Snapshot::JustCreated(startup_data)),
     preserve_snapshotted_modules: Some(&["test:preserved"]),
     ..Default::default()
@@ -441,6 +394,7 @@ fn preserve_snapshotted_modules() {
 
   // We can't import "test:not-preserved"
   {
+    assert_eq!(loader.log(), vec![]);
     let dyn_import_promise = runtime
       .execute_script_static("", "import('test:not-preserved')")
       .unwrap();
@@ -449,7 +403,86 @@ fn preserve_snapshotted_modules() {
     assert!(dyn_import_result.is_err());
     assert_eq!(
       dyn_import_result.err().unwrap().to_string().as_str(),
-      "Uncaught TypeError: Couldn't load module"
+      "Uncaught TypeError: Module loading is not supported; attempted to load: \"test:not-preserved\" from \"(no referrer)\""
+    );
+    // Ensure that we tried to load `test:not-preserved`
+    assert_eq!(
+      loader.log(),
+      vec![Url::parse("test:not-preserved").unwrap()]
+    );
+  }
+
+  // But we can import "test:preserved"
+  {
+    let dyn_import_promise = runtime
+      .execute_script_static(
+        "",
+        "import('test:preserved').then(module => module.TEST)",
+      )
+      .unwrap();
+    let dyn_import_result =
+      futures::executor::block_on(runtime.resolve_value(dyn_import_promise))
+        .unwrap();
+    let scope = &mut runtime.handle_scope();
+    assert!(dyn_import_result.open(scope).is_string());
+    assert_eq!(
+      dyn_import_result
+        .open(scope)
+        .to_rust_string_lossy(scope)
+        .as_str(),
+      "foo"
+    );
+  }
+}
+
+/// Test that `RuntimeOptions::preserve_snapshotted_modules` also works without
+/// a snapshot.
+#[test]
+fn non_snapshot_preserve_snapshotted_modules() {
+  let extension = Extension::builder("esm_extension")
+    .esm(vec![
+      ExtensionFileSource {
+        specifier: "test:preserved",
+        code: ExtensionFileSourceCode::IncludedInBinary(
+          "export const TEST = 'foo';",
+        ),
+      },
+      ExtensionFileSource {
+        specifier: "test:not-preserved",
+        code: ExtensionFileSourceCode::IncludedInBinary(
+          "import 'test:preserved'; export const TEST = 'bar';",
+        ),
+      },
+    ])
+    .esm_entry_point("test:not-preserved")
+    .build();
+
+  let loader = Rc::new(LoggingModuleLoader::new(NoopModuleLoader));
+
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    module_loader: Some(loader.clone()),
+    extensions: vec![extension],
+    preserve_snapshotted_modules: Some(&["test:preserved"]),
+    ..Default::default()
+  });
+
+  // We can't import "test:not-preserved"
+  {
+    assert_eq!(loader.log(), vec![]);
+    let dyn_import_promise = runtime
+      .execute_script_static("", "import('test:not-preserved')")
+      .unwrap();
+    let dyn_import_result =
+      futures::executor::block_on(runtime.resolve_value(dyn_import_promise));
+    assert!(dyn_import_result.is_err());
+    assert_eq!(
+      dyn_import_result.err().unwrap().to_string().as_str(),
+      "Uncaught TypeError: Module loading is not supported; attempted to load: \"test:not-preserved\" from \"(no referrer)\""
+    );
+    // Ensure that we tried to load `test:not-preserved`
+    assert_eq!(
+      loader.log(),
+      vec![Url::parse("test:not-preserved").unwrap()]
     );
   }
 


### PR DESCRIPTION
Adds the following test utilities to remove a lot of boilerplate from the deno_core tests:

 - `StaticModuleLoader` to provide a set of static files that don't require the filesystem
 - `CountingModuleLoader` to test resolve/prepare/load counts
 - `LoggingModuleLoader` to log a list of load attempts
