### PR TITLE
fix: don't swallow rejections in poll_value()

### DIFF
--- a/core/runtime/tests/snapshot.rs
+++ b/core/runtime/tests/snapshot.rs
@@ -365,7 +365,7 @@ pub(crate) fn generic_es_snapshot_without_runtime_module_loader(
   assert!(dyn_import_result.is_err());
   assert_eq!(
     dyn_import_result.err().unwrap().to_string().as_str(),
-    r#"Uncaught TypeError: Module loading is not supported; attempted to load: "ext:module_snapshot/test2.js" from "(no referrer)""#
+    r#"Uncaught (in promise) TypeError: Module loading is not supported; attempted to load: "ext:module_snapshot/test2.js" from "(no referrer)""#
   );
 }
 
@@ -447,7 +447,7 @@ pub(crate) fn generic_preserve_snapshotted_modules_test(
     assert!(dyn_import_result.is_err());
     assert_eq!(
       dyn_import_result.err().unwrap().to_string().as_str(),
-      "Uncaught TypeError: Module loading is not supported; attempted to load: \"test:not-preserved\" from \"(no referrer)\""
+      "Uncaught (in promise) TypeError: Module loading is not supported; attempted to load: \"test:not-preserved\" from \"(no referrer)\""
     );
     // Ensure that we tried to load `test:not-preserved`
     assert_eq!(


### PR DESCRIPTION
Unblocks https://github.com/denoland/deno/pull/20082.

Fixes three tangled issues:
- `JsRuntime::poll_value(promise)` swallows non-awaited rejections returned from `poll_event_loop()` when `promise` is already settled.
- `JsRuntime::poll_value(promise)` runs the event loop once even if `promise` is already settled.
- `JsRuntime::call_and_await()` needs to explicitly call `check_promise_rejections()` at the end.

Some test expectations might need to add `(in promise)` to error strings. These are correct. There's at least one in CLI repo:
```diff
diff --git a/cli/tests/testdata/node/test.out b/cli/tests/testdata/node/test.out
index 8b7f0780f..3c54a15e8 100644
--- a/cli/tests/testdata/node/test.out
+++ b/cli/tests/testdata/node/test.out
@@ -147,7 +147,7 @@ error: Error: rejected from reject fail
     at [WILDCARD]
 
 ./node/test.js (uncaught error)
-error: Error: rejected from unhandled rejection fail
+error: (in promise) Error: rejected from unhandled rejection fail
   Promise.reject(new Error("rejected from unhandled rejection fail"));
                  ^
     at [WILDCARD]
```