### PR TITLE
fix(extensions): use expr instead of literal

### DIFF
--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -779,5 +779,3 @@ macro_rules! include_js_files {
     ]
   };
 }
-
-extension!(foo, esm_entry_point = "".to_string(),);


### PR DESCRIPTION
You can see this done for things like https://doc.rust-lang.org/std/macro.concat.html.

Lets users pass computed expressions as long as they are computed at compile time.

Leads to better error messages if a non-literal is passed:
```rust
extension!(foo, esm_entry_point = "".to_string(),);
```
Before:
```
error: no rules expected the token `.`
   --> core/extensions.rs:783:37
    |
241 | macro_rules! extension {
    | ---------------------- when calling this macro
...
783 | extension!(foo, esm_entry_point = "".to_string(),);
    |                                     ^ no rules expected this token in macro call
    |
    = note: while trying to match sequence start
```
After:
```
error[E0308]: mismatched types
   --> core/extensions.rs:783:35
    |
288 |             const V: Option<&'static str> = $crate::or!($(Some($esm_entry_point))?, None);
    |                                                           ---- arguments to this enum variant are incorrect
...
783 | extension!(foo, esm_entry_point = "".to_string(),);
    |                                   ^^^^^^^^^^^^^^ expected `&str`, found `String`
```