### PR TITLE
feat: add core.currentUserCallSite()

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -800,6 +800,16 @@ for (let i = 0; i < 10; i++) {
     op_shutdown: shutdown,
   } = ensureFastOps();
 
+  const callSiteRetBuf = new Uint32Array(2);
+  const callSiteRetBufU8 = new Uint8Array(callSiteRetBuf.buffer);
+
+  function currentUserCallSite() {
+    const fileName = ops.op_current_user_call_site(callSiteRetBufU8);
+    const lineNumber = callSiteRetBuf[0];
+    const columnNumber = callSiteRetBuf[1];
+    return { fileName, lineNumber, columnNumber };
+  }
+
   // Extra Deno.core.* exports
   const core = ObjectAssign(globalThis.Deno.core, {
     asyncStub,
@@ -867,6 +877,7 @@ for (let i = 0; i < 10; i++) {
     byteLength: (str) => ops.op_str_byte_length(str),
     build,
     setBuildInfo,
+    currentUserCallSite,
   });
 
   const internals = {};

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -75,6 +75,7 @@ crate::extension!(
     ops_builtin_v8::op_op_names,
     ops_builtin_v8::op_apply_source_map,
     ops_builtin_v8::op_apply_source_map_filename,
+    ops_builtin_v8::op_current_user_call_site,
     ops_builtin_v8::op_set_format_exception_callback,
     ops_builtin_v8::op_event_loop_has_more_work,
     ops_builtin_v8::op_store_pending_promise_rejection,

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -501,6 +501,22 @@ fn test_dispatch_stack_zero_copy_bufs() {
   assert_eq!(dispatch_count.load(Ordering::Relaxed), 1);
 }
 
+#[test]
+fn test_call_site() {
+  let (mut runtime, _) = setup(Mode::Async);
+  runtime
+    .execute_script_static(
+      "file:///filename.js",
+      r#"
+      const cs = Deno.core.currentUserCallSite();
+      assert(cs.fileName === "file:///filename.js");
+      assert(cs.lineNumber === 2);
+      assert(cs.columnNumber === 28);
+    "#,
+    )
+    .unwrap();
+}
+
 /// Test that long-running ops do not block dynamic imports from loading.
 // https://github.com/denoland/deno/issues/19903
 // https://github.com/denoland/deno/issues/19455

--- a/core/source_map.rs
+++ b/core/source_map.rs
@@ -64,6 +64,8 @@ pub enum SourceMapApplication {
 /// Apply a source map to the passed location. If there is no source map for
 /// this location, or if the location remains unchanged after mapping, the
 /// changed values are returned.
+///
+/// Line and column numbers are 1-based.
 pub fn apply_source_map<G: SourceMapGetter + ?Sized>(
   file_name: &str,
   line_number: u32,


### PR DESCRIPTION
This function returns the first call site in the current stack that is
"user" code, i.e. has a file name starting with neither `ext:` or
`node:`.