### PR TITLE
feat(ops): support #[serde] return from async ops

### DIFF
--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -767,6 +767,7 @@ mod tests {
       op_async_buffer_vec,
       op_async_buffer_impl,
       op_async_external,
+      op_async_serde_option_v8,
     ],
     state = |state| {
       state.put(1234u32);
@@ -1936,6 +1937,27 @@ mod tests {
       2,
       "op_external_make, op_async_external",
       "await op_async_external(op_external_make())",
+    )
+    .await?;
+    Ok(())
+  }
+
+  #[op2(async, core)]
+  #[serde]
+  pub async fn op_async_serde_option_v8(
+    #[serde] mut serde: Serde,
+  ) -> Result<Option<Serde>, AnyError> {
+    serde.s += "!";
+    Ok(Some(serde))
+  }
+
+  #[tokio::test]
+  pub async fn test_op_async_serde_option_v8(
+  ) -> Result<(), Box<dyn std::error::Error>> {
+    run_async_test(
+      2,
+      "op_async_serde_option_v8",
+      "assert((await op_async_serde_option_v8({s: 'abc'})).s == 'abc!')",
     )
     .await?;
     Ok(())

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -681,6 +681,9 @@ pub fn return_value_v8_value(
     Arg::External(External::Ptr(_)) => {
       quote!(Ok(#deno_core::v8::External::new(#scope, #result as _).into()))
     }
+    Arg::SerdeV8(_) => {
+      quote!(#deno_core::_ops::serde_rust_to_v8(#scope, #result))
+    }
     _ => {
       return Err(V8MappingError::NoMapping(
         "a v8 return value",

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -1228,10 +1228,15 @@ mod tests {
         .trim_matches(|c| c == '[' || c == ']')
         .replace('\n', " ")
         .replace('"', "")
+        // Use the turbofish syntax (ugly but it's just for tests)
+        .replace('<', "::<")
     );
     assert_eq!(
       return_expected,
-      format!("{:?}", sig.ret_val).replace('"', "")
+      format!("{:?}", sig.ret_val)
+        .replace('"', "")
+        // Use the turbofish syntax (ugly but it's just for tests)
+        .replace('<', "::<")
     );
   }
 
@@ -1265,6 +1270,11 @@ mod tests {
   test!(
     #[serde] fn op_serde(#[serde] input: package::SerdeInputType) -> Result<package::SerdeReturnType, Error>;
     (SerdeV8(package::SerdeInputType)) -> Result(SerdeV8(package::SerdeReturnType))
+  );
+  // Note the turbofish syntax here because of macro constraints
+  test!(
+    #[serde] fn op_serde_option(#[serde] maybe: Option<package::SerdeInputType>) -> Result<Option<package::SerdeReturnType>, Error>;
+    (SerdeV8(Option::<package::SerdeInputType>)) -> Result(SerdeV8(Option::<package::SerdeReturnType>))
   );
   test!(
     #[serde] fn op_serde_tuple(#[serde] input: (A, B)) -> (A, B);


### PR DESCRIPTION
This was unimplemented for async function return values