### PR TITLE
chore: enable source map handling for TS example

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -869,10 +869,10 @@ for (let i = 0; i < 10; i++) {
     setBuildInfo,
   });
 
-  ObjectAssign(globalThis.__bootstrap, { core });
   const internals = {};
-  ObjectAssign(globalThis.__bootstrap, { internals });
+  ObjectAssign(globalThis.__bootstrap, { core, internals });
   ObjectAssign(globalThis.Deno, { core });
+  ObjectFreeze(globalThis.__bootstrap.core);
 
   // Direct bindings on `globalThis`
   ObjectAssign(globalThis, { queueMicrotask });

--- a/core/02_error.js
+++ b/core/02_error.js
@@ -6,8 +6,6 @@
   const ops = core.ops;
   const {
     Error,
-    ObjectFreeze,
-    ObjectAssign,
     StringPrototypeStartsWith,
     StringPrototypeEndsWith,
     ObjectDefineProperties,
@@ -152,6 +150,5 @@
       );
   }
 
-  ObjectAssign(globalThis.__bootstrap.core, { prepareStackTrace });
-  ObjectFreeze(globalThis.__bootstrap.core);
+  Error.prepareStackTrace = prepareStackTrace;
 })(this);

--- a/core/runtime/tests/misc.rs
+++ b/core/runtime/tests/misc.rs
@@ -967,7 +967,6 @@ async fn test_dynamic_import_module_error_stack() {
       Url::parse("file:///main.js").unwrap(),
       ascii_str!(
         "
-        Error.prepareStackTrace = Deno.core.prepareStackTrace;
         await import(\"file:///import.js\");
         "
       ),


### PR DESCRIPTION
Also always enables `Error.prepareStackTrace` so that users of
`deno_core` don't need to set it up themselves.
