### PR TITLE
fix(ops): Handle #[smi] types

### DIFF
--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -521,6 +521,9 @@ pub fn return_value_infallible(
     ArgMarker::Serde => {
       gs_quote!(generator_state(deno_core, result) => (#deno_core::_ops::RustToV8Marker::<#deno_core::_ops::SerdeMarker, _>::from(#result)))
     }
+    ArgMarker::Smi => {
+      gs_quote!(generator_state(deno_core, result) => (#deno_core::_ops::RustToV8Marker::<#deno_core::_ops::SmiMarker, _>::from(#result)))
+    }
     ArgMarker::None => gs_quote!(generator_state(result) => (#result)),
   };
   let res = match ret_type.slow_retval() {
@@ -578,6 +581,9 @@ pub fn return_value_v8_value(
   let result = match ret_type.marker() {
     ArgMarker::Serde => {
       quote!(#deno_core::_ops::RustToV8Marker::<#deno_core::_ops::SerdeMarker, _>::from(#result))
+    }
+    ArgMarker::Smi => {
+      quote!(#deno_core::_ops::RustToV8Marker::<#deno_core::_ops::SmiMarker, _>::from(#result))
     }
     ArgMarker::None => quote!(#result),
   };

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -354,6 +354,7 @@ impl Arg {
   pub fn marker(&self) -> ArgMarker {
     match self {
       Arg::SerdeV8(_) => ArgMarker::Serde,
+      Arg::Numeric(NumericArg::__SMI__) => ArgMarker::Smi,
       _ => ArgMarker::None,
     }
   }
@@ -382,7 +383,10 @@ pub enum ArgSlowRetval {
 /// Specifies an ArgMarker wrapper for a type used for trait-based serialization.
 pub enum ArgMarker {
   None,
+  /// This type should be serialized with serde_v8.
   Serde,
+  /// This type should be serialized as an SMI.
+  Smi,
 }
 
 pub enum ParsedType {

--- a/ops/op2/test_cases/async/async_result_smi.out
+++ b/ops/op2/test_cases/async/async_result_smi.out
@@ -59,10 +59,28 @@ impl op_async {
                 false,
                 promise_id,
                 result,
-                |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+                |scope, result| {
+                    Ok(
+                        deno_core::_ops::RustToV8::to_v8(
+                            deno_core::_ops::RustToV8Marker::<
+                                deno_core::_ops::SmiMarker,
+                                _,
+                            >::from(result),
+                            scope,
+                        ),
+                    )
+                },
             ) {
             match result {
-                Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
+                Ok(result) => {
+                    deno_core::_ops::RustToV8RetVal::to_v8_rv(
+                        deno_core::_ops::RustToV8Marker::<
+                            deno_core::_ops::SmiMarker,
+                            _,
+                        >::from(result),
+                        &mut rv,
+                    )
+                }
                 Err(err) => {
                     let err = err.into();
                     let exception = deno_core::error::to_v8_error(

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -112,7 +112,13 @@ impl op_smi_unsigned_return {
             let arg3 = arg3 as _;
             Self::call(arg0, arg1, arg2, arg3)
         };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(
+            deno_core::_ops::RustToV8Marker::<
+                deno_core::_ops::SmiMarker,
+                _,
+            >::from(result),
+            &mut rv,
+        )
     }
     #[inline(always)]
     fn call(a: Int16, b: Int32, c: Uint16, d: Uint32) -> Uint32 {
@@ -234,7 +240,13 @@ impl op_smi_signed_return {
             let arg3 = arg3 as _;
             Self::call(arg0, arg1, arg2, arg3)
         };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(
+            deno_core::_ops::RustToV8Marker::<
+                deno_core::_ops::SmiMarker,
+                _,
+            >::from(result),
+            &mut rv,
+        )
     }
     #[inline(always)]
     fn call(a: Int16, b: Int32, c: Uint16, d: Uint32) -> Int32 {


### PR DESCRIPTION
`#[smi]`-tagged arguments were going through the wrong path because I neglected to restore the custom `Numeric(__SMI__)` handling in  #165.

To fix this, we use a `RustToV8Marker` to override the default behaviour and ensure that SMIs are always serialized as v8 i32s. Fixes a Deno crash in the HTTP test.