### PR TITLE
fix: repository URL in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 authors = ["the Deno authors"]
 edition = "2021"
 license = "MIT"
-repository = "https://github.com/denoland/deno"
+repository = "https://github.com/denoland/deno_core"
 
 [workspace.dependencies]
 v8 = { version = "0.75.1", default-features = false }


### PR DESCRIPTION
Change the repository from `denoland/deno` to `denoland/deno_core` to fix the
information shown by https://crates.io/crates/deno_core

BTW is there a reason why Deno crates don't publish their API docs to https://docs.rs/?