### PR TITLE
fix(ops): use explicit RefCell borrow/borrow_mut

### DIFF
--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -270,6 +270,14 @@ macro_rules! try_bignum {
   };
 }
 
+pub fn opstate_borrow<T: 'static>(state: &OpState) -> &T {
+  state.borrow()
+}
+
+pub fn opstate_borrow_mut<T: 'static>(state: &mut OpState) -> &mut T {
+  state.borrow_mut()
+}
+
 pub fn to_u32_option(number: &v8::Value) -> Option<i32> {
   try_number_some!(number Integer is_uint32);
   try_number_some!(number Int32 is_int32);

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -597,6 +597,7 @@ mod tests {
   use crate::error::generic_error;
   use crate::error::AnyError;
   use crate::error::JsError;
+  use crate::runtime::JsRuntimeState;
   use crate::FastString;
   use crate::JsRuntime;
   use crate::OpState;
@@ -655,6 +656,8 @@ mod tests {
       op_test_v8_type_handle_scope_result,
       op_test_v8_global,
       op_test_serde_v8,
+      op_jsruntimestate,
+      op_jsruntimestate_mut,
       op_state_rc,
       op_state_ref,
       op_state_mut,
@@ -1421,6 +1424,19 @@ mod tests {
       "op_test_serde_v8",
       "try { op_test_serde_v8({}); assert(false) } catch (e) { assertErrorContains(e, 'missing field') }",
     )?;
+    Ok(())
+  }
+
+  #[op2(core, fast)]
+  pub fn op_jsruntimestate(_state: &JsRuntimeState) {}
+
+  #[op2(core, fast)]
+  pub fn op_jsruntimestate_mut(_state: &mut JsRuntimeState) {}
+
+  #[tokio::test]
+  pub async fn test_jsruntimestate() -> Result<(), Box<dyn std::error::Error>> {
+    run_test2(10000, "op_jsruntimestate", "op_jsruntimestate()")?;
+    run_test2(10000, "op_jsruntimestate_mut", "op_jsruntimestate_mut()")?;
     Ok(())
   }
 

--- a/ops/lib.rs
+++ b/ops/lib.rs
@@ -395,7 +395,7 @@ fn opstate_arg(arg: &FnArg) -> Option<TokenStream2> {
   match arg {
     arg if is_rc_refcell_opstate(arg) => Some(quote! { ctx.state.clone(), }),
     arg if is_mut_ref_opstate(arg) => {
-      Some(quote! { &mut std::cell::RefCell::borrow_mut(&ctx.state), })
+      Some(quote! { &mut ::std::cell::RefCell::borrow_mut(&ctx.state), })
     }
     _ => None,
   }
@@ -435,7 +435,7 @@ fn codegen_v8_sync(
   let fast_error_handler = if has_fallible_fast_call {
     quote! {
       {
-        let op_state = &mut std::cell::RefCell::borrow_mut(&ctx.state);
+        let op_state = &mut ::std::cell::RefCell::borrow_mut(&ctx.state);
         if let Some(err) = op_state.last_fast_op_error.take() {
           let exception = #core::error::to_v8_error(scope, ctx.get_error_class_fn, &err);
           scope.throw_exception(exception);

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -344,11 +344,11 @@ fn map_v8_fastcall_arg_to_arg(
     }
     Arg::Ref(RefType::Ref, Special::JsRuntimeState) => {
       *needs_js_runtime_state = true;
-      quote!(let #arg_ident = &::std::cell::RefCell::borrow(#js_runtime_state);)
+      quote!(let #arg_ident = &::std::cell::RefCell::borrow(&#js_runtime_state);)
     }
     Arg::Ref(RefType::Mut, Special::JsRuntimeState) => {
       *needs_js_runtime_state = true;
-      quote!(let #arg_ident = &mut ::std::cell::RefCell::borrow_mut(#js_runtime_state);)
+      quote!(let #arg_ident = &mut ::std::cell::RefCell::borrow_mut(&#js_runtime_state);)
     }
     Arg::RcRefCell(Special::JsRuntimeState) => {
       *needs_js_runtime_state = true;

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -332,11 +332,11 @@ fn map_v8_fastcall_arg_to_arg(
     }
     Arg::Ref(RefType::Ref, Special::OpState) => {
       *needs_opctx = true;
-      quote!(let #arg_ident = &#opctx.state.borrow();)
+      quote!(let #arg_ident = &::std::cell::RefCell::borrow(&#opctx.state);)
     }
     Arg::Ref(RefType::Mut, Special::OpState) => {
       *needs_opctx = true;
-      quote!(let #arg_ident = &mut #opctx.state.borrow_mut();)
+      quote!(let #arg_ident = &mut ::std::cell::RefCell::borrow_mut(&#opctx.state);)
     }
     Arg::RcRefCell(Special::OpState) => {
       *needs_opctx = true;
@@ -344,11 +344,11 @@ fn map_v8_fastcall_arg_to_arg(
     }
     Arg::Ref(RefType::Ref, Special::JsRuntimeState) => {
       *needs_js_runtime_state = true;
-      quote!(let #arg_ident = &#js_runtime_state.borrow();)
+      quote!(let #arg_ident = &::std::cell::RefCell::borrow(#js_runtime_state);)
     }
     Arg::Ref(RefType::Mut, Special::JsRuntimeState) => {
       *needs_js_runtime_state = true;
-      quote!(let #arg_ident = &mut #js_runtime_state.borrow_mut();)
+      quote!(let #arg_ident = &mut ::std::cell::RefCell::borrow_mut(#js_runtime_state);)
     }
     Arg::RcRefCell(Special::JsRuntimeState) => {
       *needs_js_runtime_state = true;
@@ -359,8 +359,8 @@ fn map_v8_fastcall_arg_to_arg(
       let state =
         syn::parse_str::<Type>(state).expect("Failed to reparse state type");
       quote! {
-        let #arg_ident = #opctx.state.borrow();
-        let #arg_ident = #arg_ident.borrow::<#state>();
+        let #arg_ident = ::std::cell::RefCell::borrow(&#opctx.state);
+        let #arg_ident = #deno_core::_ops::opstate_borrow::<#state>(&#arg_ident);
       }
     }
     Arg::State(RefType::Mut, state) => {
@@ -368,8 +368,8 @@ fn map_v8_fastcall_arg_to_arg(
       let state =
         syn::parse_str::<Type>(state).expect("Failed to reparse state type");
       quote! {
-        let mut #arg_ident = #opctx.state.borrow_mut();
-        let #arg_ident = #arg_ident.borrow_mut::<#state>();
+        let mut #arg_ident = ::std::cell::RefCell::borrow_mut(&#opctx.state);
+        let #arg_ident = #deno_core::_ops::opstate_borrow_mut::<#state>(&mut #arg_ident);
       }
     }
     Arg::OptionState(RefType::Ref, state) => {
@@ -377,7 +377,7 @@ fn map_v8_fastcall_arg_to_arg(
       let state =
         syn::parse_str::<Type>(state).expect("Failed to reparse state type");
       quote! {
-        let #arg_ident = #opctx.state.borrow();
+        let #arg_ident = &::std::cell::RefCell::borrow(&#opctx.state);
         let #arg_ident = #arg_ident.try_borrow::<#state>();
       }
     }
@@ -386,7 +386,7 @@ fn map_v8_fastcall_arg_to_arg(
       let state =
         syn::parse_str::<Type>(state).expect("Failed to reparse state type");
       quote! {
-        let mut #arg_ident = #opctx.state.borrow_mut();
+        let mut #arg_ident = &mut ::std::cell::RefCell::borrow_mut(&#opctx.state);
         let #arg_ident = #arg_ident.try_borrow_mut::<#state>();
       }
     }

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -353,11 +353,11 @@ pub fn from_arg(
     }
     Arg::Ref(RefType::Ref, Special::OpState) => {
       *needs_opstate = true;
-      quote!(let #arg_ident = &#opstate.borrow();)
+      quote!(let #arg_ident = &::std::cell::RefCell::borrow(&#opstate);)
     }
     Arg::Ref(RefType::Mut, Special::OpState) => {
       *needs_opstate = true;
-      quote!(let #arg_ident = &mut #opstate.borrow_mut();)
+      quote!(let #arg_ident = &mut ::std::cell::RefCell::borrow_mut(&#opstate);)
     }
     Arg::RcRefCell(Special::OpState) => {
       *needs_opstate = true;
@@ -365,11 +365,11 @@ pub fn from_arg(
     }
     Arg::Ref(RefType::Ref, Special::JsRuntimeState) => {
       *needs_js_runtime_state = true;
-      quote!(let #arg_ident = &#js_runtime_state.borrow();)
+      quote!(let #arg_ident = &::std::cell::RefCell::borrow(&#js_runtime_state);)
     }
     Arg::Ref(RefType::Mut, Special::JsRuntimeState) => {
       *needs_js_runtime_state = true;
-      quote!(let #arg_ident = &mut #js_runtime_state.borrow_mut();)
+      quote!(let #arg_ident = &mut ::std::cell::RefCell::borrow_mut(&#js_runtime_state);)
     }
     Arg::RcRefCell(Special::JsRuntimeState) => {
       *needs_js_runtime_state = true;
@@ -380,8 +380,8 @@ pub fn from_arg(
       let state =
         syn::parse_str::<Type>(state).expect("Failed to reparse state type");
       quote! {
-        let #arg_ident = #opstate.borrow();
-        let #arg_ident = #arg_ident.borrow::<#state>();
+        let #arg_ident = ::std::cell::RefCell::borrow(&#opstate);
+        let #arg_ident = #deno_core::_ops::opstate_borrow::<#state>(&#arg_ident);
       }
     }
     Arg::State(RefType::Mut, state) => {
@@ -389,8 +389,8 @@ pub fn from_arg(
       let state =
         syn::parse_str::<Type>(state).expect("Failed to reparse state type");
       quote! {
-        let mut #arg_ident = #opstate.borrow_mut();
-        let #arg_ident = #arg_ident.borrow_mut::<#state>();
+        let mut #arg_ident = ::std::cell::RefCell::borrow_mut(&#opstate);
+        let #arg_ident = #deno_core::_ops::opstate_borrow_mut::<#state>(&mut #arg_ident);
       }
     }
     Arg::OptionState(RefType::Ref, state) => {
@@ -398,7 +398,7 @@ pub fn from_arg(
       let state =
         syn::parse_str::<Type>(state).expect("Failed to reparse state type");
       quote! {
-        let #arg_ident = #opstate.borrow();
+        let #arg_ident = &::std::cell::RefCell::borrow(&#opstate);
         let #arg_ident = #arg_ident.try_borrow::<#state>();
       }
     }
@@ -407,7 +407,7 @@ pub fn from_arg(
       let state =
         syn::parse_str::<Type>(state).expect("Failed to reparse state type");
       quote! {
-        let mut #arg_ident = #opstate.borrow_mut();
+        let mut #arg_ident = &mut ::std::cell::RefCell::borrow_mut(&#opstate);
         let #arg_ident = #arg_ident.try_borrow_mut::<#state>();
       }
     }

--- a/ops/op2/test_cases/sync/op_state_attr.out
+++ b/ops/op2/test_cases/sync/op_state_attr.out
@@ -42,9 +42,9 @@ impl op_state_rc {
                 .value() as *const deno_core::_ops::OpCtx)
         };
         let result = {
-            let arg0 = opctx.state.borrow();
-            let arg0 = arg0.borrow::<Something>();
-            let arg1 = opctx.state.borrow();
+            let arg0 = ::std::cell::RefCell::borrow(&opctx.state);
+            let arg0 = deno_core::_ops::opstate_borrow::<Something>(&arg0);
+            let arg1 = &::std::cell::RefCell::borrow(&opctx.state);
             let arg1 = arg1.try_borrow::<Something>();
             Self::call(arg0, arg1)
         };
@@ -63,9 +63,9 @@ impl op_state_rc {
         };
         let opstate = &opctx.state;
         let result = {
-            let arg0 = opstate.borrow();
-            let arg0 = arg0.borrow::<Something>();
-            let arg1 = opstate.borrow();
+            let arg0 = ::std::cell::RefCell::borrow(&opstate);
+            let arg0 = deno_core::_ops::opstate_borrow::<Something>(&arg0);
+            let arg1 = &::std::cell::RefCell::borrow(&opstate);
             let arg1 = arg1.try_borrow::<Something>();
             Self::call(arg0, arg1)
         };

--- a/ops/op2/test_cases/sync/op_state_attr.rs
+++ b/ops/op2/test_cases/sync/op_state_attr.rs
@@ -2,6 +2,12 @@
 #![deny(warnings)]
 deno_ops_compile_test_runner::prelude!();
 
+// Test w/ import pollution
+#[allow(unused)]
+use std::borrow::Borrow;
+#[allow(unused)]
+use std::borrow::BorrowMut;
+
 struct Something {}
 
 #[op2(fast)]

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -42,7 +42,7 @@ impl op_state_ref {
                 .value() as *const deno_core::_ops::OpCtx)
         };
         let result = {
-            let arg0 = &opctx.state.borrow();
+            let arg0 = &::std::cell::RefCell::borrow(&opctx.state);
             Self::call(arg0)
         };
         result as _
@@ -60,11 +60,145 @@ impl op_state_ref {
         };
         let opstate = &opctx.state;
         let result = {
-            let arg0 = &opstate.borrow();
+            let arg0 = &::std::cell::RefCell::borrow(&opstate);
             Self::call(arg0)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     #[inline(always)]
     fn call(_state: &OpState) {}
+}
+
+#[allow(non_camel_case_types)]
+struct op_state_mut {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
+impl deno_core::_ops::Op for op_state_mut {
+    const NAME: &'static str = stringify!(op_state_mut);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_state_mut),
+        false,
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::CallbackOptions],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+    );
+}
+impl op_state_mut {
+    pub const fn name() -> &'static str {
+        stringify!(op_state_mut)
+    }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
+    }
+    fn v8_fn_ptr_fast(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        let result = {
+            let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opctx.state);
+            Self::call(arg0)
+        };
+        result as _
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+            &*info
+        });
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        let opstate = &opctx.state;
+        let result = {
+            let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opstate);
+            Self::call(arg0)
+        };
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    #[inline(always)]
+    fn call(_state: &mut OpState) {}
+}
+
+#[allow(non_camel_case_types)]
+struct op_state_and_v8 {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
+impl deno_core::_ops::Op for op_state_and_v8 {
+    const NAME: &'static str = stringify!(op_state_and_v8);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+        stringify!(op_state_and_v8),
+        false,
+        false,
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        None,
+    );
+}
+impl op_state_and_v8 {
+    pub const fn name() -> &'static str {
+        stringify!(op_state_and_v8)
+    }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+            &*info
+        });
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        let mut scope = unsafe { &mut *opctx.isolate };
+        let opstate = &opctx.state;
+        let result = {
+            let arg1 = args.get(0usize as i32);
+            let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
+                deno_core::v8::Function,
+            >(arg1) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        "expected Function".as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return;
+            };
+            let arg1 = deno_core::v8::Global::new(&mut scope, arg1);
+            let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opstate);
+            Self::call(arg0, arg1)
+        };
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    #[inline(always)]
+    fn call(_state: &mut OpState, _callback: v8::Global<v8::Function>) {}
 }

--- a/ops/op2/test_cases/sync/op_state_ref.rs
+++ b/ops/op2/test_cases/sync/op_state_ref.rs
@@ -3,6 +3,19 @@
 deno_ops_compile_test_runner::prelude!();
 
 use deno_core::OpState;
+use deno_core::v8;
+
+// Test w/ import pollution
+#[allow(unused)]
+use std::borrow::Borrow;
+#[allow(unused)]
+use std::borrow::BorrowMut;
 
 #[op2(fast)]
 fn op_state_ref(_state: &OpState) {}
+
+#[op2(fast)]
+fn op_state_mut(_state: &mut OpState) {}
+
+#[op2]
+fn op_state_and_v8(_state: &mut OpState, #[global] _callback: v8::Global<v8::Function>) {}

--- a/ops/optimizer_tests/op_blob_revoke_object_url.out
+++ b/ops/optimizer_tests/op_blob_revoke_object_url.out
@@ -66,7 +66,10 @@ impl op_blob_revoke_object_url {
                 );
             }
         };
-        let result = Self::call(&mut std::cell::RefCell::borrow_mut(&ctx.state), arg_0);
+        let result = Self::call(
+            &mut ::std::cell::RefCell::borrow_mut(&ctx.state),
+            arg_0,
+        );
         let op_state = ::std::cell::RefCell::borrow(&*ctx.state);
         op_state.tracker.track_sync(ctx.id);
         match result {

--- a/ops/optimizer_tests/op_print.out
+++ b/ops/optimizer_tests/op_print.out
@@ -78,7 +78,7 @@ impl op_print {
             }
         };
         let result = Self::call(
-            &mut std::cell::RefCell::borrow_mut(&ctx.state),
+            &mut ::std::cell::RefCell::borrow_mut(&ctx.state),
             arg_0,
             arg_1,
         );

--- a/ops/optimizer_tests/op_state.out
+++ b/ops/optimizer_tests/op_state.out
@@ -73,7 +73,10 @@ impl op_set_exit_code {
                 return deno_core::_ops::throw_type_error(scope, msg);
             }
         };
-        let result = Self::call(&mut std::cell::RefCell::borrow_mut(&ctx.state), arg_0);
+        let result = Self::call(
+            &mut ::std::cell::RefCell::borrow_mut(&ctx.state),
+            arg_0,
+        );
         let op_state = ::std::cell::RefCell::borrow(&*ctx.state);
         op_state.tracker.track_sync(ctx.id);
     }

--- a/ops/optimizer_tests/op_state_basic1.out
+++ b/ops/optimizer_tests/op_state_basic1.out
@@ -85,7 +85,7 @@ impl foo {
             }
         };
         let result = Self::call(
-            &mut std::cell::RefCell::borrow_mut(&ctx.state),
+            &mut ::std::cell::RefCell::borrow_mut(&ctx.state),
             arg_0,
             arg_1,
         );

--- a/ops/optimizer_tests/op_state_generics.out
+++ b/ops/optimizer_tests/op_state_generics.out
@@ -66,7 +66,7 @@ where
             &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
                 as *const deno_core::_ops::OpCtx)
         };
-        let result = Self::call(&mut std::cell::RefCell::borrow_mut(&ctx.state));
+        let result = Self::call(&mut ::std::cell::RefCell::borrow_mut(&ctx.state));
         let op_state = ::std::cell::RefCell::borrow(&*ctx.state);
         op_state.tracker.track_sync(ctx.id);
     }

--- a/ops/optimizer_tests/op_state_result.out
+++ b/ops/optimizer_tests/op_state_result.out
@@ -63,7 +63,7 @@ impl foo {
                 as *const deno_core::_ops::OpCtx)
         };
         {
-            let op_state = &mut std::cell::RefCell::borrow_mut(&ctx.state);
+            let op_state = &mut ::std::cell::RefCell::borrow_mut(&ctx.state);
             if let Some(err) = op_state.last_fast_op_error.take() {
                 let exception = deno_core::error::to_v8_error(
                     scope,
@@ -97,7 +97,7 @@ impl foo {
             }
         };
         let result = Self::call(
-            &mut std::cell::RefCell::borrow_mut(&ctx.state),
+            &mut ::std::cell::RefCell::borrow_mut(&ctx.state),
             arg_0,
             arg_1,
         );

--- a/ops/optimizer_tests/op_state_warning.out
+++ b/ops/optimizer_tests/op_state_warning.out
@@ -69,7 +69,7 @@ impl op_listen {
                 as *const deno_core::_ops::OpCtx)
         };
         {
-            let op_state = &mut std::cell::RefCell::borrow_mut(&ctx.state);
+            let op_state = &mut ::std::cell::RefCell::borrow_mut(&ctx.state);
             if let Some(err) = op_state.last_fast_op_error.take() {
                 let exception = deno_core::error::to_v8_error(
                     scope,
@@ -80,7 +80,7 @@ impl op_listen {
                 return;
             }
         }
-        let result = Self::call(&mut std::cell::RefCell::borrow_mut(&ctx.state));
+        let result = Self::call(&mut ::std::cell::RefCell::borrow_mut(&ctx.state));
         let op_state = ::std::cell::RefCell::borrow(&*ctx.state);
         op_state.tracker.track_sync(ctx.id);
         match result {

--- a/ops/optimizer_tests/op_state_with_transforms.out
+++ b/ops/optimizer_tests/op_state_with_transforms.out
@@ -110,7 +110,10 @@ where
                 }
             }
         };
-        let result = Self::call(&mut std::cell::RefCell::borrow_mut(&ctx.state), arg_0);
+        let result = Self::call(
+            &mut ::std::cell::RefCell::borrow_mut(&ctx.state),
+            arg_0,
+        );
         let op_state = ::std::cell::RefCell::borrow(&*ctx.state);
         op_state.tracker.track_sync(ctx.id);
     }

--- a/ops/optimizer_tests/opstate_with_arity.out
+++ b/ops/optimizer_tests/opstate_with_arity.out
@@ -63,7 +63,7 @@ impl op_add_4 {
                 as *const deno_core::_ops::OpCtx)
         };
         {
-            let op_state = &mut std::cell::RefCell::borrow_mut(&ctx.state);
+            let op_state = &mut ::std::cell::RefCell::borrow_mut(&ctx.state);
             if let Some(err) = op_state.last_fast_op_error.take() {
                 let exception = deno_core::error::to_v8_error(
                     scope,

--- a/ops/optimizer_tests/option_arg.out
+++ b/ops/optimizer_tests/option_arg.out
@@ -64,7 +64,10 @@ impl op_try_close {
                 return deno_core::_ops::throw_type_error(scope, msg);
             }
         };
-        let result = Self::call(&mut std::cell::RefCell::borrow_mut(&ctx.state), arg_0);
+        let result = Self::call(
+            &mut ::std::cell::RefCell::borrow_mut(&ctx.state),
+            arg_0,
+        );
         let op_state = ::std::cell::RefCell::borrow(&*ctx.state);
         op_state.tracker.track_sync(ctx.id);
         match result {

--- a/ops/optimizer_tests/param_mut_binding_warning.out
+++ b/ops/optimizer_tests/param_mut_binding_warning.out
@@ -79,7 +79,7 @@ impl op_read_sync {
             }
         };
         let result = Self::call(
-            &mut std::cell::RefCell::borrow_mut(&ctx.state),
+            &mut ::std::cell::RefCell::borrow_mut(&ctx.state),
             arg_0,
             arg_1,
         );

--- a/ops/optimizer_tests/raw_ptr.out
+++ b/ops/optimizer_tests/raw_ptr.out
@@ -141,7 +141,7 @@ where
             );
         };
         let result = Self::call(
-            &mut std::cell::RefCell::borrow_mut(&ctx.state),
+            &mut ::std::cell::RefCell::borrow_mut(&ctx.state),
             arg_0,
             arg_1,
         );

--- a/ops/optimizer_tests/u64_result.out
+++ b/ops/optimizer_tests/u64_result.out
@@ -54,7 +54,7 @@ impl op_bench_now {
             &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
                 as *const deno_core::_ops::OpCtx)
         };
-        let result = Self::call(&mut std::cell::RefCell::borrow_mut(&ctx.state));
+        let result = Self::call(&mut ::std::cell::RefCell::borrow_mut(&ctx.state));
         let op_state = ::std::cell::RefCell::borrow(&*ctx.state);
         op_state.tracker.track_sync(ctx.id);
         match result {

--- a/ops/optimizer_tests/unit_result.out
+++ b/ops/optimizer_tests/unit_result.out
@@ -63,7 +63,7 @@ impl op_unit_result {
                 as *const deno_core::_ops::OpCtx)
         };
         {
-            let op_state = &mut std::cell::RefCell::borrow_mut(&ctx.state);
+            let op_state = &mut ::std::cell::RefCell::borrow_mut(&ctx.state);
             if let Some(err) = op_state.last_fast_op_error.take() {
                 let exception = deno_core::error::to_v8_error(
                     scope,

--- a/ops/optimizer_tests/unit_result2.out
+++ b/ops/optimizer_tests/unit_result2.out
@@ -70,7 +70,7 @@ impl op_set_nodelay {
                 as *const deno_core::_ops::OpCtx)
         };
         {
-            let op_state = &mut std::cell::RefCell::borrow_mut(&ctx.state);
+            let op_state = &mut ::std::cell::RefCell::borrow_mut(&ctx.state);
             if let Some(err) = op_state.last_fast_op_error.take() {
                 let exception = deno_core::error::to_v8_error(
                     scope,
@@ -104,7 +104,7 @@ impl op_set_nodelay {
             }
         };
         let result = Self::call(
-            &mut std::cell::RefCell::borrow_mut(&ctx.state),
+            &mut ::std::cell::RefCell::borrow_mut(&ctx.state),
             arg_0,
             arg_1,
         );


### PR DESCRIPTION
If a user imports the common `std::borrow::Borrow` or `std::borrow::BorrowMut` traits, `op2` tends to behave badly. Any method that looks like one of these should be fully-qualified.