### PR TITLE
fix(realms): Make realm creation not hang with async ops running

### DIFF
--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -967,11 +967,36 @@ impl JsRuntime {
               panic!("{} not present in the module map", specifier)
             })
         };
-        let receiver = realm.mod_evaluate(self.v8_isolate(), mod_id);
-        self.run_event_loop(false).await?;
-        receiver
-          .await?
-          .with_context(|| format!("Couldn't execute '{specifier}'"))?;
+        let mut receiver = realm.mod_evaluate(self.v8_isolate(), mod_id);
+        realm.evaluate_pending_module(&mut self.v8_isolate());
+
+        // After evaluate_pending_module, if the module isn't fully evaluated
+        // and the resolver solved, it means the module or one of its imports
+        // uses TLA.
+        match receiver.try_recv()? {
+          Some(result) => {
+            result
+              .with_context(|| format!("Couldn't execute '{specifier}'"))?;
+          }
+          None => {
+            // Find the TLA location to display it on the panic.
+            let location = {
+              let scope = &mut realm.handle_scope(self.v8_isolate());
+              let module_map = module_map_rc.borrow();
+              let messages = module_map.find_stalled_top_level_await(scope);
+              assert!(!messages.is_empty());
+              let msg = v8::Local::new(scope, &messages[0]);
+              let js_error = JsError::from_v8_message(scope, msg);
+              js_error
+                .frames
+                .first()
+                .unwrap()
+                .maybe_format_location()
+                .unwrap()
+            };
+            panic!("Top-level await is not allowed in extensions ({location})");
+          }
+        }
       }
 
       #[cfg(debug_assertions)]

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -968,7 +968,7 @@ impl JsRuntime {
             })
         };
         let mut receiver = realm.mod_evaluate(self.v8_isolate(), mod_id);
-        realm.evaluate_pending_module(&mut self.v8_isolate());
+        realm.evaluate_pending_module(self.v8_isolate());
 
         // After evaluate_pending_module, if the module isn't fully evaluated
         // and the resolver solved, it means the module or one of its imports


### PR DESCRIPTION
The way `JsRuntime::init_extension_js` initialized ESM extensions without a snapshot was by running the event loop and blocking the thread ntil there were no more tasks. This works fine for the main realm, because it is created before any user code can start any async ops. However, other realms may be created while async ops are running, which would make realm creation hang until those ops are resolved.

Since extensions are not expected to use top-level await, there would be no need to run the entire event loop for modules to resolve; calling `JsRealm::evaluate_pending_module` would be enough. If the module is not resolved after calling that functions, then it or one of its dependencies has TLA, in which case we panic.

Since a panic like "TLA is not allowed" would be hard to debug, especially on codebases with many modules, we use `ModuleMap::find_stalled_top_level_await` to find at least one of the TLA locations, and we display it in the panic message.
