### PR TITLE
fix: run js event loop tick before polling dynamic imports

### DIFF
--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1417,7 +1417,7 @@ impl JsRuntime {
     self.pump_v8_message_loop()?;
 
     // Resolve async ops, run all next tick callbacks and macrotasks callbacks,
-    // poll pending dynamic imports and only then check for any promise 
+    // poll pending dynamic imports and only then check for any promise
     // exceptions (`unhandledrejection` handlers are run in macrotasks callbacks
     // so we need to let them run first).
     let dispatched_ops = self.do_js_event_loop_tick(cx)?;

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1568,7 +1568,10 @@ impl JsRuntime {
     }
 
     // If ops were dispatched we may have progress on pending modules that we should re-check
-    if (pending_state.has_pending_module_evaluation || pending_state.has_pending_dyn_module_evaluation) && dispatched_ops {
+    if (pending_state.has_pending_module_evaluation
+      || pending_state.has_pending_dyn_module_evaluation)
+      && dispatched_ops
+    {
       state.op_state.borrow().waker.wake();
     }
 


### PR DESCRIPTION
This fixes regressions reported in https://github.com/denoland/deno/issues/19903.

We mistakenly were not waking up the event loop again if ops made progress
and there are pending dynamic imports waiting for TLA to resolve.