### PR TITLE
fix(core): don't include a v8 dependency as this breaks docs.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,6 @@ dependencies = [
  "syn 2.0.27",
  "testing_macros",
  "thiserror",
- "v8",
 ]
 
 [[package]]

--- a/ops/Cargo.toml
+++ b/ops/Cargo.toml
@@ -28,7 +28,6 @@ strum_macros.workspace = true
 syn.workspace = true
 syn2.workspace = true
 thiserror.workspace = true
-v8.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -734,10 +734,7 @@ fn throw_type_error(
   message: String,
 ) -> Result<TokenStream, V8MappingError> {
   // Sanity check ASCII and a valid/reasonable message size
-  debug_assert!(
-    message.is_ascii()
-      && message.len() < 1024
-  );
+  debug_assert!(message.is_ascii() && message.len() < 1024);
 
   let maybe_scope = if generator_state.needs_scope {
     quote!()

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -736,7 +736,6 @@ fn throw_type_error(
   // Sanity check ASCII and a valid/reasonable message size
   debug_assert!(
     message.is_ascii()
-      && message.len() < v8::String::max_length()
       && message.len() < 1024
   );
 


### PR DESCRIPTION
Fixes #98

If v8 fails to link, the proc macro won't compile, causing docs.rs to barf.