### PR TITLE
feat(ops): zero-cost-if-unused, pluggable metrics for op2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 # Use Unix line endings in all text files.
 * text=auto eol=lf
 *.png -text
+*.out linguist-generated=true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pin-project",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "serde_v8",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -49,6 +49,7 @@ path = "examples/http_bench_json_ops/main.rs"
 cooked-waker.workspace = true
 deno_ast.workspace = true
 bencher.workspace = true
+pretty_assertions.workspace = true
 
 [[bench]]
 name = "ops_sync"

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -100,7 +100,7 @@ pub struct OpDecl {
   pub is_v8: bool,
   pub arg_count: u8,
   pub(crate) slow_fn: OpFnRef,
-  pub(crate) slow_fn_metrics: Option<OpFnRef>,
+  pub(crate) slow_fn_metrics: OpFnRef,
   pub(crate) fast_fn: Option<FastFunction>,
   pub(crate) fast_fn_metrics: Option<FastFunction>,
 }
@@ -125,9 +125,9 @@ impl OpDecl {
       is_v8,
       arg_count,
       slow_fn,
-      slow_fn_metrics: None,
+      slow_fn_metrics: slow_fn,
       fast_fn,
-      fast_fn_metrics: None,
+      fast_fn_metrics: fast_fn,
     }
   }
 
@@ -150,7 +150,7 @@ impl OpDecl {
       is_v8: false,
       arg_count,
       slow_fn,
-      slow_fn_metrics: Some(slow_fn_metrics),
+      slow_fn_metrics,
       fast_fn,
       fast_fn_metrics,
     }

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -175,9 +175,9 @@ impl OpDecl {
   pub const fn with_implementation_from(self, from: &Self) -> Self {
     Self {
       slow_fn: from.slow_fn,
-      slow_fn_metrics: from.slow_fn_metrics,
+      slow_fn_with_metrics: from.slow_fn_with_metrics,
       fast_fn: from.fast_fn,
-      fast_fn_metrics: from.fast_fn_metrics,
+      fast_fn_with_metrics: from.fast_fn_with_metrics,
       ..self
     }
   }

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -99,8 +99,10 @@ pub struct OpDecl {
   pub is_unstable: bool,
   pub is_v8: bool,
   pub arg_count: u8,
-  pub(crate) v8_fn_ptr: OpFnRef,
+  pub(crate) slow_fn: OpFnRef,
+  pub(crate) slow_fn_metrics: Option<OpFnRef>,
   pub(crate) fast_fn: Option<FastFunction>,
+  pub(crate) fast_fn_metrics: Option<FastFunction>,
 }
 
 impl OpDecl {
@@ -112,7 +114,7 @@ impl OpDecl {
     is_unstable: bool,
     is_v8: bool,
     arg_count: u8,
-    v8_fn_ptr: OpFnRef,
+    slow_fn: OpFnRef,
     fast_fn: Option<FastFunction>,
   ) -> Self {
     Self {
@@ -122,8 +124,35 @@ impl OpDecl {
       is_unstable,
       is_v8,
       arg_count,
-      v8_fn_ptr,
+      slow_fn,
+      slow_fn_metrics: None,
       fast_fn,
+      fast_fn_metrics: None,
+    }
+  }
+
+  /// For use by internal op implementation only.
+  #[doc(hidden)]
+  pub const fn new_internal_op2(
+    name: &'static str,
+    is_async: bool,
+    arg_count: u8,
+    slow_fn: OpFnRef,
+    slow_fn_metrics: OpFnRef,
+    fast_fn: Option<FastFunction>,
+    fast_fn_metrics: Option<FastFunction>,
+  ) -> Self {
+    Self {
+      name,
+      enabled: true,
+      is_async,
+      is_unstable: false,
+      is_v8: false,
+      arg_count,
+      slow_fn,
+      slow_fn_metrics: Some(slow_fn_metrics),
+      fast_fn,
+      fast_fn_metrics,
     }
   }
 
@@ -141,8 +170,10 @@ impl OpDecl {
   /// `OpDecl`.
   pub const fn with_implementation_from(self, from: &Self) -> Self {
     Self {
-      v8_fn_ptr: from.v8_fn_ptr,
+      slow_fn: from.slow_fn,
+      slow_fn_metrics: from.slow_fn_metrics,
       fast_fn: from.fast_fn,
+      fast_fn_metrics: from.fast_fn_metrics,
       ..self
     }
   }

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -99,10 +99,14 @@ pub struct OpDecl {
   pub is_unstable: bool,
   pub is_v8: bool,
   pub arg_count: u8,
+  /// The slow dispatch call. If metrics are disabled, the `v8::Function` is created with this callback.
   pub(crate) slow_fn: OpFnRef,
-  pub(crate) slow_fn_metrics: OpFnRef,
+  /// The slow dispatch call with metrics enabled. If metrics are enabled, the `v8::Function` is created with this callback.
+  pub(crate) slow_fn_with_metrics: OpFnRef,
+  /// The fast dispatch call. If metrics are disabled, the `v8::Function`'s fastcall is created with this callback.
   pub(crate) fast_fn: Option<FastFunction>,
-  pub(crate) fast_fn_metrics: Option<FastFunction>,
+  /// The fast dispatch call with metrics enabled. If metrics are enabled, the `v8::Function`'s fastcall is created with this callback.
+  pub(crate) fast_fn_with_metrics: Option<FastFunction>,
 }
 
 impl OpDecl {
@@ -125,9 +129,9 @@ impl OpDecl {
       is_v8,
       arg_count,
       slow_fn,
-      slow_fn_metrics: slow_fn,
+      slow_fn_with_metrics: slow_fn,
       fast_fn,
-      fast_fn_metrics: fast_fn,
+      fast_fn_with_metrics: fast_fn,
     }
   }
 
@@ -138,9 +142,9 @@ impl OpDecl {
     is_async: bool,
     arg_count: u8,
     slow_fn: OpFnRef,
-    slow_fn_metrics: OpFnRef,
+    slow_fn_with_metrics: OpFnRef,
     fast_fn: Option<FastFunction>,
-    fast_fn_metrics: Option<FastFunction>,
+    fast_fn_with_metrics: Option<FastFunction>,
   ) -> Self {
     Self {
       name,
@@ -150,9 +154,9 @@ impl OpDecl {
       is_v8: false,
       arg_count,
       slow_fn,
-      slow_fn_metrics,
+      slow_fn_with_metrics,
       fast_fn,
-      fast_fn_metrics,
+      fast_fn_with_metrics,
     }
   }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -140,6 +140,7 @@ pub mod _ops {
   pub use super::extensions::OpDecl;
   pub use super::ops::to_op_result;
   pub use super::ops::OpCtx;
+  pub use super::ops::OpMetricsEvent;
   pub use super::ops::OpResult;
   pub use super::runtime::ops::*;
   pub use super::runtime::ops_rust_to_v8::*;

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -133,6 +133,7 @@ pub struct OpCtx {
   pub decl: Rc<OpDecl>,
   pub fast_fn_c_info: Option<NonNull<v8::fast_api::CFunctionInfo>>,
   pub runtime_state: Weak<RefCell<JsRuntimeState>>,
+  pub(crate) metrics_fn: Option<fn(&OpDecl)>,
   pub(crate) context_state: Rc<RefCell<ContextState>>,
   /// If the last fast op failed, stores the error to be picked up by the slow op.
   pub(crate) last_fast_error: UnsafeCell<Option<AnyError>>,
@@ -179,6 +180,7 @@ impl OpCtx {
       fast_fn_c_info,
       last_fast_error: UnsafeCell::new(None),
       isolate,
+      metrics_fn: None,
     }
   }
 

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -126,15 +126,15 @@ pub fn to_op_result<R: Serialize + 'static>(
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum OpMetricsEvent {
   /// Entered an op.
-  Enter,
+  Dispatched,
   /// Left an op synchronously.
-  Leave,
+  Completed,
   /// Left an op asynchronously.
-  LeaveAsync,
+  CompletedAsync,
   /// Left an op synchronously with an exception.
-  Exception,
+  Error,
   /// Left an op asynchronously with an exception.
-  ExceptionAsync,
+  ErrorAsync,
 }
 
 pub type OpMetricsFn = Rc<dyn Fn(&OpDecl, OpMetricsEvent)>;

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -120,6 +120,12 @@ pub fn to_op_result<R: Serialize + 'static>(
   }
 }
 
+pub enum OpMetricsEvent {
+  Enter,
+  Leave,
+  Exception,
+}
+
 /// Per-op context.
 ///
 // Note: We don't worry too much about the size of this struct because it's allocated once per realm, and is
@@ -133,7 +139,7 @@ pub struct OpCtx {
   pub decl: Rc<OpDecl>,
   pub fast_fn_c_info: Option<NonNull<v8::fast_api::CFunctionInfo>>,
   pub runtime_state: Weak<RefCell<JsRuntimeState>>,
-  pub(crate) metrics_fn: Option<fn(&OpDecl)>,
+  pub(crate) metrics_fn: Option<fn(&OpDecl, OpMetricsEvent)>,
   pub(crate) context_state: Rc<RefCell<ContextState>>,
   /// If the last fast op failed, stores the error to be picked up by the slow op.
   pub(crate) last_fast_error: UnsafeCell<Option<AnyError>>,

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -159,6 +159,7 @@ pub struct OpCtx {
 }
 
 impl OpCtx {
+  #[allow(clippy::too_many_arguments)]
   pub(crate) fn new(
     id: OpId,
     isolate: *mut Isolate,

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -137,7 +137,7 @@ pub enum OpMetricsEvent {
   ExceptionAsync,
 }
 
-pub type MetricsFn = Rc<dyn Fn(&OpDecl, OpMetricsEvent)>;
+pub type OpMetricsFn = Rc<dyn Fn(&OpDecl, OpMetricsEvent)>;
 
 /// Per-op context.
 ///
@@ -152,7 +152,7 @@ pub struct OpCtx {
   pub decl: Rc<OpDecl>,
   pub fast_fn_c_info: Option<NonNull<v8::fast_api::CFunctionInfo>>,
   pub runtime_state: Weak<RefCell<JsRuntimeState>>,
-  pub(crate) metrics_fn: Option<MetricsFn>,
+  pub(crate) metrics_fn: Option<OpMetricsFn>,
   pub(crate) context_state: Rc<RefCell<ContextState>>,
   /// If the last fast op failed, stores the error to be picked up by the slow op.
   pub(crate) last_fast_error: UnsafeCell<Option<AnyError>>,
@@ -168,7 +168,7 @@ impl OpCtx {
     state: Rc<RefCell<OpState>>,
     runtime_state: Weak<RefCell<JsRuntimeState>>,
     get_error_class_fn: GetErrorClassFn,
-    metrics_fn: Option<MetricsFn>,
+    metrics_fn: Option<OpMetricsFn>,
   ) -> Self {
     let mut fast_fn_c_info = None;
 

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -172,10 +172,14 @@ impl OpCtx {
   ) -> Self {
     let mut fast_fn_c_info = None;
 
+    // If we want metrics for this function, create the fastcall `CFunctionInfo` from the metrics
+    // `FastFunction`. For some extremely fast ops, the parameter list may change for the metrics
+    // version and require a slightly different set of arguments (for example, it may need the fastcall
+    // callback information to get the `OpCtx`).
     let fast_fn = if metrics_fn.is_some() {
       &decl.fast_fn
     } else {
-      &decl.fast_fn_metrics
+      &decl.fast_fn_with_metrics
     };
 
     if let Some(fast_fn) = fast_fn {

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -46,7 +46,7 @@ pub(crate) fn external_references(
     let ctx_ptr = ctx as *const OpCtx as _;
     references.push(v8::ExternalReference { pointer: ctx_ptr });
     references.push(v8::ExternalReference {
-      function: ctx.decl.v8_fn_ptr,
+      function: ctx.decl.slow_fn,
     });
     if let Some(fast_fn) = &ctx.decl.fast_fn {
       references.push(v8::ExternalReference {
@@ -191,7 +191,7 @@ fn op_ctx_function<'s>(
     v8::String::new_external_onebyte_static(scope, op_ctx.decl.name.as_bytes())
       .unwrap();
   let builder: v8::FunctionBuilder<v8::FunctionTemplate> =
-    v8::FunctionTemplate::builder_raw(op_ctx.decl.v8_fn_ptr)
+    v8::FunctionTemplate::builder_raw(op_ctx.decl.slow_fn)
       .data(external.into())
       .length(op_ctx.decl.arg_count as i32);
 

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -47,9 +47,9 @@ pub(crate) fn external_references(
       let ctx_ptr = ctx as *const OpCtx as _;
       references.push(v8::ExternalReference { pointer: ctx_ptr });
       references.push(v8::ExternalReference {
-        function: ctx.decl.slow_fn_metrics,
+        function: ctx.decl.slow_fn_with_metrics,
       });
-      if let Some(fast_fn) = &ctx.decl.fast_fn_metrics {
+      if let Some(fast_fn) = &ctx.decl.fast_fn_with_metrics {
         references.push(v8::ExternalReference {
           pointer: fast_fn.function as _,
         });
@@ -208,7 +208,10 @@ fn op_ctx_function<'s>(
       .unwrap();
 
   let (slow_fn, fast_fn) = if op_ctx.metrics_enabled() {
-    (op_ctx.decl.slow_fn_metrics, op_ctx.decl.fast_fn_metrics)
+    (
+      op_ctx.decl.slow_fn_with_metrics,
+      op_ctx.decl.fast_fn_with_metrics,
+    )
   } else {
     (op_ctx.decl.slow_fn, op_ctx.decl.fast_fn)
   };

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -10,11 +10,9 @@ use crate::modules::ModuleId;
 use crate::modules::ModuleLoadId;
 use crate::modules::ModuleMap;
 use crate::ops::OpCtx;
+use crate::ops::PendingOp;
 use crate::runtime::JsRuntimeState;
 use crate::JsRuntime;
-use crate::OpId;
-use crate::OpResult;
-use crate::PromiseId;
 use anyhow::Error;
 use deno_unsync::JoinSet;
 use futures::channel::oneshot;
@@ -76,7 +74,7 @@ pub(crate) struct ContextState {
   pending_dyn_mod_evaluate: Vec<DynImportModEvaluate>,
   pub(crate) pending_mod_evaluate: Option<ModEvaluate>,
   pub(crate) unrefed_ops: HashSet<i32, BuildHasherDefault<IdentityHasher>>,
-  pub(crate) pending_ops: JoinSet<(PromiseId, OpId, OpResult)>,
+  pub(crate) pending_ops: JoinSet<PendingOp>,
   // We don't explicitly re-read this prop but need the slice to live alongside
   // the context
   pub(crate) op_ctxs: Box<[OpCtx]>,

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1992,12 +1992,12 @@ impl JsRuntime {
           if res.is_ok() && !was_error {
             dispatch_metrics_async(
               &context_state.op_ctxs[op_id as usize],
-              OpMetricsEvent::LeaveAsync,
+              OpMetricsEvent::CompletedAsync,
             );
           } else {
             dispatch_metrics_async(
               &context_state.op_ctxs[op_id as usize],
-              OpMetricsEvent::ExceptionAsync,
+              OpMetricsEvent::ErrorAsync,
             );
           }
         }

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -362,7 +362,7 @@ fn v8_init(
   v8::V8::initialize();
 }
 
-pub type MetricsFactoryFn = fn(&OpDecl) -> Option<MetricsFn>;
+pub type MetricsFactoryFn = Box<dyn Fn(&OpDecl) -> Option<MetricsFn>>;
 
 #[derive(Default)]
 pub struct RuntimeOptions {
@@ -599,7 +599,7 @@ impl JsRuntime {
       .into_iter()
       .enumerate()
       .map(|(id, decl)| {
-        let metrics_fn = options.metrics_fn.and_then(|f| (f)(&decl));
+        let metrics_fn = options.metrics_fn.as_ref().and_then(|f| (f)(&decl));
         OpCtx::new(
           id as u16,
           std::ptr::null_mut(),

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -362,7 +362,7 @@ fn v8_init(
   v8::V8::initialize();
 }
 
-pub type MetricsFactoryFn = Box<dyn Fn(&OpDecl) -> Option<MetricsFn>>;
+pub type OpMetricsFactoryFn = Box<dyn Fn(&OpDecl) -> Option<OpMetricsFn>>;
 
 #[derive(Default)]
 pub struct RuntimeOptions {
@@ -380,7 +380,9 @@ pub struct RuntimeOptions {
   /// executed tries to load modules.
   pub module_loader: Option<Rc<dyn ModuleLoader>>,
 
-  pub metrics_fn: Option<MetricsFactoryFn>,
+  /// Provide a function that may optionally provide a metrics collector
+  /// for a given op.
+  pub op_metrics_fn: Option<OpMetricsFactoryFn>,
 
   /// JsRuntime extensions, not to be confused with ES modules.
   /// Only ops registered by extensions will be initialized. If you need
@@ -599,7 +601,8 @@ impl JsRuntime {
       .into_iter()
       .enumerate()
       .map(|(id, decl)| {
-        let metrics_fn = options.metrics_fn.as_ref().and_then(|f| (f)(&decl));
+        let metrics_fn =
+          options.op_metrics_fn.as_ref().and_then(|f| (f)(&decl));
         OpCtx::new(
           id as u16,
           std::ptr::null_mut(),

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -176,7 +176,7 @@ pub fn map_async_op_infallible<R: 'static>(
     Poll::Pending => {}
     Poll::Ready(res) => {
       if ctx.metrics_enabled() {
-        dispatch_metrics_async(&ctx, OpMetricsEvent::Leave);
+        dispatch_metrics_async(ctx, OpMetricsEvent::Leave);
       }
       ctx.state.borrow_mut().tracker.track_async_completed(ctx.id);
       return Some(res.2);
@@ -243,9 +243,9 @@ pub fn map_async_op_fallible<R: 'static, E: Into<Error> + 'static>(
     Poll::Ready(res) => {
       if ctx.metrics_enabled() {
         if res.2.is_err() {
-          dispatch_metrics_async(&ctx, OpMetricsEvent::Exception);
+          dispatch_metrics_async(ctx, OpMetricsEvent::Exception);
         } else {
-          dispatch_metrics_async(&ctx, OpMetricsEvent::Leave);
+          dispatch_metrics_async(ctx, OpMetricsEvent::Leave);
         }
       }
       ctx.state.borrow_mut().tracker.track_async_completed(ctx.id);

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -176,7 +176,7 @@ pub fn map_async_op_infallible<R: 'static>(
     Poll::Pending => {}
     Poll::Ready(res) => {
       if ctx.metrics_enabled() {
-        dispatch_metrics_async(ctx, OpMetricsEvent::Leave);
+        dispatch_metrics_async(ctx, OpMetricsEvent::Completed);
       }
       ctx.state.borrow_mut().tracker.track_async_completed(ctx.id);
       return Some(res.2);
@@ -243,9 +243,9 @@ pub fn map_async_op_fallible<R: 'static, E: Into<Error> + 'static>(
     Poll::Ready(res) => {
       if ctx.metrics_enabled() {
         if res.2.is_err() {
-          dispatch_metrics_async(ctx, OpMetricsEvent::Exception);
+          dispatch_metrics_async(ctx, OpMetricsEvent::Error);
         } else {
-          dispatch_metrics_async(ctx, OpMetricsEvent::Leave);
+          dispatch_metrics_async(ctx, OpMetricsEvent::Completed);
         }
       }
       ctx.state.borrow_mut().tracker.track_async_completed(ctx.id);

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -250,9 +250,17 @@ pub fn map_async_op_fallible<R: 'static, E: Into<Error> + 'static>(
   None
 }
 
-pub fn dispatch_metrics_fast(_opctx: &OpCtx, _metrics: OpMetricsEvent) {}
+pub fn dispatch_metrics_fast(opctx: &OpCtx, metrics: OpMetricsEvent) {
+  (opctx.metrics_fn.unwrap())(&opctx.decl, metrics)
+}
 
-pub fn dispatch_metrics_slow(_opctx: &OpCtx, _metrics: OpMetricsEvent) {}
+pub fn dispatch_metrics_slow(opctx: &OpCtx, metrics: OpMetricsEvent) {
+  (opctx.metrics_fn.unwrap())(&opctx.decl, metrics)
+}
+
+pub fn dispatch_metrics_async(opctx: &OpCtx, metrics: OpMetricsEvent) {
+  (opctx.metrics_fn.unwrap())(&opctx.decl, metrics)
+}
 
 macro_rules! try_number_some {
   ($n:ident $type:ident $is:ident) => {

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -250,6 +250,10 @@ pub fn map_async_op_fallible<R: 'static, E: Into<Error> + 'static>(
   None
 }
 
+pub fn dispatch_metrics_fast(_opctx: &OpCtx, _metrics: OpMetricsEvent) {}
+
+pub fn dispatch_metrics_slow(_opctx: &OpCtx, _metrics: OpMetricsEvent) {}
+
 macro_rules! try_number_some {
   ($n:ident $type:ident $is:ident) => {
     if $n.$is() {

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -629,7 +629,7 @@ pub async fn test_op_metrics() {
   let mut runtime = JsRuntime::new(RuntimeOptions {
     extensions: vec![test_ext::init_ops()],
     metrics_fn: Some(|_op| {
-      Some(|op, metrics| println!("{} {:?}", op.name, metrics))
+      Some(Rc::new(|op, metrics| println!("{} {:?}", op.name, metrics)))
     }),
     ..Default::default()
   });

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -671,15 +671,15 @@ pub async fn test_op_metrics() {
   let out = Rc::try_unwrap(out).unwrap().into_inner().join("\n");
   assert_eq!(
     out,
-    r#"op_sync Enter
-op_sync Leave
-op_async Enter
-op_async Leave
-op_async_error Enter
-op_async_error Exception
-op_async_deferred Enter
-op_async_deferred LeaveAsync
-op_async_deferred_error Enter
-op_async_deferred_error ExceptionAsync"#
+    r#"op_sync Dispatched
+op_sync Completed
+op_async Dispatched
+op_async Completed
+op_async_error Dispatched
+op_async_error Error
+op_async_deferred Dispatched
+op_async_deferred CompletedAsync
+op_async_deferred_error Dispatched
+op_async_deferred_error ErrorAsync"#
   );
 }

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -632,7 +632,7 @@ pub async fn test_op_metrics() {
   let out_clone = out.clone();
   let mut runtime = JsRuntime::new(RuntimeOptions {
     extensions: vec![test_ext::init_ops()],
-    metrics_fn: Some(Box::new(move |op| {
+    op_metrics_fn: Some(Box::new(move |op| {
       if !op.name.starts_with("op_async") && !op.name.starts_with("op_sync") {
         return None;
       }

--- a/ops/op2/dispatch_async.rs
+++ b/ops/op2/dispatch_async.rs
@@ -81,7 +81,7 @@ pub(crate) fn generate_dispatch_async(
   args.extend(call(generator_state)?);
   output.extend(gs_quote!(generator_state(deno_core, result, opctx) => {
     if #opctx.metrics_enabled() {
-      #deno_core::_ops::dispatch_metrics_async(&#opctx, #deno_core::_ops::OpMetricsEvent::Enter);
+      #deno_core::_ops::dispatch_metrics_async(&#opctx, #deno_core::_ops::OpMetricsEvent::Dispatched);
     }
     let #result = {
       #args
@@ -98,7 +98,7 @@ pub(crate) fn generate_dispatch_async(
         Ok(#result) => #result,
         Err(err) => {
           if #opctx.metrics_enabled() {
-            #deno_core::_ops::dispatch_metrics_async(&#opctx, #deno_core::_ops::OpMetricsEvent::Exception);
+            #deno_core::_ops::dispatch_metrics_async(&#opctx, #deno_core::_ops::OpMetricsEvent::Error);
           }
           // Handle eager error -- this will leave only a Future<R> or Future<Result<R>>
           #exception

--- a/ops/op2/dispatch_async.rs
+++ b/ops/op2/dispatch_async.rs
@@ -113,9 +113,6 @@ pub(crate) fn generate_dispatch_async(
     if let Some(#result) = #deno_core::_ops::#mapper(#opctx, #lazy, #promise_id, #result, |#scope, #result| {
       #return_value
     }) {
-      if #opctx.metrics_enabled() {
-        #deno_core::_ops::dispatch_metrics_async(&#opctx, #deno_core::_ops::OpMetricsEvent::Leave);
-      }
       // Eager poll returned a value
       #return_value_immediate
     }

--- a/ops/op2/dispatch_async.rs
+++ b/ops/op2/dispatch_async.rs
@@ -143,15 +143,20 @@ pub(crate) fn generate_dispatch_async(
   };
 
   Ok(
-    gs_quote!(generator_state(deno_core, info, slow_function) => {
+    gs_quote!(generator_state(deno_core, info, slow_function, slow_function_metrics) => {
       extern "C" fn #slow_function(#info: *const #deno_core::v8::FunctionCallbackInfo) {
-      #with_scope
-      #with_retval
-      #with_args
-      #with_opctx
-      #with_opstate
+        #with_scope
+        #with_retval
+        #with_args
+        #with_opctx
+        #with_opstate
 
-      #output
-    }}),
+        #output
+      }
+
+      extern "C" fn #slow_function_metrics(#info: *const #deno_core::v8::FunctionCallbackInfo) {
+        Self::#slow_function(#info)
+      }
+    }),
   )
 }

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -327,9 +327,9 @@ pub fn generate_dispatch_fast(
             unsafe { #fast_api_callback_options.data.data }
           ).value() as *const #deno_core::_ops::OpCtx)
       };
-      #deno_core::_ops::dispatch_metrics_fast(&opctx, #deno_core::_ops::OpMetricsEvent::Enter);
+      #deno_core::_ops::dispatch_metrics_fast(&opctx, #deno_core::_ops::OpMetricsEvent::Dispatched);
       let res = Self::#fast_function( this, #( #fastcall_names, )* );
-      #deno_core::_ops::dispatch_metrics_fast(&opctx, #deno_core::_ops::OpMetricsEvent::Leave);
+      #deno_core::_ops::dispatch_metrics_fast(&opctx, #deno_core::_ops::OpMetricsEvent::Completed);
       res
     }
 

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -305,7 +305,7 @@ pub fn generate_dispatch_fast(
     #deno_core::v8::fast_api::FastFunction::new_with_bigint(
       &[ Type::V8Value, #( #input_types_metrics ),* ],
       #output_type,
-      Self::#fast_function as *const ::std::ffi::c_void
+      Self::#fast_function_metrics as *const ::std::ffi::c_void
     )
   });
 

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -141,9 +141,9 @@ pub(crate) fn generate_dispatch_slow(
                 as *const #deno_core::_ops::OpCtx)
         };
 
-        #deno_core::_ops::dispatch_metrics_slow(&#opctx, #deno_core::_ops::OpMetricsEvent::Enter);
+        #deno_core::_ops::dispatch_metrics_slow(&#opctx, #deno_core::_ops::OpMetricsEvent::Dispatched);
         Self::#slow_function(#info);
-        #deno_core::_ops::dispatch_metrics_slow(&#opctx, #deno_core::_ops::OpMetricsEvent::Leave);
+        #deno_core::_ops::dispatch_metrics_slow(&#opctx, #deno_core::_ops::OpMetricsEvent::Completed);
       }
     }),
   )

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -120,7 +120,7 @@ pub(crate) fn generate_dispatch_slow(
   };
 
   Ok(
-    gs_quote!(generator_state(deno_core, info, slow_function) => {
+    gs_quote!(generator_state(deno_core, info, slow_function, slow_function_metrics) => {
       extern "C" fn #slow_function(#info: *const #deno_core::v8::FunctionCallbackInfo) {
         #with_scope
         #with_retval
@@ -131,6 +131,9 @@ pub(crate) fn generate_dispatch_slow(
         #with_js_runtime_state
 
         #output
+      }
+      extern "C" fn #slow_function_metrics(#info: *const #deno_core::v8::FunctionCallbackInfo) {
+        Self::#slow_function(#info)
       }
     }),
   )

--- a/ops/op2/generator_state.rs
+++ b/ops/op2/generator_state.rs
@@ -31,8 +31,12 @@ pub struct GeneratorState {
   pub retval: Ident,
   /// The "slow" function (ie: the one that isn't a fastcall)
   pub slow_function: Ident,
+  /// The "slow" function (ie: the one that isn't a fastcall)
+  pub slow_function_metrics: Ident,
   /// The "fast" function (ie: a fastcall)
   pub fast_function: Ident,
+  /// The "fast" function (ie: a fastcall)
+  pub fast_function_metrics: Ident,
   /// The async function promise ID argument
   pub promise_id: Ident,
 

--- a/ops/op2/test_cases/async/async_arg_return.out
+++ b/ops/op2/test_cases/async/async_arg_return.out
@@ -37,7 +37,7 @@ impl op_async {
         if opctx.metrics_enabled() {
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Enter,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
         }
         let result = {

--- a/ops/op2/test_cases/async/async_arg_return.out
+++ b/ops/op2/test_cases/async/async_arg_return.out
@@ -66,12 +66,6 @@ impl op_async {
             result,
             |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
-            if opctx.metrics_enabled() {
-                deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
-                    deno_core::_ops::OpMetricsEvent::Leave,
-                );
-            }
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
         }
     }

--- a/ops/op2/test_cases/async/async_arg_return.out
+++ b/ops/op2/test_cases/async/async_arg_return.out
@@ -4,13 +4,13 @@ pub struct op_async {
 }
 impl deno_core::_ops::Op for op_async {
     const NAME: &'static str = stringify!(op_async);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_async),
         true,
-        false,
-        false,
         2usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -62,6 +62,9 @@ impl op_async {
         ) {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
         }
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub async fn call(x: i32) -> i32 {

--- a/ops/op2/test_cases/async/async_arg_return.out
+++ b/ops/op2/test_cases/async/async_arg_return.out
@@ -34,6 +34,12 @@ impl op_async {
             &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
                 as *const deno_core::_ops::OpCtx)
         };
+        if opctx.metrics_enabled() {
+            deno_core::_ops::dispatch_metrics_async(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Enter,
+            );
+        }
         let result = {
             let arg0 = args.get(1usize as i32);
             let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
@@ -60,6 +66,12 @@ impl op_async {
             result,
             |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
+            if opctx.metrics_enabled() {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Leave,
+                );
+            }
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
         }
     }

--- a/ops/op2/test_cases/async/async_arg_return_result.out
+++ b/ops/op2/test_cases/async/async_arg_return_result.out
@@ -37,7 +37,7 @@ impl op_async {
         if opctx.metrics_enabled() {
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Enter,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
         }
         let result = {

--- a/ops/op2/test_cases/async/async_arg_return_result.out
+++ b/ops/op2/test_cases/async/async_arg_return_result.out
@@ -66,12 +66,6 @@ impl op_async {
             result,
             |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
-            if opctx.metrics_enabled() {
-                deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
-                    deno_core::_ops::OpMetricsEvent::Leave,
-                );
-            }
             match result {
                 Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
                 Err(err) => {

--- a/ops/op2/test_cases/async/async_arg_return_result.out
+++ b/ops/op2/test_cases/async/async_arg_return_result.out
@@ -34,6 +34,12 @@ impl op_async {
             &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
                 as *const deno_core::_ops::OpCtx)
         };
+        if opctx.metrics_enabled() {
+            deno_core::_ops::dispatch_metrics_async(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Enter,
+            );
+        }
         let result = {
             let arg0 = args.get(1usize as i32);
             let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
@@ -60,6 +66,12 @@ impl op_async {
             result,
             |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
+            if opctx.metrics_enabled() {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Leave,
+                );
+            }
             match result {
                 Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
                 Err(err) => {

--- a/ops/op2/test_cases/async/async_arg_return_result.out
+++ b/ops/op2/test_cases/async/async_arg_return_result.out
@@ -4,13 +4,13 @@ pub struct op_async {
 }
 impl deno_core::_ops::Op for op_async {
     const NAME: &'static str = stringify!(op_async);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_async),
         true,
-        false,
-        false,
         2usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -74,6 +74,9 @@ impl op_async {
                 }
             };
         }
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub async fn call(x: i32) -> std::io::Result<i32> {

--- a/ops/op2/test_cases/async/async_jsbuffer.out
+++ b/ops/op2/test_cases/async/async_jsbuffer.out
@@ -34,6 +34,12 @@ impl op_async_v8_buffer {
             &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
                 as *const deno_core::_ops::OpCtx)
         };
+        if opctx.metrics_enabled() {
+            deno_core::_ops::dispatch_metrics_async(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Enter,
+            );
+        }
         let result = {
             let arg0 = args.get(1usize as i32);
             let mut arg0_temp;
@@ -68,6 +74,12 @@ impl op_async_v8_buffer {
                 deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, scope)
             },
         ) {
+            if opctx.metrics_enabled() {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Leave,
+                );
+            }
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {

--- a/ops/op2/test_cases/async/async_jsbuffer.out
+++ b/ops/op2/test_cases/async/async_jsbuffer.out
@@ -74,12 +74,6 @@ impl op_async_v8_buffer {
                 deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, scope)
             },
         ) {
-            if opctx.metrics_enabled() {
-                deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
-                    deno_core::_ops::OpMetricsEvent::Leave,
-                );
-            }
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {

--- a/ops/op2/test_cases/async/async_jsbuffer.out
+++ b/ops/op2/test_cases/async/async_jsbuffer.out
@@ -4,13 +4,13 @@ pub struct op_async_v8_buffer {
 }
 impl deno_core::_ops::Op for op_async_v8_buffer {
     const NAME: &'static str = stringify!(op_async_v8_buffer);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_async_v8_buffer),
         true,
-        false,
-        false,
         2usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -82,6 +82,9 @@ impl op_async_v8_buffer {
                 }
             }
         }
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub async fn call(buf: JsBuffer) -> JsBuffer {

--- a/ops/op2/test_cases/async/async_jsbuffer.out
+++ b/ops/op2/test_cases/async/async_jsbuffer.out
@@ -37,7 +37,7 @@ impl op_async_v8_buffer {
         if opctx.metrics_enabled() {
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Enter,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
         }
         let result = {

--- a/ops/op2/test_cases/async/async_opstate.out
+++ b/ops/op2/test_cases/async/async_opstate.out
@@ -38,7 +38,7 @@ impl op_async_opstate {
         if opctx.metrics_enabled() {
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Enter,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
         }
         let result = {

--- a/ops/op2/test_cases/async/async_opstate.out
+++ b/ops/op2/test_cases/async/async_opstate.out
@@ -35,6 +35,12 @@ impl op_async_opstate {
                 as *const deno_core::_ops::OpCtx)
         };
         let opstate = &opctx.state;
+        if opctx.metrics_enabled() {
+            deno_core::_ops::dispatch_metrics_async(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Enter,
+            );
+        }
         let result = {
             let arg0 = opstate.clone();
             Self::call(arg0)
@@ -48,6 +54,12 @@ impl op_async_opstate {
             result,
             |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
+            if opctx.metrics_enabled() {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Leave,
+                );
+            }
             match result {
                 Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
                 Err(err) => {

--- a/ops/op2/test_cases/async/async_opstate.out
+++ b/ops/op2/test_cases/async/async_opstate.out
@@ -4,13 +4,13 @@ pub struct op_async_opstate {
 }
 impl deno_core::_ops::Op for op_async_opstate {
     const NAME: &'static str = stringify!(op_async_opstate);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_async_opstate),
         true,
-        false,
-        false,
         2usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -62,6 +62,9 @@ impl op_async_opstate {
                 }
             };
         }
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub async fn call(state: Rc<RefCell<OpState>>) -> std::io::Result<i32> {

--- a/ops/op2/test_cases/async/async_opstate.out
+++ b/ops/op2/test_cases/async/async_opstate.out
@@ -54,12 +54,6 @@ impl op_async_opstate {
             result,
             |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
-            if opctx.metrics_enabled() {
-                deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
-                    deno_core::_ops::OpMetricsEvent::Leave,
-                );
-            }
             match result {
                 Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
                 Err(err) => {

--- a/ops/op2/test_cases/async/async_result.out
+++ b/ops/op2/test_cases/async/async_result.out
@@ -4,13 +4,13 @@ pub struct op_async {
 }
 impl deno_core::_ops::Op for op_async {
     const NAME: &'static str = stringify!(op_async);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_async),
         true,
-        false,
-        false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -58,6 +58,9 @@ impl op_async {
                 }
             };
         }
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub async fn call() -> std::io::Result<i32> {

--- a/ops/op2/test_cases/async/async_result.out
+++ b/ops/op2/test_cases/async/async_result.out
@@ -50,12 +50,6 @@ impl op_async {
             result,
             |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
-            if opctx.metrics_enabled() {
-                deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
-                    deno_core::_ops::OpMetricsEvent::Leave,
-                );
-            }
             match result {
                 Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
                 Err(err) => {

--- a/ops/op2/test_cases/async/async_result.out
+++ b/ops/op2/test_cases/async/async_result.out
@@ -34,6 +34,12 @@ impl op_async {
             &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
                 as *const deno_core::_ops::OpCtx)
         };
+        if opctx.metrics_enabled() {
+            deno_core::_ops::dispatch_metrics_async(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Enter,
+            );
+        }
         let result = { Self::call() };
         let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
             .unwrap_or_default();
@@ -44,6 +50,12 @@ impl op_async {
             result,
             |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
+            if opctx.metrics_enabled() {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Leave,
+                );
+            }
             match result {
                 Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
                 Err(err) => {

--- a/ops/op2/test_cases/async/async_result.out
+++ b/ops/op2/test_cases/async/async_result.out
@@ -37,7 +37,7 @@ impl op_async {
         if opctx.metrics_enabled() {
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Enter,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
         }
         let result = { Self::call() };

--- a/ops/op2/test_cases/async/async_result_impl.out
+++ b/ops/op2/test_cases/async/async_result_impl.out
@@ -34,6 +34,12 @@ impl op_async_result_impl {
             &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
                 as *const deno_core::_ops::OpCtx)
         };
+        if opctx.metrics_enabled() {
+            deno_core::_ops::dispatch_metrics_async(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Enter,
+            );
+        }
         let result = {
             let arg0 = args.get(1usize as i32);
             let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
@@ -54,6 +60,12 @@ impl op_async_result_impl {
         let result = match result {
             Ok(result) => result,
             Err(err) => {
+                if opctx.metrics_enabled() {
+                    deno_core::_ops::dispatch_metrics_async(
+                        &opctx,
+                        deno_core::_ops::OpMetricsEvent::Exception,
+                    );
+                }
                 let err = err.into();
                 let exception = deno_core::error::to_v8_error(
                     &mut scope,
@@ -73,6 +85,12 @@ impl op_async_result_impl {
             result,
             |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
+            if opctx.metrics_enabled() {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Leave,
+                );
+            }
             match result {
                 Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
                 Err(err) => {

--- a/ops/op2/test_cases/async/async_result_impl.out
+++ b/ops/op2/test_cases/async/async_result_impl.out
@@ -37,7 +37,7 @@ impl op_async_result_impl {
         if opctx.metrics_enabled() {
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Enter,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
         }
         let result = {
@@ -63,7 +63,7 @@ impl op_async_result_impl {
                 if opctx.metrics_enabled() {
                     deno_core::_ops::dispatch_metrics_async(
                         &opctx,
-                        deno_core::_ops::OpMetricsEvent::Exception,
+                        deno_core::_ops::OpMetricsEvent::Error,
                     );
                 }
                 let err = err.into();

--- a/ops/op2/test_cases/async/async_result_impl.out
+++ b/ops/op2/test_cases/async/async_result_impl.out
@@ -4,13 +4,13 @@ pub struct op_async_result_impl {
 }
 impl deno_core::_ops::Op for op_async_result_impl {
     const NAME: &'static str = stringify!(op_async_result_impl);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_async_result_impl),
         true,
-        false,
-        false,
         2usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -87,6 +87,9 @@ impl op_async_result_impl {
                 }
             };
         }
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub fn call(x: i32) -> Result<impl Future<Output = std::io::Result<i32>>, AnyError> {

--- a/ops/op2/test_cases/async/async_result_impl.out
+++ b/ops/op2/test_cases/async/async_result_impl.out
@@ -85,12 +85,6 @@ impl op_async_result_impl {
             result,
             |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
-            if opctx.metrics_enabled() {
-                deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
-                    deno_core::_ops::OpMetricsEvent::Leave,
-                );
-            }
             match result {
                 Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
                 Err(err) => {

--- a/ops/op2/test_cases/async/async_result_smi.out
+++ b/ops/op2/test_cases/async/async_result_smi.out
@@ -34,6 +34,12 @@ impl op_async {
             &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
                 as *const deno_core::_ops::OpCtx)
         };
+        if opctx.metrics_enabled() {
+            deno_core::_ops::dispatch_metrics_async(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Enter,
+            );
+        }
         let result = {
             let arg0 = args.get(1usize as i32);
             let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
@@ -70,6 +76,12 @@ impl op_async {
                 )
             },
         ) {
+            if opctx.metrics_enabled() {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Leave,
+                );
+            }
             match result {
                 Ok(result) => {
                     deno_core::_ops::RustToV8RetVal::to_v8_rv(

--- a/ops/op2/test_cases/async/async_result_smi.out
+++ b/ops/op2/test_cases/async/async_result_smi.out
@@ -4,13 +4,13 @@ pub struct op_async {
 }
 impl deno_core::_ops::Op for op_async {
     const NAME: &'static str = stringify!(op_async);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_async),
         true,
-        false,
-        false,
         2usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -92,6 +92,9 @@ impl op_async {
                 }
             };
         }
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub async fn call(rid: ResourceId) -> std::io::Result<ResourceId> {

--- a/ops/op2/test_cases/async/async_result_smi.out
+++ b/ops/op2/test_cases/async/async_result_smi.out
@@ -37,7 +37,7 @@ impl op_async {
         if opctx.metrics_enabled() {
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Enter,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
         }
         let result = {

--- a/ops/op2/test_cases/async/async_result_smi.out
+++ b/ops/op2/test_cases/async/async_result_smi.out
@@ -76,12 +76,6 @@ impl op_async {
                 )
             },
         ) {
-            if opctx.metrics_enabled() {
-                deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
-                    deno_core::_ops::OpMetricsEvent::Leave,
-                );
-            }
             match result {
                 Ok(result) => {
                     deno_core::_ops::RustToV8RetVal::to_v8_rv(

--- a/ops/op2/test_cases/async/async_v8_global.out
+++ b/ops/op2/test_cases/async/async_v8_global.out
@@ -34,6 +34,12 @@ impl op_async_v8_global {
             &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
                 as *const deno_core::_ops::OpCtx)
         };
+        if opctx.metrics_enabled() {
+            deno_core::_ops::dispatch_metrics_async(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Enter,
+            );
+        }
         let result = {
             let arg0 = args.get(1usize as i32);
             let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
@@ -62,6 +68,12 @@ impl op_async_v8_global {
             result,
             |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
+            if opctx.metrics_enabled() {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Leave,
+                );
+            }
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
         }
     }

--- a/ops/op2/test_cases/async/async_v8_global.out
+++ b/ops/op2/test_cases/async/async_v8_global.out
@@ -4,13 +4,13 @@ pub struct op_async_v8_global {
 }
 impl deno_core::_ops::Op for op_async_v8_global {
     const NAME: &'static str = stringify!(op_async_v8_global);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_async_v8_global),
         true,
-        false,
-        false,
         2usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -64,6 +64,9 @@ impl op_async_v8_global {
         ) {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
         }
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub async fn call(_s: v8::Global<v8::String>) {}

--- a/ops/op2/test_cases/async/async_v8_global.out
+++ b/ops/op2/test_cases/async/async_v8_global.out
@@ -68,12 +68,6 @@ impl op_async_v8_global {
             result,
             |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
-            if opctx.metrics_enabled() {
-                deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
-                    deno_core::_ops::OpMetricsEvent::Leave,
-                );
-            }
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
         }
     }

--- a/ops/op2/test_cases/async/async_v8_global.out
+++ b/ops/op2/test_cases/async/async_v8_global.out
@@ -37,7 +37,7 @@ impl op_async_v8_global {
         if opctx.metrics_enabled() {
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Enter,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
         }
         let result = {

--- a/ops/op2/test_cases/async/async_void.out
+++ b/ops/op2/test_cases/async/async_void.out
@@ -50,12 +50,6 @@ impl op_async {
             result,
             |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
-            if opctx.metrics_enabled() {
-                deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
-                    deno_core::_ops::OpMetricsEvent::Leave,
-                );
-            }
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
         }
     }

--- a/ops/op2/test_cases/async/async_void.out
+++ b/ops/op2/test_cases/async/async_void.out
@@ -34,6 +34,12 @@ impl op_async {
             &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
                 as *const deno_core::_ops::OpCtx)
         };
+        if opctx.metrics_enabled() {
+            deno_core::_ops::dispatch_metrics_async(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Enter,
+            );
+        }
         let result = { Self::call() };
         let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
             .unwrap_or_default();
@@ -44,6 +50,12 @@ impl op_async {
             result,
             |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
+            if opctx.metrics_enabled() {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Leave,
+                );
+            }
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
         }
     }

--- a/ops/op2/test_cases/async/async_void.out
+++ b/ops/op2/test_cases/async/async_void.out
@@ -37,7 +37,7 @@ impl op_async {
         if opctx.metrics_enabled() {
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Enter,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
         }
         let result = { Self::call() };

--- a/ops/op2/test_cases/async/async_void.out
+++ b/ops/op2/test_cases/async/async_void.out
@@ -4,13 +4,13 @@ pub struct op_async {
 }
 impl deno_core::_ops::Op for op_async {
     const NAME: &'static str = stringify!(op_async);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_async),
         true,
-        false,
-        false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -46,6 +46,9 @@ impl op_async {
         ) {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
         }
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub async fn call() {}

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -54,12 +54,12 @@ impl op_add {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -126,12 +126,12 @@ impl op_add {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -25,7 +25,7 @@ impl deno_core::_ops::Op for op_add {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Uint32, Type::Uint32, Type::CallbackOptions],
                 CType::Uint32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -4,18 +4,26 @@ struct op_add {
 }
 impl deno_core::_ops::Op for op_add {
     const NAME: &'static str = stringify!(op_add);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_add),
-        false,
-        false,
         false,
         2usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Uint32, Type::Uint32],
+                CType::Uint32,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::Uint32, Type::Uint32, Type::CallbackOptions],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
@@ -29,6 +37,15 @@ impl op_add {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: u32,
+        arg1: u32,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> u32 {
+        Self::v8_fn_ptr_fast(this, arg0, arg1)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -82,6 +99,9 @@ impl op_add {
             Self::call(arg0, arg1)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     fn call(a: u32, b: u32) -> u32 {

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -45,7 +45,23 @@ impl op_add {
         arg1: u32,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> u32 {
-        Self::v8_fn_ptr_fast(this, arg0, arg1)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -101,7 +117,22 @@ impl op_add {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(a: u32, b: u32) -> u32 {

--- a/ops/op2/test_cases/sync/add_options.out
+++ b/ops/op2/test_cases/sync/add_options.out
@@ -68,7 +68,22 @@ impl op_test_add_option {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call(a: u32, b: Option<u32>) -> u32 {

--- a/ops/op2/test_cases/sync/add_options.out
+++ b/ops/op2/test_cases/sync/add_options.out
@@ -77,12 +77,12 @@ impl op_test_add_option {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/add_options.out
+++ b/ops/op2/test_cases/sync/add_options.out
@@ -4,13 +4,13 @@ pub struct op_test_add_option {
 }
 impl deno_core::_ops::Op for op_test_add_option {
     const NAME: &'static str = stringify!(op_test_add_option);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_test_add_option),
-        false,
-        false,
         false,
         2usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -66,6 +66,9 @@ impl op_test_add_option {
             Self::call(arg0, arg1)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub fn call(a: u32, b: Option<u32>) -> u32 {

--- a/ops/op2/test_cases/sync/bool.out
+++ b/ops/op2/test_cases/sync/bool.out
@@ -4,18 +4,26 @@ pub struct op_bool {
 }
 impl deno_core::_ops::Op for op_bool {
     const NAME: &'static str = stringify!(op_bool);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_bool),
-        false,
-        false,
         false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Bool],
+                CType::Bool,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::Bool, Type::CallbackOptions],
                 CType::Bool,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
@@ -29,6 +37,14 @@ impl op_bool {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: bool,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> bool {
+        Self::v8_fn_ptr_fast(this, arg0)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -54,6 +70,9 @@ impl op_bool {
             Self::call(arg0)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub fn call(arg: bool) -> bool {

--- a/ops/op2/test_cases/sync/bool.out
+++ b/ops/op2/test_cases/sync/bool.out
@@ -53,12 +53,12 @@ impl op_bool {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -97,12 +97,12 @@ impl op_bool {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/bool.out
+++ b/ops/op2/test_cases/sync/bool.out
@@ -25,7 +25,7 @@ impl deno_core::_ops::Op for op_bool {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Bool, Type::CallbackOptions],
                 CType::Bool,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/bool.out
+++ b/ops/op2/test_cases/sync/bool.out
@@ -44,7 +44,23 @@ impl op_bool {
         arg0: bool,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> bool {
-        Self::v8_fn_ptr_fast(this, arg0)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, arg0);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -72,7 +88,22 @@ impl op_bool {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call(arg: bool) -> bool {

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -53,12 +53,12 @@ impl op_bool {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -143,12 +143,12 @@ impl op_bool {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -4,13 +4,21 @@ pub struct op_bool {
 }
 impl deno_core::_ops::Op for op_bool {
     const NAME: &'static str = stringify!(op_bool);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_bool),
-        false,
-        false,
         false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::Bool, Type::CallbackOptions],
+                CType::Bool,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
@@ -29,6 +37,14 @@ impl op_bool {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: bool,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> bool {
+        Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -100,6 +116,9 @@ impl op_bool {
                 return;
             }
         };
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub fn call(arg: bool) -> Result<bool, AnyError> {

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -44,7 +44,23 @@ impl op_bool {
         arg0: bool,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> bool {
-        Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -118,7 +134,22 @@ impl op_bool {
         };
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call(arg: bool) -> Result<bool, AnyError> {

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -25,7 +25,7 @@ impl deno_core::_ops::Op for op_bool {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Bool, Type::CallbackOptions],
                 CType::Bool,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -4,13 +4,12 @@ struct op_buffers {
 }
 impl deno_core::_ops::Op for op_buffers {
     const NAME: &'static str = stringify!(op_buffers);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_buffers),
-        false,
-        false,
         false,
         4usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
@@ -26,6 +25,22 @@ impl deno_core::_ops::Op for op_buffers {
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[
+                    Type::V8Value,
+                    Type::TypedArray(CType::Uint8),
+                    Type::TypedArray(CType::Uint8),
+                    Type::TypedArray(CType::Uint8),
+                    Type::TypedArray(CType::Uint8),
+                    Type::CallbackOptions,
+                ],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
     );
 }
 impl op_buffers {
@@ -35,6 +50,17 @@ impl op_buffers {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -183,6 +209,9 @@ impl op_buffers {
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
+    }
     #[inline(always)]
     fn call(_a: &[u8], _b: &mut [u8], _c: *const u8, _d: *mut u8) {}
 }
@@ -193,13 +222,12 @@ struct op_buffers_32 {
 }
 impl deno_core::_ops::Op for op_buffers_32 {
     const NAME: &'static str = stringify!(op_buffers_32);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_buffers_32),
-        false,
-        false,
         false,
         4usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
@@ -215,6 +243,22 @@ impl deno_core::_ops::Op for op_buffers_32 {
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[
+                    Type::V8Value,
+                    Type::TypedArray(CType::Uint32),
+                    Type::TypedArray(CType::Uint32),
+                    Type::TypedArray(CType::Uint32),
+                    Type::TypedArray(CType::Uint32),
+                    Type::CallbackOptions,
+                ],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
     );
 }
 impl op_buffers_32 {
@@ -224,6 +268,17 @@ impl op_buffers_32 {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -372,6 +427,9 @@ impl op_buffers_32 {
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
+    }
     #[inline(always)]
     fn call(_a: &[u32], _b: &mut [u32], _c: *const u32, _d: *mut u32) {}
 }
@@ -382,13 +440,13 @@ struct op_buffers_option {
 }
 impl deno_core::_ops::Op for op_buffers_option {
     const NAME: &'static str = stringify!(op_buffers_option);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_buffers_option),
-        false,
-        false,
         false,
         2usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -463,6 +521,9 @@ impl op_buffers_option {
             Self::call(arg0, arg1)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     fn call(_a: Option<&[u8]>, _b: Option<JsBuffer>) {}

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -60,7 +60,23 @@ impl op_buffers {
         arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
-        Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -210,7 +226,22 @@ impl op_buffers {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(_a: &[u8], _b: &mut [u8], _c: *const u8, _d: *mut u8) {}
@@ -278,7 +309,23 @@ impl op_buffers_32 {
         arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
-        Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -428,7 +475,22 @@ impl op_buffers_32 {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(_a: &[u32], _b: &mut [u32], _c: *const u32, _d: *mut u32) {}
@@ -523,7 +585,22 @@ impl op_buffers_option {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(_a: Option<&[u8]>, _b: Option<JsBuffer>) {}

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -69,12 +69,12 @@ impl op_buffers {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -235,12 +235,12 @@ impl op_buffers {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]
@@ -318,12 +318,12 @@ impl op_buffers_32 {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -484,12 +484,12 @@ impl op_buffers_32 {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]
@@ -594,12 +594,12 @@ impl op_buffers_option {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -38,7 +38,7 @@ impl deno_core::_ops::Op for op_buffers {
                     Type::CallbackOptions,
                 ],
                 CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );
@@ -287,7 +287,7 @@ impl deno_core::_ops::Op for op_buffers_32 {
                     Type::CallbackOptions,
                 ],
                 CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -4,13 +4,12 @@ struct op_buffers {
 }
 impl deno_core::_ops::Op for op_buffers {
     const NAME: &'static str = stringify!(op_buffers);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_buffers),
-        false,
-        false,
         false,
         3usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
@@ -25,6 +24,21 @@ impl deno_core::_ops::Op for op_buffers {
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[
+                    Type::V8Value,
+                    Type::TypedArray(CType::Uint8),
+                    Type::TypedArray(CType::Uint8),
+                    Type::TypedArray(CType::Uint8),
+                    Type::CallbackOptions,
+                ],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
     );
 }
 impl op_buffers {
@@ -34,6 +48,16 @@ impl op_buffers {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        Self::v8_fn_ptr_fast(this, arg0, arg1, arg2)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -139,6 +163,9 @@ impl op_buffers {
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
+    }
     #[inline(always)]
     fn call(_a: Vec<u8>, _b: Box<[u8]>, _c: bytes::Bytes) {}
 }
@@ -149,13 +176,12 @@ struct op_buffers_32 {
 }
 impl deno_core::_ops::Op for op_buffers_32 {
     const NAME: &'static str = stringify!(op_buffers_32);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_buffers_32),
-        false,
-        false,
         false,
         2usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
@@ -164,6 +190,20 @@ impl deno_core::_ops::Op for op_buffers_32 {
                     Type::V8Value,
                     Type::TypedArray(CType::Uint32),
                     Type::TypedArray(CType::Uint32),
+                ],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[
+                    Type::V8Value,
+                    Type::TypedArray(CType::Uint32),
+                    Type::TypedArray(CType::Uint32),
+                    Type::CallbackOptions,
                 ],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
@@ -178,6 +218,15 @@ impl op_buffers_32 {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        Self::v8_fn_ptr_fast(this, arg0, arg1)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -255,6 +304,9 @@ impl op_buffers_32 {
             Self::call(arg0, arg1)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     fn call(_a: Vec<u32>, _b: Box<[u32]>) {}

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -36,7 +36,7 @@ impl deno_core::_ops::Op for op_buffers {
                     Type::CallbackOptions,
                 ],
                 CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );
@@ -237,7 +237,7 @@ impl deno_core::_ops::Op for op_buffers_32 {
                     Type::CallbackOptions,
                 ],
                 CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -66,12 +66,12 @@ impl op_buffers {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -189,12 +189,12 @@ impl op_buffers {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]
@@ -266,12 +266,12 @@ impl op_buffers_32 {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -362,12 +362,12 @@ impl op_buffers_32 {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -57,7 +57,23 @@ impl op_buffers {
         arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
-        Self::v8_fn_ptr_fast(this, arg0, arg1, arg2)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -164,7 +180,22 @@ impl op_buffers {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(_a: Vec<u8>, _b: Box<[u8]>, _c: bytes::Bytes) {}
@@ -226,7 +257,23 @@ impl op_buffers_32 {
         arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
-        Self::v8_fn_ptr_fast(this, arg0, arg1)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -306,7 +353,22 @@ impl op_buffers_32 {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(_a: Vec<u32>, _b: Box<[u32]>) {}

--- a/ops/op2/test_cases/sync/buffers_out.out
+++ b/ops/op2/test_cases/sync/buffers_out.out
@@ -68,7 +68,22 @@ impl op_buffers {
         }
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(buffer: JsBuffer) -> JsBuffer {
@@ -153,7 +168,22 @@ impl op_buffers_option {
         }
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(buffer: Option<JsBuffer>) -> Option<JsBuffer> {
@@ -225,7 +255,22 @@ impl op_arraybuffers {
         )
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(buffer: JsBuffer) -> JsBuffer {

--- a/ops/op2/test_cases/sync/buffers_out.out
+++ b/ops/op2/test_cases/sync/buffers_out.out
@@ -77,12 +77,12 @@ impl op_buffers {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]
@@ -177,12 +177,12 @@ impl op_buffers_option {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]
@@ -264,12 +264,12 @@ impl op_arraybuffers {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/buffers_out.out
+++ b/ops/op2/test_cases/sync/buffers_out.out
@@ -4,13 +4,13 @@ struct op_buffers {
 }
 impl deno_core::_ops::Op for op_buffers {
     const NAME: &'static str = stringify!(op_buffers);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_buffers),
-        false,
-        false,
         false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -67,6 +67,9 @@ impl op_buffers {
             }
         }
     }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
+    }
     #[inline(always)]
     fn call(buffer: JsBuffer) -> JsBuffer {
         buffer
@@ -79,13 +82,13 @@ struct op_buffers_option {
 }
 impl deno_core::_ops::Op for op_buffers_option {
     const NAME: &'static str = stringify!(op_buffers_option);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_buffers_option),
-        false,
-        false,
         false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -149,6 +152,9 @@ impl op_buffers_option {
             }
         }
     }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
+    }
     #[inline(always)]
     fn call(buffer: Option<JsBuffer>) -> Option<JsBuffer> {
         buffer
@@ -161,13 +167,13 @@ struct op_arraybuffers {
 }
 impl deno_core::_ops::Op for op_arraybuffers {
     const NAME: &'static str = stringify!(op_arraybuffers);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_arraybuffers),
-        false,
-        false,
         false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -217,6 +223,9 @@ impl op_arraybuffers {
                 &mut scope,
             ),
         )
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     fn call(buffer: JsBuffer) -> JsBuffer {

--- a/ops/op2/test_cases/sync/cfg.out
+++ b/ops/op2/test_cases/sync/cfg.out
@@ -45,7 +45,23 @@ impl op_maybe_windows {
         this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
-        Self::v8_fn_ptr_fast(this)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
@@ -60,7 +76,22 @@ impl op_maybe_windows {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     /// This is a doc comment.
@@ -115,7 +146,23 @@ impl op_maybe_windows {
         this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
-        Self::v8_fn_ptr_fast(this)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
@@ -130,7 +177,22 @@ impl op_maybe_windows {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     /// This is a doc comment.

--- a/ops/op2/test_cases/sync/cfg.out
+++ b/ops/op2/test_cases/sync/cfg.out
@@ -6,18 +6,26 @@ pub struct op_maybe_windows {
 }
 impl deno_core::_ops::Op for op_maybe_windows {
     const NAME: &'static str = stringify!(op_maybe_windows);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_maybe_windows),
-        false,
-        false,
         false,
         0usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
@@ -33,6 +41,13 @@ impl op_maybe_windows {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        Self::v8_fn_ptr_fast(this)
+    }
+    #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = { Self::call() };
         result as _
@@ -43,6 +58,9 @@ impl op_maybe_windows {
         });
         let result = { Self::call() };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     /// This is a doc comment.
@@ -58,18 +76,26 @@ pub struct op_maybe_windows {
 }
 impl deno_core::_ops::Op for op_maybe_windows {
     const NAME: &'static str = stringify!(op_maybe_windows);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_maybe_windows),
-        false,
-        false,
         false,
         0usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
@@ -85,6 +111,13 @@ impl op_maybe_windows {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        Self::v8_fn_ptr_fast(this)
+    }
+    #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = { Self::call() };
         result as _
@@ -95,6 +128,9 @@ impl op_maybe_windows {
         });
         let result = { Self::call() };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     /// This is a doc comment.

--- a/ops/op2/test_cases/sync/cfg.out
+++ b/ops/op2/test_cases/sync/cfg.out
@@ -27,7 +27,7 @@ impl deno_core::_ops::Op for op_maybe_windows {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );
@@ -128,7 +128,7 @@ impl deno_core::_ops::Op for op_maybe_windows {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/cfg.out
+++ b/ops/op2/test_cases/sync/cfg.out
@@ -54,12 +54,12 @@ impl op_maybe_windows {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -85,12 +85,12 @@ impl op_maybe_windows {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]
@@ -155,12 +155,12 @@ impl op_maybe_windows {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -186,12 +186,12 @@ impl op_maybe_windows {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/clippy_allow.out
+++ b/ops/op2/test_cases/sync/clippy_allow.out
@@ -54,12 +54,12 @@ impl op_extra_annotation {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -85,12 +85,12 @@ impl op_extra_annotation {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]
@@ -153,12 +153,12 @@ impl op_clippy_internal {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -184,12 +184,12 @@ impl op_clippy_internal {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/clippy_allow.out
+++ b/ops/op2/test_cases/sync/clippy_allow.out
@@ -6,18 +6,26 @@ pub struct op_extra_annotation {
 }
 impl deno_core::_ops::Op for op_extra_annotation {
     const NAME: &'static str = stringify!(op_extra_annotation);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_extra_annotation),
-        false,
-        false,
         false,
         0usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
@@ -33,6 +41,13 @@ impl op_extra_annotation {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        Self::v8_fn_ptr_fast(this)
+    }
+    #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = { Self::call() };
         result as _
@@ -43,6 +58,9 @@ impl op_extra_annotation {
         });
         let result = { Self::call() };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     /// This is a doc comment.
@@ -56,18 +74,26 @@ pub struct op_clippy_internal {
 }
 impl deno_core::_ops::Op for op_clippy_internal {
     const NAME: &'static str = stringify!(op_clippy_internal);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_clippy_internal),
-        false,
-        false,
         false,
         0usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
@@ -83,6 +109,13 @@ impl op_clippy_internal {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        Self::v8_fn_ptr_fast(this)
+    }
+    #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = { Self::call() };
         result as _
@@ -93,6 +126,9 @@ impl op_clippy_internal {
         });
         let result = { Self::call() };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub fn call() -> () {

--- a/ops/op2/test_cases/sync/clippy_allow.out
+++ b/ops/op2/test_cases/sync/clippy_allow.out
@@ -45,7 +45,23 @@ impl op_extra_annotation {
         this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
-        Self::v8_fn_ptr_fast(this)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
@@ -60,7 +76,22 @@ impl op_extra_annotation {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     /// This is a doc comment.
@@ -113,7 +144,23 @@ impl op_clippy_internal {
         this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
-        Self::v8_fn_ptr_fast(this)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
@@ -128,7 +175,22 @@ impl op_clippy_internal {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call() -> () {

--- a/ops/op2/test_cases/sync/clippy_allow.out
+++ b/ops/op2/test_cases/sync/clippy_allow.out
@@ -27,7 +27,7 @@ impl deno_core::_ops::Op for op_extra_annotation {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );
@@ -126,7 +126,7 @@ impl deno_core::_ops::Op for op_clippy_internal {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/doc_comment.out
+++ b/ops/op2/test_cases/sync/doc_comment.out
@@ -26,7 +26,7 @@ impl deno_core::_ops::Op for op_has_doc_comment {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/doc_comment.out
+++ b/ops/op2/test_cases/sync/doc_comment.out
@@ -53,12 +53,12 @@ impl op_has_doc_comment {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -84,12 +84,12 @@ impl op_has_doc_comment {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/doc_comment.out
+++ b/ops/op2/test_cases/sync/doc_comment.out
@@ -5,18 +5,26 @@ pub struct op_has_doc_comment {
 }
 impl deno_core::_ops::Op for op_has_doc_comment {
     const NAME: &'static str = stringify!(op_has_doc_comment);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_has_doc_comment),
-        false,
-        false,
         false,
         0usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
@@ -32,6 +40,13 @@ impl op_has_doc_comment {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        Self::v8_fn_ptr_fast(this)
+    }
+    #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = { Self::call() };
         result as _
@@ -42,6 +57,9 @@ impl op_has_doc_comment {
         });
         let result = { Self::call() };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     /// This is a doc comment.

--- a/ops/op2/test_cases/sync/doc_comment.out
+++ b/ops/op2/test_cases/sync/doc_comment.out
@@ -44,7 +44,23 @@ impl op_has_doc_comment {
         this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
-        Self::v8_fn_ptr_fast(this)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
@@ -59,7 +75,22 @@ impl op_has_doc_comment {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     /// This is a doc comment.

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -4,18 +4,26 @@ pub struct op_generics<T> {
 }
 impl<T: Trait> deno_core::_ops::Op for op_generics<T> {
     const NAME: &'static str = stringify!(op_generics);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_generics),
-        false,
-        false,
         false,
         0usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
@@ -31,6 +39,13 @@ impl<T: Trait> op_generics<T> {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        Self::v8_fn_ptr_fast(this)
+    }
+    #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = { Self::call() };
         result as _
@@ -42,6 +57,9 @@ impl<T: Trait> op_generics<T> {
         let result = { Self::call() };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
+    }
     #[inline(always)]
     pub fn call() {}
 }
@@ -52,18 +70,26 @@ pub struct op_generics_static<T> {
 }
 impl<T: Trait + 'static> deno_core::_ops::Op for op_generics_static<T> {
     const NAME: &'static str = stringify!(op_generics_static);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_generics_static),
-        false,
-        false,
         false,
         0usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
@@ -79,6 +105,13 @@ impl<T: Trait + 'static> op_generics_static<T> {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        Self::v8_fn_ptr_fast(this)
+    }
+    #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = { Self::call() };
         result as _
@@ -90,6 +123,9 @@ impl<T: Trait + 'static> op_generics_static<T> {
         let result = { Self::call() };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
+    }
     #[inline(always)]
     pub fn call() {}
 }
@@ -100,18 +136,26 @@ pub struct op_generics_static_where<T> {
 }
 impl<T: Trait + 'static> deno_core::_ops::Op for op_generics_static_where<T> {
     const NAME: &'static str = stringify!(op_generics_static_where);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_generics_static_where),
-        false,
-        false,
         false,
         0usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
@@ -127,6 +171,13 @@ impl<T: Trait + 'static> op_generics_static_where<T> {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        Self::v8_fn_ptr_fast(this)
+    }
+    #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = { Self::call() };
         result as _
@@ -137,6 +188,9 @@ impl<T: Trait + 'static> op_generics_static_where<T> {
         });
         let result = { Self::call() };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub fn call()

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -25,7 +25,7 @@ impl<T: Trait> deno_core::_ops::Op for op_generics<T> {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );
@@ -122,7 +122,7 @@ impl<T: Trait + 'static> deno_core::_ops::Op for op_generics_static<T> {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );
@@ -219,7 +219,7 @@ impl<T: Trait + 'static> deno_core::_ops::Op for op_generics_static_where<T> {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -52,12 +52,12 @@ impl<T: Trait> op_generics<T> {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -83,12 +83,12 @@ impl<T: Trait> op_generics<T> {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]
@@ -149,12 +149,12 @@ impl<T: Trait + 'static> op_generics_static<T> {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -180,12 +180,12 @@ impl<T: Trait + 'static> op_generics_static<T> {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]
@@ -246,12 +246,12 @@ impl<T: Trait + 'static> op_generics_static_where<T> {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -277,12 +277,12 @@ impl<T: Trait + 'static> op_generics_static_where<T> {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -43,7 +43,23 @@ impl<T: Trait> op_generics<T> {
         this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
-        Self::v8_fn_ptr_fast(this)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
@@ -58,7 +74,22 @@ impl<T: Trait> op_generics<T> {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call() {}
@@ -109,7 +140,23 @@ impl<T: Trait + 'static> op_generics_static<T> {
         this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
-        Self::v8_fn_ptr_fast(this)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
@@ -124,7 +171,22 @@ impl<T: Trait + 'static> op_generics_static<T> {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call() {}
@@ -175,7 +237,23 @@ impl<T: Trait + 'static> op_generics_static_where<T> {
         this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
-        Self::v8_fn_ptr_fast(this)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
@@ -190,7 +268,22 @@ impl<T: Trait + 'static> op_generics_static_where<T> {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call()

--- a/ops/op2/test_cases/sync/nofast.out
+++ b/ops/op2/test_cases/sync/nofast.out
@@ -63,7 +63,22 @@ impl op_nofast {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(a: u32, b: u32) -> u32 {

--- a/ops/op2/test_cases/sync/nofast.out
+++ b/ops/op2/test_cases/sync/nofast.out
@@ -72,12 +72,12 @@ impl op_nofast {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/nofast.out
+++ b/ops/op2/test_cases/sync/nofast.out
@@ -4,13 +4,13 @@ struct op_nofast {
 }
 impl deno_core::_ops::Op for op_nofast {
     const NAME: &'static str = stringify!(op_nofast);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_nofast),
-        false,
-        false,
         false,
         2usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -61,6 +61,9 @@ impl op_nofast {
             Self::call(arg0, arg1)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     fn call(a: u32, b: u32) -> u32 {

--- a/ops/op2/test_cases/sync/op_state_attr.out
+++ b/ops/op2/test_cases/sync/op_state_attr.out
@@ -52,12 +52,12 @@ impl op_state_rc {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -113,12 +113,12 @@ impl op_state_rc {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/op_state_attr.out
+++ b/ops/op2/test_cases/sync/op_state_attr.out
@@ -43,7 +43,23 @@ impl op_state_rc {
         this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
-        Self::v8_fn_ptr_fast(this, fast_api_callback_options)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -88,7 +104,22 @@ impl op_state_rc {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(_arg: &Something, _arg_opt: Option<&Something>) {}

--- a/ops/op2/test_cases/sync/op_state_attr.out
+++ b/ops/op2/test_cases/sync/op_state_attr.out
@@ -25,7 +25,7 @@ impl deno_core::_ops::Op for op_state_rc {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/op_state_attr.out
+++ b/ops/op2/test_cases/sync/op_state_attr.out
@@ -4,13 +4,21 @@ struct op_state_rc {
 }
 impl deno_core::_ops::Op for op_state_rc {
     const NAME: &'static str = stringify!(op_state_rc);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_state_rc),
-        false,
-        false,
         false,
         2usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::CallbackOptions],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
@@ -29,6 +37,13 @@ impl op_state_rc {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        Self::v8_fn_ptr_fast(this, fast_api_callback_options)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -71,6 +86,9 @@ impl op_state_rc {
             Self::call(arg0, arg1)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     fn call(_arg: &Something, _arg_opt: Option<&Something>) {}

--- a/ops/op2/test_cases/sync/op_state_rc.out
+++ b/ops/op2/test_cases/sync/op_state_rc.out
@@ -52,12 +52,12 @@ impl op_state_rc {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -107,12 +107,12 @@ impl op_state_rc {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/op_state_rc.out
+++ b/ops/op2/test_cases/sync/op_state_rc.out
@@ -43,7 +43,23 @@ impl op_state_rc {
         this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
-        Self::v8_fn_ptr_fast(this, fast_api_callback_options)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -82,7 +98,22 @@ impl op_state_rc {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(_state: Rc<RefCell<OpState>>) {}

--- a/ops/op2/test_cases/sync/op_state_rc.out
+++ b/ops/op2/test_cases/sync/op_state_rc.out
@@ -25,7 +25,7 @@ impl deno_core::_ops::Op for op_state_rc {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/op_state_rc.out
+++ b/ops/op2/test_cases/sync/op_state_rc.out
@@ -4,13 +4,21 @@ struct op_state_rc {
 }
 impl deno_core::_ops::Op for op_state_rc {
     const NAME: &'static str = stringify!(op_state_rc);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_state_rc),
-        false,
-        false,
         false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::CallbackOptions],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
@@ -29,6 +37,13 @@ impl op_state_rc {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        Self::v8_fn_ptr_fast(this, fast_api_callback_options)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -65,6 +80,9 @@ impl op_state_rc {
             Self::call(arg0)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     fn call(_state: Rc<RefCell<OpState>>) {}

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -52,12 +52,12 @@ impl op_state_ref {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -107,12 +107,12 @@ impl op_state_ref {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]
@@ -173,12 +173,12 @@ impl op_state_mut {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -228,12 +228,12 @@ impl op_state_mut {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]
@@ -309,12 +309,12 @@ impl op_state_and_v8 {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -25,7 +25,7 @@ impl deno_core::_ops::Op for op_state_ref {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );
@@ -146,7 +146,7 @@ impl deno_core::_ops::Op for op_state_mut {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -4,13 +4,21 @@ struct op_state_ref {
 }
 impl deno_core::_ops::Op for op_state_ref {
     const NAME: &'static str = stringify!(op_state_ref);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_state_ref),
-        false,
-        false,
         false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::CallbackOptions],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
@@ -29,6 +37,13 @@ impl op_state_ref {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        Self::v8_fn_ptr_fast(this, fast_api_callback_options)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -66,6 +81,9 @@ impl op_state_ref {
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
+    }
     #[inline(always)]
     fn call(_state: &OpState) {}
 }
@@ -76,13 +94,21 @@ struct op_state_mut {
 }
 impl deno_core::_ops::Op for op_state_mut {
     const NAME: &'static str = stringify!(op_state_mut);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_state_mut),
-        false,
-        false,
         false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::CallbackOptions],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
@@ -101,6 +127,13 @@ impl op_state_mut {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        Self::v8_fn_ptr_fast(this, fast_api_callback_options)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -138,6 +171,9 @@ impl op_state_mut {
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
+    }
     #[inline(always)]
     fn call(_state: &mut OpState) {}
 }
@@ -148,13 +184,13 @@ struct op_state_and_v8 {
 }
 impl deno_core::_ops::Op for op_state_and_v8 {
     const NAME: &'static str = stringify!(op_state_and_v8);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_state_and_v8),
-        false,
-        false,
         false,
         2usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -200,6 +236,9 @@ impl op_state_and_v8 {
             Self::call(arg0, arg1)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     fn call(_state: &mut OpState, _callback: v8::Global<v8::Function>) {}

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -43,7 +43,23 @@ impl op_state_ref {
         this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
-        Self::v8_fn_ptr_fast(this, fast_api_callback_options)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -82,7 +98,22 @@ impl op_state_ref {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(_state: &OpState) {}
@@ -133,7 +164,23 @@ impl op_state_mut {
         this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
-        Self::v8_fn_ptr_fast(this, fast_api_callback_options)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -172,7 +219,22 @@ impl op_state_mut {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(_state: &mut OpState) {}
@@ -238,7 +300,22 @@ impl op_state_and_v8 {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(_state: &mut OpState, _callback: v8::Global<v8::Function>) {}

--- a/ops/op2/test_cases/sync/result_external.out
+++ b/ops/op2/test_cases/sync/result_external.out
@@ -52,12 +52,12 @@ impl op_external_with_result {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -140,12 +140,12 @@ impl op_external_with_result {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/result_external.out
+++ b/ops/op2/test_cases/sync/result_external.out
@@ -43,7 +43,23 @@ impl op_external_with_result {
         this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> *mut ::std::ffi::c_void {
-        Self::v8_fn_ptr_fast(this, fast_api_callback_options)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -115,7 +131,22 @@ impl op_external_with_result {
         };
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call() -> Result<*mut std::ffi::c_void, AnyError> {

--- a/ops/op2/test_cases/sync/result_external.out
+++ b/ops/op2/test_cases/sync/result_external.out
@@ -25,7 +25,7 @@ impl deno_core::_ops::Op for op_external_with_result {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Pointer,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/result_external.out
+++ b/ops/op2/test_cases/sync/result_external.out
@@ -4,13 +4,21 @@ pub struct op_external_with_result {
 }
 impl deno_core::_ops::Op for op_external_with_result {
     const NAME: &'static str = stringify!(op_external_with_result);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_external_with_result),
-        false,
-        false,
         false,
         0usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::CallbackOptions],
+                CType::Pointer,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
@@ -29,6 +37,13 @@ impl op_external_with_result {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> *mut ::std::ffi::c_void {
+        Self::v8_fn_ptr_fast(this, fast_api_callback_options)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -98,6 +113,9 @@ impl op_external_with_result {
                 return;
             }
         };
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub fn call() -> Result<*mut std::ffi::c_void, AnyError> {

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -25,7 +25,7 @@ impl deno_core::_ops::Op for op_u32_with_result {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Uint32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -4,13 +4,21 @@ pub struct op_u32_with_result {
 }
 impl deno_core::_ops::Op for op_u32_with_result {
     const NAME: &'static str = stringify!(op_u32_with_result);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_u32_with_result),
-        false,
-        false,
         false,
         0usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::CallbackOptions],
+                CType::Uint32,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
@@ -29,6 +37,13 @@ impl op_u32_with_result {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> u32 {
+        Self::v8_fn_ptr_fast(this, fast_api_callback_options)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -98,6 +113,9 @@ impl op_u32_with_result {
                 return;
             }
         };
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub fn call() -> Result<u32, AnyError> {

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -43,7 +43,23 @@ impl op_u32_with_result {
         this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> u32 {
-        Self::v8_fn_ptr_fast(this, fast_api_callback_options)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -115,7 +131,22 @@ impl op_u32_with_result {
         };
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call() -> Result<u32, AnyError> {

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -52,12 +52,12 @@ impl op_u32_with_result {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -140,12 +140,12 @@ impl op_u32_with_result {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/result_scope.out
+++ b/ops/op2/test_cases/sync/result_scope.out
@@ -53,7 +53,22 @@ impl op_void_with_result {
         };
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call(_scope: &mut v8::HandleScope) -> Result<(), AnyError> {

--- a/ops/op2/test_cases/sync/result_scope.out
+++ b/ops/op2/test_cases/sync/result_scope.out
@@ -4,13 +4,13 @@ pub struct op_void_with_result {
 }
 impl deno_core::_ops::Op for op_void_with_result {
     const NAME: &'static str = stringify!(op_void_with_result);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_void_with_result),
-        false,
-        false,
         false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -51,6 +51,9 @@ impl op_void_with_result {
                 return;
             }
         };
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub fn call(_scope: &mut v8::HandleScope) -> Result<(), AnyError> {

--- a/ops/op2/test_cases/sync/result_scope.out
+++ b/ops/op2/test_cases/sync/result_scope.out
@@ -62,12 +62,12 @@ impl op_void_with_result {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -4,13 +4,21 @@ pub struct op_void_with_result {
 }
 impl deno_core::_ops::Op for op_void_with_result {
     const NAME: &'static str = stringify!(op_void_with_result);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_void_with_result),
-        false,
-        false,
         false,
         0usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::CallbackOptions],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
@@ -29,6 +37,13 @@ impl op_void_with_result {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        Self::v8_fn_ptr_fast(this, fast_api_callback_options)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -98,6 +113,9 @@ impl op_void_with_result {
                 return;
             }
         };
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub fn call() -> Result<(), AnyError> {

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -25,7 +25,7 @@ impl deno_core::_ops::Op for op_void_with_result {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -52,12 +52,12 @@ impl op_void_with_result {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -140,12 +140,12 @@ impl op_void_with_result {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -43,7 +43,23 @@ impl op_void_with_result {
         this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
-        Self::v8_fn_ptr_fast(this, fast_api_callback_options)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -115,7 +131,22 @@ impl op_void_with_result {
         };
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call() -> Result<(), AnyError> {

--- a/ops/op2/test_cases/sync/serde_v8.out
+++ b/ops/op2/test_cases/sync/serde_v8.out
@@ -4,13 +4,13 @@ pub struct op_serde_v8 {
 }
 impl deno_core::_ops::Op for op_serde_v8 {
     const NAME: &'static str = stringify!(op_serde_v8);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_serde_v8),
-        false,
-        false,
         false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -66,6 +66,9 @@ impl op_serde_v8 {
                 return;
             }
         }
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub fn call(_input: Input) -> Output {

--- a/ops/op2/test_cases/sync/serde_v8.out
+++ b/ops/op2/test_cases/sync/serde_v8.out
@@ -77,12 +77,12 @@ impl op_serde_v8 {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/serde_v8.out
+++ b/ops/op2/test_cases/sync/serde_v8.out
@@ -68,7 +68,22 @@ impl op_serde_v8 {
         }
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call(_input: Input) -> Output {

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -54,7 +54,23 @@ impl op_smi_unsigned_return {
         arg3: i32,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> i32 {
-        Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -148,7 +164,22 @@ impl op_smi_unsigned_return {
         )
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(a: Int16, b: Int32, c: Uint16, d: Uint32) -> Uint32 {
@@ -212,7 +243,23 @@ impl op_smi_signed_return {
         arg3: i32,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> i32 {
-        Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -306,7 +353,22 @@ impl op_smi_signed_return {
         )
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(a: Int16, b: Int32, c: Uint16, d: Uint32) -> Int32 {
@@ -370,7 +432,22 @@ impl op_smi_option {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(a: Option<Uint32>) -> Option<Uint32> {

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -63,12 +63,12 @@ impl op_smi_unsigned_return {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -173,12 +173,12 @@ impl op_smi_unsigned_return {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]
@@ -252,12 +252,12 @@ impl op_smi_signed_return {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -362,12 +362,12 @@ impl op_smi_signed_return {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]
@@ -441,12 +441,12 @@ impl op_smi_option {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -32,7 +32,7 @@ impl deno_core::_ops::Op for op_smi_unsigned_return {
                     Type::CallbackOptions,
                 ],
                 CType::Int32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );
@@ -221,7 +221,7 @@ impl deno_core::_ops::Op for op_smi_signed_return {
                     Type::CallbackOptions,
                 ],
                 CType::Int32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -4,18 +4,33 @@ struct op_smi_unsigned_return {
 }
 impl deno_core::_ops::Op for op_smi_unsigned_return {
     const NAME: &'static str = stringify!(op_smi_unsigned_return);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_smi_unsigned_return),
-        false,
-        false,
         false,
         4usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Int32, Type::Int32, Type::Int32, Type::Int32],
+                CType::Int32,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[
+                    Type::V8Value,
+                    Type::Int32,
+                    Type::Int32,
+                    Type::Int32,
+                    Type::Int32,
+                    Type::CallbackOptions,
+                ],
                 CType::Int32,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
@@ -31,133 +46,15 @@ impl op_smi_unsigned_return {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[allow(clippy::too_many_arguments)]
-    fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: i32,
         arg1: i32,
         arg2: i32,
         arg3: i32,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> i32 {
-        let result = {
-            let arg0 = arg0 as _;
-            let arg1 = arg1 as _;
-            let arg2 = arg2 as _;
-            let arg3 = arg3 as _;
-            Self::call(arg0, arg1, arg2, arg3)
-        };
-        result as _
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected i32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return;
-            };
-            let arg0 = arg0 as _;
-            let arg1 = args.get(1usize as i32);
-            let Some(arg1) = deno_core::_ops::to_i32_option(&arg1) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected i32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return;
-            };
-            let arg1 = arg1 as _;
-            let arg2 = args.get(2usize as i32);
-            let Some(arg2) = deno_core::_ops::to_i32_option(&arg2) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected i32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return;
-            };
-            let arg2 = arg2 as _;
-            let arg3 = args.get(3usize as i32);
-            let Some(arg3) = deno_core::_ops::to_i32_option(&arg3) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected i32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return;
-            };
-            let arg3 = arg3 as _;
-            Self::call(arg0, arg1, arg2, arg3)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(
-            deno_core::_ops::RustToV8Marker::<
-                deno_core::_ops::SmiMarker,
-                _,
-            >::from(result),
-            &mut rv,
-        )
-    }
-    #[inline(always)]
-    fn call(a: Int16, b: Int32, c: Uint16, d: Uint32) -> Uint32 {
-        a as Uint32 + b as Uint32 + c as Uint32 + d as Uint32
-    }
-}
-
-#[allow(non_camel_case_types)]
-struct op_smi_signed_return {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl deno_core::_ops::Op for op_smi_signed_return {
-    const NAME: &'static str = stringify!(op_smi_signed_return);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
-        stringify!(op_smi_signed_return),
-        false,
-        false,
-        false,
-        4usize as u8,
-        Self::v8_fn_ptr as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::Int32, Type::Int32, Type::Int32, Type::Int32],
-                CType::Int32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-    );
-}
-impl op_smi_signed_return {
-    pub const fn name() -> &'static str {
-        stringify!(op_smi_signed_return)
-    }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
+        Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -250,6 +147,167 @@ impl op_smi_signed_return {
             &mut rv,
         )
     }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
+    }
+    #[inline(always)]
+    fn call(a: Int16, b: Int32, c: Uint16, d: Uint32) -> Uint32 {
+        a as Uint32 + b as Uint32 + c as Uint32 + d as Uint32
+    }
+}
+
+#[allow(non_camel_case_types)]
+struct op_smi_signed_return {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
+impl deno_core::_ops::Op for op_smi_signed_return {
+    const NAME: &'static str = stringify!(op_smi_signed_return);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
+        stringify!(op_smi_signed_return),
+        false,
+        4usize as u8,
+        Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::Int32, Type::Int32, Type::Int32, Type::Int32],
+                CType::Int32,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[
+                    Type::V8Value,
+                    Type::Int32,
+                    Type::Int32,
+                    Type::Int32,
+                    Type::Int32,
+                    Type::CallbackOptions,
+                ],
+                CType::Int32,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+    );
+}
+impl op_smi_signed_return {
+    pub const fn name() -> &'static str {
+        stringify!(op_smi_signed_return)
+    }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: i32,
+        arg1: i32,
+        arg2: i32,
+        arg3: i32,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> i32 {
+        Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3)
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: i32,
+        arg1: i32,
+        arg2: i32,
+        arg3: i32,
+    ) -> i32 {
+        let result = {
+            let arg0 = arg0 as _;
+            let arg1 = arg1 as _;
+            let arg2 = arg2 as _;
+            let arg3 = arg3 as _;
+            Self::call(arg0, arg1, arg2, arg3)
+        };
+        result as _
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+            &*info
+        });
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        "expected i32".as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return;
+            };
+            let arg0 = arg0 as _;
+            let arg1 = args.get(1usize as i32);
+            let Some(arg1) = deno_core::_ops::to_i32_option(&arg1) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        "expected i32".as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return;
+            };
+            let arg1 = arg1 as _;
+            let arg2 = args.get(2usize as i32);
+            let Some(arg2) = deno_core::_ops::to_i32_option(&arg2) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        "expected i32".as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return;
+            };
+            let arg2 = arg2 as _;
+            let arg3 = args.get(3usize as i32);
+            let Some(arg3) = deno_core::_ops::to_i32_option(&arg3) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        "expected i32".as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return;
+            };
+            let arg3 = arg3 as _;
+            Self::call(arg0, arg1, arg2, arg3)
+        };
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(
+            deno_core::_ops::RustToV8Marker::<
+                deno_core::_ops::SmiMarker,
+                _,
+            >::from(result),
+            &mut rv,
+        )
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
+    }
     #[inline(always)]
     fn call(a: Int16, b: Int32, c: Uint16, d: Uint32) -> Int32 {
         a as Int32 + b as Int32 + c as Int32 + d as Int32
@@ -262,13 +320,13 @@ struct op_smi_option {
 }
 impl deno_core::_ops::Op for op_smi_option {
     const NAME: &'static str = stringify!(op_smi_option);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_smi_option),
-        false,
-        false,
         false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -310,6 +368,9 @@ impl op_smi_option {
             Self::call(arg0)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     fn call(a: Option<Uint32>) -> Option<Uint32> {

--- a/ops/op2/test_cases/sync/string_cow.out
+++ b/ops/op2/test_cases/sync/string_cow.out
@@ -53,12 +53,12 @@ impl op_string_cow {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -111,12 +111,12 @@ impl op_string_cow {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/string_cow.out
+++ b/ops/op2/test_cases/sync/string_cow.out
@@ -44,7 +44,23 @@ impl op_string_cow {
         arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> u32 {
-        Self::v8_fn_ptr_fast(this, arg0)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, arg0);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -86,7 +102,22 @@ impl op_string_cow {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(s: Cow<str>) -> u32 {

--- a/ops/op2/test_cases/sync/string_cow.out
+++ b/ops/op2/test_cases/sync/string_cow.out
@@ -25,7 +25,7 @@ impl deno_core::_ops::Op for op_string_cow {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
                 CType::Uint32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/string_cow.out
+++ b/ops/op2/test_cases/sync/string_cow.out
@@ -4,18 +4,26 @@ struct op_string_cow {
 }
 impl deno_core::_ops::Op for op_string_cow {
     const NAME: &'static str = stringify!(op_string_cow);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_string_cow),
-        false,
-        false,
         false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::SeqOneByteString],
+                CType::Uint32,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
@@ -29,6 +37,14 @@ impl op_string_cow {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> u32 {
+        Self::v8_fn_ptr_fast(this, arg0)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -68,6 +84,9 @@ impl op_string_cow {
             Self::call(arg0)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     fn call(s: Cow<str>) -> u32 {

--- a/ops/op2/test_cases/sync/string_onebyte.out
+++ b/ops/op2/test_cases/sync/string_onebyte.out
@@ -4,18 +4,26 @@ struct op_string_onebyte {
 }
 impl deno_core::_ops::Op for op_string_onebyte {
     const NAME: &'static str = stringify!(op_string_onebyte);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_string_onebyte),
-        false,
-        false,
         false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::SeqOneByteString],
+                CType::Uint32,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
@@ -29,6 +37,14 @@ impl op_string_onebyte {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> u32 {
+        Self::v8_fn_ptr_fast(this, arg0)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -73,6 +89,9 @@ impl op_string_onebyte {
             Self::call(arg0)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     fn call(s: Cow<[u8]>) -> u32 {

--- a/ops/op2/test_cases/sync/string_onebyte.out
+++ b/ops/op2/test_cases/sync/string_onebyte.out
@@ -44,7 +44,23 @@ impl op_string_onebyte {
         arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> u32 {
-        Self::v8_fn_ptr_fast(this, arg0)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, arg0);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -91,7 +107,22 @@ impl op_string_onebyte {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(s: Cow<[u8]>) -> u32 {

--- a/ops/op2/test_cases/sync/string_onebyte.out
+++ b/ops/op2/test_cases/sync/string_onebyte.out
@@ -53,12 +53,12 @@ impl op_string_onebyte {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -116,12 +116,12 @@ impl op_string_onebyte {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/string_onebyte.out
+++ b/ops/op2/test_cases/sync/string_onebyte.out
@@ -25,7 +25,7 @@ impl deno_core::_ops::Op for op_string_onebyte {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
                 CType::Uint32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/string_option_return.out
+++ b/ops/op2/test_cases/sync/string_option_return.out
@@ -4,13 +4,13 @@ pub struct op_string_return {
 }
 impl deno_core::_ops::Op for op_string_return {
     const NAME: &'static str = stringify!(op_string_return);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_string_return),
-        false,
-        false,
         false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -52,6 +52,9 @@ impl op_string_return {
                 return;
             }
         }
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub fn call(s: Option<String>) -> Option<String> {

--- a/ops/op2/test_cases/sync/string_option_return.out
+++ b/ops/op2/test_cases/sync/string_option_return.out
@@ -63,12 +63,12 @@ impl op_string_return {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/string_option_return.out
+++ b/ops/op2/test_cases/sync/string_option_return.out
@@ -54,7 +54,22 @@ impl op_string_return {
         }
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call(s: Option<String>) -> Option<String> {

--- a/ops/op2/test_cases/sync/string_owned.out
+++ b/ops/op2/test_cases/sync/string_owned.out
@@ -4,18 +4,26 @@ struct op_string_owned {
 }
 impl deno_core::_ops::Op for op_string_owned {
     const NAME: &'static str = stringify!(op_string_owned);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_string_owned),
-        false,
-        false,
         false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::SeqOneByteString],
+                CType::Uint32,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
@@ -29,6 +37,14 @@ impl op_string_owned {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> u32 {
+        Self::v8_fn_ptr_fast(this, arg0)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -59,6 +75,9 @@ impl op_string_owned {
             Self::call(arg0)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     fn call(s: String) -> u32 {

--- a/ops/op2/test_cases/sync/string_owned.out
+++ b/ops/op2/test_cases/sync/string_owned.out
@@ -25,7 +25,7 @@ impl deno_core::_ops::Op for op_string_owned {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
                 CType::Uint32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/string_owned.out
+++ b/ops/op2/test_cases/sync/string_owned.out
@@ -44,7 +44,23 @@ impl op_string_owned {
         arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> u32 {
-        Self::v8_fn_ptr_fast(this, arg0)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, arg0);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -77,7 +93,22 @@ impl op_string_owned {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(s: String) -> u32 {

--- a/ops/op2/test_cases/sync/string_owned.out
+++ b/ops/op2/test_cases/sync/string_owned.out
@@ -53,12 +53,12 @@ impl op_string_owned {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -102,12 +102,12 @@ impl op_string_owned {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/string_ref.out
+++ b/ops/op2/test_cases/sync/string_ref.out
@@ -44,7 +44,23 @@ impl op_string_owned {
         arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> u32 {
-        Self::v8_fn_ptr_fast(this, arg0)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, arg0);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -86,7 +102,22 @@ impl op_string_owned {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call(s: &str) -> u32 {

--- a/ops/op2/test_cases/sync/string_ref.out
+++ b/ops/op2/test_cases/sync/string_ref.out
@@ -53,12 +53,12 @@ impl op_string_owned {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -111,12 +111,12 @@ impl op_string_owned {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/string_ref.out
+++ b/ops/op2/test_cases/sync/string_ref.out
@@ -4,18 +4,26 @@ struct op_string_owned {
 }
 impl deno_core::_ops::Op for op_string_owned {
     const NAME: &'static str = stringify!(op_string_owned);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_string_owned),
-        false,
-        false,
         false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::SeqOneByteString],
+                CType::Uint32,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
@@ -29,6 +37,14 @@ impl op_string_owned {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> u32 {
+        Self::v8_fn_ptr_fast(this, arg0)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -68,6 +84,9 @@ impl op_string_owned {
             Self::call(arg0)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     fn call(s: &str) -> u32 {

--- a/ops/op2/test_cases/sync/string_ref.out
+++ b/ops/op2/test_cases/sync/string_ref.out
@@ -25,7 +25,7 @@ impl deno_core::_ops::Op for op_string_owned {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
                 CType::Uint32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/string_return.out
+++ b/ops/op2/test_cases/sync/string_return.out
@@ -43,7 +43,22 @@ impl op_string_return {
         }
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call() -> String {
@@ -96,7 +111,22 @@ impl op_string_return_ref {
         }
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call() -> &'static str {
@@ -149,7 +179,22 @@ impl op_string_return_cow {
         }
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call<'a>() -> Cow<'a, str> {

--- a/ops/op2/test_cases/sync/string_return.out
+++ b/ops/op2/test_cases/sync/string_return.out
@@ -52,12 +52,12 @@ impl op_string_return {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]
@@ -120,12 +120,12 @@ impl op_string_return_ref {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]
@@ -188,12 +188,12 @@ impl op_string_return_cow {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/string_return.out
+++ b/ops/op2/test_cases/sync/string_return.out
@@ -4,13 +4,13 @@ pub struct op_string_return {
 }
 impl deno_core::_ops::Op for op_string_return {
     const NAME: &'static str = stringify!(op_string_return);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_string_return),
-        false,
-        false,
         false,
         0usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -42,6 +42,9 @@ impl op_string_return {
             }
         }
     }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
+    }
     #[inline(always)]
     pub fn call() -> String {
         "".into()
@@ -54,13 +57,13 @@ pub struct op_string_return_ref {
 }
 impl deno_core::_ops::Op for op_string_return_ref {
     const NAME: &'static str = stringify!(op_string_return_ref);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_string_return_ref),
-        false,
-        false,
         false,
         0usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -92,6 +95,9 @@ impl op_string_return_ref {
             }
         }
     }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
+    }
     #[inline(always)]
     pub fn call() -> &'static str {
         ""
@@ -104,13 +110,13 @@ pub struct op_string_return_cow {
 }
 impl deno_core::_ops::Op for op_string_return_cow {
     const NAME: &'static str = stringify!(op_string_return_cow);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_string_return_cow),
-        false,
-        false,
         false,
         0usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -141,6 +147,9 @@ impl op_string_return_cow {
                 return;
             }
         }
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub fn call<'a>() -> Cow<'a, str> {

--- a/ops/op2/test_cases/sync/v8_global.out
+++ b/ops/op2/test_cases/sync/v8_global.out
@@ -4,13 +4,13 @@ pub struct op_global {
 }
 impl deno_core::_ops::Op for op_global {
     const NAME: &'static str = stringify!(op_global);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_global),
-        false,
-        false,
         false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -50,6 +50,9 @@ impl op_global {
             Self::call(arg0)
         };
         rv.set(deno_core::_ops::RustToV8::to_v8(result, &mut scope))
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub fn call(g: v8::Global<v8::String>) -> v8::Global<v8::String> {

--- a/ops/op2/test_cases/sync/v8_global.out
+++ b/ops/op2/test_cases/sync/v8_global.out
@@ -61,12 +61,12 @@ impl op_global {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/v8_global.out
+++ b/ops/op2/test_cases/sync/v8_global.out
@@ -52,7 +52,22 @@ impl op_global {
         rv.set(deno_core::_ops::RustToV8::to_v8(result, &mut scope))
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call(g: v8::Global<v8::String>) -> v8::Global<v8::String> {

--- a/ops/op2/test_cases/sync/v8_handlescope.out
+++ b/ops/op2/test_cases/sync/v8_handlescope.out
@@ -61,12 +61,12 @@ impl op_handlescope {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/v8_handlescope.out
+++ b/ops/op2/test_cases/sync/v8_handlescope.out
@@ -52,7 +52,22 @@ impl op_handlescope {
         rv.set(deno_core::_ops::RustToV8NoScope::to_v8(result))
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call<'a>(

--- a/ops/op2/test_cases/sync/v8_handlescope.out
+++ b/ops/op2/test_cases/sync/v8_handlescope.out
@@ -4,13 +4,13 @@ struct op_handlescope {
 }
 impl deno_core::_ops::Op for op_handlescope {
     const NAME: &'static str = stringify!(op_handlescope);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_handlescope),
-        false,
-        false,
         false,
         2usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -50,6 +50,9 @@ impl op_handlescope {
             Self::call(arg0, arg1)
         };
         rv.set(deno_core::_ops::RustToV8NoScope::to_v8(result))
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     fn call<'a>(

--- a/ops/op2/test_cases/sync/v8_lifetime.out
+++ b/ops/op2/test_cases/sync/v8_lifetime.out
@@ -51,7 +51,22 @@ impl op_v8_lifetime {
         rv.set(deno_core::_ops::RustToV8NoScope::to_v8(result))
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call<'s>(_s: v8::Local<'s, v8::String>) -> v8::Local<'s, v8::String> {

--- a/ops/op2/test_cases/sync/v8_lifetime.out
+++ b/ops/op2/test_cases/sync/v8_lifetime.out
@@ -60,12 +60,12 @@ impl op_v8_lifetime {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/v8_lifetime.out
+++ b/ops/op2/test_cases/sync/v8_lifetime.out
@@ -4,13 +4,13 @@ pub struct op_v8_lifetime {
 }
 impl deno_core::_ops::Op for op_v8_lifetime {
     const NAME: &'static str = stringify!(op_v8_lifetime);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_v8_lifetime),
-        false,
-        false,
         false,
         1usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -49,6 +49,9 @@ impl op_v8_lifetime {
             Self::call(arg0)
         };
         rv.set(deno_core::_ops::RustToV8NoScope::to_v8(result))
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub fn call<'s>(_s: v8::Local<'s, v8::String>) -> v8::Local<'s, v8::String> {

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -45,7 +45,23 @@ impl op_v8_lifetime {
         arg1: deno_core::v8::Local<deno_core::v8::Value>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
-        Self::v8_fn_ptr_fast(this, arg0, arg1, fast_api_callback_options)
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        let res = Self::v8_fn_ptr_fast(this, arg0, arg1, fast_api_callback_options);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
+        res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -131,7 +147,22 @@ impl op_v8_lifetime {
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     pub fn call<'s>(_s: Option<&v8::String>, _s2: Option<&v8::String>) {}

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -4,13 +4,21 @@ pub struct op_v8_lifetime {
 }
 impl deno_core::_ops::Op for op_v8_lifetime {
     const NAME: &'static str = stringify!(op_v8_lifetime);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_v8_lifetime),
-        false,
-        false,
         false,
         2usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::V8Value, Type::V8Value, Type::CallbackOptions],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
@@ -29,6 +37,15 @@ impl op_v8_lifetime {
     #[deprecated(note = "Use the const op::DECL instead")]
     pub const fn decl() -> deno_core::_ops::OpDecl {
         <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: deno_core::v8::Local<deno_core::v8::Value>,
+        arg1: deno_core::v8::Local<deno_core::v8::Value>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        Self::v8_fn_ptr_fast(this, arg0, arg1, fast_api_callback_options)
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
@@ -112,6 +129,9 @@ impl op_v8_lifetime {
             Self::call(arg0, arg1)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     pub fn call<'s>(_s: Option<&v8::String>, _s2: Option<&v8::String>) {}

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -54,12 +54,12 @@ impl op_v8_lifetime {
         };
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, arg1, fast_api_callback_options);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
@@ -156,12 +156,12 @@ impl op_v8_lifetime {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -25,7 +25,7 @@ impl deno_core::_ops::Op for op_v8_lifetime {
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::V8Value, Type::V8Value, Type::CallbackOptions],
                 CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
     );

--- a/ops/op2/test_cases/sync/v8_string.out
+++ b/ops/op2/test_cases/sync/v8_string.out
@@ -4,13 +4,13 @@ struct op_v8_string {
 }
 impl deno_core::_ops::Op for op_v8_string {
     const NAME: &'static str = stringify!(op_v8_string);
-    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal(
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_v8_string),
-        false,
-        false,
         false,
         2usize as u8,
         Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
         None,
     );
 }
@@ -65,6 +65,9 @@ impl op_v8_string {
             Self::call(arg0, arg1)
         };
         rv.set(deno_core::_ops::RustToV8NoScope::to_v8(result))
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::v8_fn_ptr(info)
     }
     #[inline(always)]
     fn call<'a>(

--- a/ops/op2/test_cases/sync/v8_string.out
+++ b/ops/op2/test_cases/sync/v8_string.out
@@ -67,7 +67,22 @@ impl op_v8_string {
         rv.set(deno_core::_ops::RustToV8NoScope::to_v8(result))
     }
     extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::v8_fn_ptr(info)
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Enter,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Leave,
+        );
     }
     #[inline(always)]
     fn call<'a>(

--- a/ops/op2/test_cases/sync/v8_string.out
+++ b/ops/op2/test_cases/sync/v8_string.out
@@ -76,12 +76,12 @@ impl op_v8_string {
         };
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Enter,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         Self::v8_fn_ptr(info);
         deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            deno_core::_ops::OpMetricsEvent::Leave,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
     }
     #[inline(always)]


### PR DESCRIPTION
Introduces a basic metrics API for op2 that is zero cost when unused, pluggable-per-op and a flexible system that we can add more to in the future.

As we remove op1 from the system, we will likely be able to simplify the async portion of this metrics system. Right now we're juggling the old and new op systems.

The metrics function gets a reference to the op's per-realm OpCtx, and a metrics event (`Enter`, `Leave`, `Exception`). Async function also have `LeaveAsync`, `ExceptionAsync` if they return a value/error asynchronously.

```rust
  let mut runtime = JsRuntime::new(RuntimeOptions {
    extensions: vec![test_ext::init_ops()],
    op_metrics_fn: Some(Box::new(move |op| {
      if !op.name.starts_with("op_async") && !op.name.starts_with("op_sync") {
        return None;
      }
      Some(Rc::new(move |op, metrics| {
        println!("{} {:?}", op.name, metrics);
      }))
    })),
    ..Default::default()
  });
```