### PR TITLE
feat: add JsRuntime::op_names

### DIFF
--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1180,6 +1180,18 @@ impl JsRuntime {
     state.op_state.clone()
   }
 
+  /// Returns the runtime's op names, ordered by OpId.
+  pub fn op_names(&self) -> Vec<String> {
+    let main_realm = self.inner.main_realm.as_ref().unwrap().clone();
+    let state_rc = main_realm.0.state();
+    let state = state_rc.borrow();
+    state
+      .op_ctxs
+      .iter()
+      .map(|o| o.decl.name.to_string())
+      .collect()
+  }
+
   /// Executes traditional JavaScript code (traditional = not ES modules).
   ///
   /// The execution takes place on the current main realm, so it is possible

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1181,15 +1181,11 @@ impl JsRuntime {
   }
 
   /// Returns the runtime's op names, ordered by OpId.
-  pub fn op_names(&self) -> Vec<String> {
+  pub fn op_names(&self) -> Vec<&'static str> {
     let main_realm = self.inner.main_realm.as_ref().unwrap().clone();
     let state_rc = main_realm.0.state();
     let state = state_rc.borrow();
-    state
-      .op_ctxs
-      .iter()
-      .map(|o| o.decl.name.to_string())
-      .collect()
+    state.op_ctxs.iter().map(|o| o.decl.name).collect()
   }
 
   /// Executes traditional JavaScript code (traditional = not ES modules).

--- a/core/runtime/tests/jsrealm.rs
+++ b/core/runtime/tests/jsrealm.rs
@@ -176,6 +176,9 @@ fn js_realm_init() {
     .execute_script_static(runtime.v8_isolate(), "", "Deno.core.ops.op_test()")
     .unwrap();
 
+  let op_names = runtime.op_names();
+  assert_eq!(op_names[op_names.len() - 1], "op_test");
+
   let scope = &mut realm.handle_scope(runtime.v8_isolate());
   assert_eq!(ret, serde_v8::to_v8(scope, "Test").unwrap());
 }


### PR DESCRIPTION
This is needed in order to implement `Deno.metrics()` equivalent in Rust.