### PR TITLE
fix: Remove unnecessary clones in `v8::Local` constructors

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -669,7 +669,7 @@ pub(crate) fn exception_to_err_result<T>(
     // was passed to this function.
     let state = state_rc.borrow();
     exception = if let Some(exception) = &state.dispatched_exception {
-      v8::Local::new(scope, exception.clone())
+      v8::Local::new(scope, exception)
     } else if was_terminating_execution && exception.is_null_or_undefined() {
       let message = v8::String::new(scope, "execution terminated").unwrap();
       v8::Exception::error(scope, message)

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1615,7 +1615,7 @@ fn find_and_report_stalled_level_await_in_any_realm(
       // with source line of offending promise shown. Once user fixed it, then
       // they will get another error message for the next promise (but this
       // situation is gonna be very rare, if ever happening).
-      let msg = v8::Local::new(scope, messages[0].clone());
+      let msg = v8::Local::new(scope, &messages[0]);
       let js_error = JsError::from_v8_message(scope, msg);
       return js_error.into();
     }

--- a/serde_v8/magic/global.rs
+++ b/serde_v8/magic/global.rs
@@ -26,7 +26,7 @@ impl ToV8 for Global {
     &mut self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, crate::Error> {
-    Ok(v8::Local::new(scope, self.v8_value.clone()))
+    Ok(v8::Local::new(scope, &self.v8_value))
   }
 }
 


### PR DESCRIPTION
The second argument to `v8::Local` can be a reference, so cloning isn't needed.
