### PR TITLE
chore(core): deprecate ResourceTable::close

### DIFF
--- a/core/resources.rs
+++ b/core/resources.rs
@@ -458,7 +458,7 @@ impl ResourceTable {
   /// counted, therefore pending ops are not automatically cancelled. A resource
   /// may implement the `close()` method to perform clean-ups such as canceling
   /// ops.
-  #[deprecated="This method may deadlock. Use take() and close() instead."]
+  #[deprecated = "This method may deadlock. Use take() and close() instead."]
   pub fn close(&mut self, rid: ResourceId) -> Result<(), Error> {
     self
       .index

--- a/core/resources.rs
+++ b/core/resources.rs
@@ -458,6 +458,7 @@ impl ResourceTable {
   /// counted, therefore pending ops are not automatically cancelled. A resource
   /// may implement the `close()` method to perform clean-ups such as canceling
   /// ops.
+  #[deprecated="This method may deadlock. Use take() and close() instead."]
   pub fn close(&mut self, rid: ResourceId) -> Result<(), Error> {
     self
       .index


### PR DESCRIPTION
Follow-up to #179 -- we don't want to use this method.