### PR TITLE
fix(ops): roundtrip external null pointers as JS null

### DIFF
--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -327,6 +327,8 @@ pub fn to_external_option(external: &v8::Value) -> Option<*mut c_void> {
     // SAFETY: We know this is an external
     let external: &v8::External = unsafe { std::mem::transmute(external) };
     Some(external.value())
+  } else if external.is_null() {
+    Some(0 as _)
   } else {
     None
   }
@@ -670,6 +672,8 @@ mod tests {
       op_buffer_bytesmut,
       op_external_make,
       op_external_process,
+      op_external_make_null,
+      op_external_process_null,
 
       op_async_void,
       op_async_number,
@@ -1698,6 +1702,29 @@ mod tests {
       10000,
       "op_external_make, op_external_process",
       "op_external_process(op_external_make())",
+    )?;
+    Ok(())
+  }
+
+  #[op2(core, fast)]
+  fn op_external_make_null() -> *const std::ffi::c_void {
+    0 as _
+  }
+
+  #[op2(core, fast)]
+  fn op_external_process_null(
+    input: *const std::ffi::c_void,
+  ) -> *const std::ffi::c_void {
+    assert_eq!(input, 0 as _);
+    input
+  }
+
+  #[tokio::test]
+  pub async fn test_external_null() -> Result<(), Box<dyn std::error::Error>> {
+    run_test2(
+      10000,
+      "op_external_make_null, op_external_process_null",
+      "assert(op_external_process_null(op_external_make_null()) === null)",
     )?;
     Ok(())
   }

--- a/core/runtime/ops_rust_to_v8.rs
+++ b/core/runtime/ops_rust_to_v8.rs
@@ -278,7 +278,13 @@ to_v8_retval!((f32, f64): |value, rv| rv.set_double(value as _));
 // Heavier primitives with no retval shortcuts
 //
 
-to_v8!((*const c_void, *mut c_void): |value, scope| v8::External::new(scope, value as _));
+to_v8!((*const c_void, *mut c_void): |value, scope| {
+  if value.is_null() {
+    v8::Local::<v8::Value>::from(v8::null(scope))
+  } else {
+    v8::Local::<v8::Value>::from(v8::External::new(scope, value as _))
+  }
+});
 to_v8!((u64, usize): |value, scope| v8::BigInt::new_from_u64(scope, value as _));
 to_v8!((i64, isize): |value, scope| v8::BigInt::new_from_i64(scope, value as _));
 


### PR DESCRIPTION
This matches the behaviour of the Fast API path.

Constructing v8:Externals with null pointers is undefined behaviour and may cause problems once pointer compression is turned on.

Closes #235