### PR TITLE
refactor: move get_error_class_fn to OpCtx

### DIFF
--- a/core/ops.rs
+++ b/core/ops.rs
@@ -129,6 +129,7 @@ pub struct OpCtx {
   /// A stashed Isolate that ops can use in callbacks
   pub isolate: *mut Isolate,
   pub state: Rc<RefCell<OpState>>,
+  pub get_error_class_fn: GetErrorClassFn,
   pub decl: Rc<OpDecl>,
   pub fast_fn_c_info: Option<NonNull<v8::fast_api::CFunctionInfo>>,
   pub runtime_state: Weak<RefCell<JsRuntimeState>>,
@@ -145,6 +146,7 @@ impl OpCtx {
     decl: Rc<OpDecl>,
     state: Rc<RefCell<OpState>>,
     runtime_state: Weak<RefCell<JsRuntimeState>>,
+    get_error_class_fn: GetErrorClassFn,
   ) -> Self {
     let mut fast_fn_c_info = None;
 
@@ -170,6 +172,7 @@ impl OpCtx {
     OpCtx {
       id,
       state,
+      get_error_class_fn,
       runtime_state,
       decl,
       context_state,

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -212,7 +212,6 @@ impl OpCtx {
 /// Maintains the resources and ops inside a JS runtime.
 pub struct OpState {
   pub resource_table: ResourceTable,
-  pub get_error_class_fn: GetErrorClassFn,
   pub tracker: OpsTracker,
   pub last_fast_op_error: Option<AnyError>,
   pub(crate) gotham_state: GothamState,
@@ -223,7 +222,6 @@ impl OpState {
   pub fn new(ops_count: usize) -> OpState {
     OpState {
       resource_table: Default::default(),
-      get_error_class_fn: &|_| "Error",
       gotham_state: Default::default(),
       last_fast_op_error: None,
       tracker: OpsTracker::new(ops_count),

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1064,10 +1064,6 @@ impl JsRuntime {
 
     let mut op_state = OpState::new(ops.len());
 
-    if let Some(get_error_class_fn) = options.get_error_class_fn {
-      op_state.get_error_class_fn = get_error_class_fn;
-    }
-
     // Setup state
     for e in &mut options.extensions {
       // ops are already registered during in bindings::initialize_context();

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -571,6 +571,7 @@ impl JsRuntime {
           Rc::new(decl),
           op_state.clone(),
           weak.clone(),
+          options.get_error_class_fn.unwrap_or(&|_| "Error"),
         )
       })
       .collect::<Vec<_>>()
@@ -800,6 +801,7 @@ impl JsRuntime {
             op_ctx.decl.clone(),
             op_ctx.state.clone(),
             op_ctx.runtime_state.clone(),
+            op_ctx.get_error_class_fn,
           )
         })
         .collect();

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -437,7 +437,7 @@ fn codegen_v8_sync(
       {
         let op_state = &mut std::cell::RefCell::borrow_mut(&ctx.state);
         if let Some(err) = op_state.last_fast_op_error.take() {
-          let exception = #core::error::to_v8_error(scope, op_state.get_error_class_fn, &err);
+          let exception = #core::error::to_v8_error(scope, ctx.get_error_class_fn, &err);
           scope.throw_exception(exception);
           return;
         }
@@ -791,7 +791,7 @@ fn codegen_sync_ret(
         #ok_block
       },
       Err(err) => {
-        let exception = #core::error::to_v8_error(scope, op_state.get_error_class_fn, &err);
+        let exception = #core::error::to_v8_error(scope, ctx.get_error_class_fn, &err);
         scope.throw_exception(exception);
       },
     };

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -723,10 +723,9 @@ pub(crate) fn throw_exception(
     #maybe_args
     #maybe_opctx
     let err = err.into();
-    let opstate = ::std::cell::RefCell::borrow(&*#opctx.state);
     let exception = #deno_core::error::to_v8_error(
       &mut #scope,
-      opstate.get_error_class_fn,
+      #opctx.get_error_class_fn,
       &err,
     );
     #scope.throw_exception(exception);

--- a/ops/op2/test_cases/async/async_arg_return_result.out
+++ b/ops/op2/test_cases/async/async_arg_return_result.out
@@ -69,10 +69,9 @@ impl op_async {
                 }
                 Err(err) => {
                     let err = err.into();
-                    let opstate = ::std::cell::RefCell::borrow(&*opctx.state);
                     let exception = deno_core::error::to_v8_error(
                         &mut scope,
-                        opstate.get_error_class_fn,
+                        opctx.get_error_class_fn,
                         &err,
                     );
                     scope.throw_exception(exception);

--- a/ops/op2/test_cases/async/async_opstate.out
+++ b/ops/op2/test_cases/async/async_opstate.out
@@ -57,10 +57,9 @@ impl op_async_opstate {
                 }
                 Err(err) => {
                     let err = err.into();
-                    let opstate = ::std::cell::RefCell::borrow(&*opctx.state);
                     let exception = deno_core::error::to_v8_error(
                         &mut scope,
-                        opstate.get_error_class_fn,
+                        opctx.get_error_class_fn,
                         &err,
                     );
                     scope.throw_exception(exception);

--- a/ops/op2/test_cases/async/async_result.out
+++ b/ops/op2/test_cases/async/async_result.out
@@ -53,10 +53,9 @@ impl op_async {
                 }
                 Err(err) => {
                     let err = err.into();
-                    let opstate = ::std::cell::RefCell::borrow(&*opctx.state);
                     let exception = deno_core::error::to_v8_error(
                         &mut scope,
-                        opstate.get_error_class_fn,
+                        opctx.get_error_class_fn,
                         &err,
                     );
                     scope.throw_exception(exception);

--- a/ops/op2/test_cases/async/async_result_impl.out
+++ b/ops/op2/test_cases/async/async_result_impl.out
@@ -55,10 +55,9 @@ impl op_async_result_impl {
             Ok(result) => result,
             Err(err) => {
                 let err = err.into();
-                let opstate = ::std::cell::RefCell::borrow(&*opctx.state);
                 let exception = deno_core::error::to_v8_error(
                     &mut scope,
-                    opstate.get_error_class_fn,
+                    opctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);
@@ -83,10 +82,9 @@ impl op_async_result_impl {
                 }
                 Err(err) => {
                     let err = err.into();
-                    let opstate = ::std::cell::RefCell::borrow(&*opctx.state);
                     let exception = deno_core::error::to_v8_error(
                         &mut scope,
-                        opstate.get_error_class_fn,
+                        opctx.get_error_class_fn,
                         &err,
                     );
                     scope.throw_exception(exception);

--- a/ops/op2/test_cases/async/async_result_smi.out
+++ b/ops/op2/test_cases/async/async_result_smi.out
@@ -69,10 +69,9 @@ impl op_async {
                 }
                 Err(err) => {
                     let err = err.into();
-                    let opstate = ::std::cell::RefCell::borrow(&*opctx.state);
                     let exception = deno_core::error::to_v8_error(
                         &mut scope,
-                        opstate.get_error_class_fn,
+                        opctx.get_error_class_fn,
                         &err,
                     );
                     scope.throw_exception(exception);

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -72,10 +72,9 @@ impl op_bool {
         if let Some(err) = unsafe { opctx.unsafely_take_last_error_for_ops_only() } {
             let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
             let err = err.into();
-            let opstate = ::std::cell::RefCell::borrow(&*opctx.state);
             let exception = deno_core::error::to_v8_error(
                 &mut scope,
-                opstate.get_error_class_fn,
+                opctx.get_error_class_fn,
                 &err,
             );
             scope.throw_exception(exception);
@@ -93,10 +92,9 @@ impl op_bool {
             Err(err) => {
                 let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                 let err = err.into();
-                let opstate = ::std::cell::RefCell::borrow(&*opctx.state);
                 let exception = deno_core::error::to_v8_error(
                     &mut scope,
-                    opstate.get_error_class_fn,
+                    opctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -71,10 +71,9 @@ impl op_u32_with_result {
                 &*info
             });
             let err = err.into();
-            let opstate = ::std::cell::RefCell::borrow(&*opctx.state);
             let exception = deno_core::error::to_v8_error(
                 &mut scope,
-                opstate.get_error_class_fn,
+                opctx.get_error_class_fn,
                 &err,
             );
             scope.throw_exception(exception);
@@ -91,10 +90,9 @@ impl op_u32_with_result {
                     &*info
                 });
                 let err = err.into();
-                let opstate = ::std::cell::RefCell::borrow(&*opctx.state);
                 let exception = deno_core::error::to_v8_error(
                     &mut scope,
-                    opstate.get_error_class_fn,
+                    opctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);

--- a/ops/op2/test_cases/sync/result_scope.out
+++ b/ops/op2/test_cases/sync/result_scope.out
@@ -44,10 +44,9 @@ impl op_void_with_result {
                         .value() as *const deno_core::_ops::OpCtx)
                 };
                 let err = err.into();
-                let opstate = ::std::cell::RefCell::borrow(&*opctx.state);
                 let exception = deno_core::error::to_v8_error(
                     &mut scope,
-                    opstate.get_error_class_fn,
+                    opctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -71,10 +71,9 @@ impl op_void_with_result {
                 &*info
             });
             let err = err.into();
-            let opstate = ::std::cell::RefCell::borrow(&*opctx.state);
             let exception = deno_core::error::to_v8_error(
                 &mut scope,
-                opstate.get_error_class_fn,
+                opctx.get_error_class_fn,
                 &err,
             );
             scope.throw_exception(exception);
@@ -91,10 +90,9 @@ impl op_void_with_result {
                     &*info
                 });
                 let err = err.into();
-                let opstate = ::std::cell::RefCell::borrow(&*opctx.state);
                 let exception = deno_core::error::to_v8_error(
                     &mut scope,
-                    opstate.get_error_class_fn,
+                    opctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);

--- a/ops/optimizer_tests/incompatible_1.out
+++ b/ops/optimizer_tests/incompatible_1.out
@@ -74,7 +74,7 @@ impl op_sync_serialize_object_with_numbers_as_keys {
             Err(err) => {
                 let exception = deno_core::error::to_v8_error(
                     scope,
-                    op_state.get_error_class_fn,
+                    ctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);

--- a/ops/optimizer_tests/op_blob_revoke_object_url.out
+++ b/ops/optimizer_tests/op_blob_revoke_object_url.out
@@ -74,7 +74,7 @@ impl op_blob_revoke_object_url {
             Err(err) => {
                 let exception = deno_core::error::to_v8_error(
                     scope,
-                    op_state.get_error_class_fn,
+                    ctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);

--- a/ops/optimizer_tests/op_print.out
+++ b/ops/optimizer_tests/op_print.out
@@ -89,7 +89,7 @@ impl op_print {
             Err(err) => {
                 let exception = deno_core::error::to_v8_error(
                     scope,
-                    op_state.get_error_class_fn,
+                    ctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);

--- a/ops/optimizer_tests/op_state_result.out
+++ b/ops/optimizer_tests/op_state_result.out
@@ -67,7 +67,7 @@ impl foo {
             if let Some(err) = op_state.last_fast_op_error.take() {
                 let exception = deno_core::error::to_v8_error(
                     scope,
-                    op_state.get_error_class_fn,
+                    ctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);
@@ -110,7 +110,7 @@ impl foo {
             Err(err) => {
                 let exception = deno_core::error::to_v8_error(
                     scope,
-                    op_state.get_error_class_fn,
+                    ctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);

--- a/ops/optimizer_tests/op_state_warning.out
+++ b/ops/optimizer_tests/op_state_warning.out
@@ -73,7 +73,7 @@ impl op_listen {
             if let Some(err) = op_state.last_fast_op_error.take() {
                 let exception = deno_core::error::to_v8_error(
                     scope,
-                    op_state.get_error_class_fn,
+                    ctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);
@@ -101,7 +101,7 @@ impl op_listen {
             Err(err) => {
                 let exception = deno_core::error::to_v8_error(
                     scope,
-                    op_state.get_error_class_fn,
+                    ctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);

--- a/ops/optimizer_tests/opstate_with_arity.out
+++ b/ops/optimizer_tests/opstate_with_arity.out
@@ -67,7 +67,7 @@ impl op_add_4 {
             if let Some(err) = op_state.last_fast_op_error.take() {
                 let exception = deno_core::error::to_v8_error(
                     scope,
-                    op_state.get_error_class_fn,
+                    ctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);
@@ -128,7 +128,7 @@ impl op_add_4 {
             Err(err) => {
                 let exception = deno_core::error::to_v8_error(
                     scope,
-                    op_state.get_error_class_fn,
+                    ctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);

--- a/ops/optimizer_tests/option_arg.out
+++ b/ops/optimizer_tests/option_arg.out
@@ -72,7 +72,7 @@ impl op_try_close {
             Err(err) => {
                 let exception = deno_core::error::to_v8_error(
                     scope,
-                    op_state.get_error_class_fn,
+                    ctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);

--- a/ops/optimizer_tests/param_mut_binding_warning.out
+++ b/ops/optimizer_tests/param_mut_binding_warning.out
@@ -92,7 +92,7 @@ impl op_read_sync {
             Err(err) => {
                 let exception = deno_core::error::to_v8_error(
                     scope,
-                    op_state.get_error_class_fn,
+                    ctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);

--- a/ops/optimizer_tests/strings_result.out
+++ b/ops/optimizer_tests/strings_result.out
@@ -74,7 +74,7 @@ impl op_string_length {
             Err(err) => {
                 let exception = deno_core::error::to_v8_error(
                     scope,
-                    op_state.get_error_class_fn,
+                    ctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);

--- a/ops/optimizer_tests/u64_result.out
+++ b/ops/optimizer_tests/u64_result.out
@@ -75,7 +75,7 @@ impl op_bench_now {
             Err(err) => {
                 let exception = deno_core::error::to_v8_error(
                     scope,
-                    op_state.get_error_class_fn,
+                    ctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);

--- a/ops/optimizer_tests/unit_result.out
+++ b/ops/optimizer_tests/unit_result.out
@@ -67,7 +67,7 @@ impl op_unit_result {
             if let Some(err) = op_state.last_fast_op_error.take() {
                 let exception = deno_core::error::to_v8_error(
                     scope,
-                    op_state.get_error_class_fn,
+                    ctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);
@@ -82,7 +82,7 @@ impl op_unit_result {
             Err(err) => {
                 let exception = deno_core::error::to_v8_error(
                     scope,
-                    op_state.get_error_class_fn,
+                    ctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);

--- a/ops/optimizer_tests/unit_result2.out
+++ b/ops/optimizer_tests/unit_result2.out
@@ -74,7 +74,7 @@ impl op_set_nodelay {
             if let Some(err) = op_state.last_fast_op_error.take() {
                 let exception = deno_core::error::to_v8_error(
                     scope,
-                    op_state.get_error_class_fn,
+                    ctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);
@@ -115,7 +115,7 @@ impl op_set_nodelay {
             Err(err) => {
                 let exception = deno_core::error::to_v8_error(
                     scope,
-                    op_state.get_error_class_fn,
+                    ctx.get_error_class_fn,
                     &err,
                 );
                 scope.throw_exception(exception);


### PR DESCRIPTION
Closes #51. `cargo test error` works in main repo.