### PR TITLE
fix(ops): correctly handle multiple array buffers in op_deserialize

### DIFF
--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -493,7 +493,7 @@ pub fn op_deserialize<'a>(
           let array_buffer =
             v8::ArrayBuffer::with_backing_store(scope, &backing_store);
           value_deserializer.transfer_array_buffer(id, array_buffer);
-          transferred_array_buffers.set(scope, id_val, array_buffer.into());
+          transferred_array_buffers.set(scope, i, array_buffer.into());
         } else {
           return Err(type_error(
             "transferred array buffer not present in shared_array_buffer_store",

--- a/core/runtime/tests/mod.rs
+++ b/core/runtime/tests/mod.rs
@@ -3,6 +3,7 @@ use crate::error::AnyError;
 use crate::JsRuntime;
 use crate::OpState;
 use crate::RuntimeOptions;
+use crate::CrossIsolateStore;
 use deno_ops::op;
 use serde_v8::JsBuffer;
 use std::cell::RefCell;
@@ -82,6 +83,7 @@ fn setup(mode: Mode) -> (JsRuntime, Arc<AtomicUsize>) {
     get_error_class_fn: Some(&|error| {
       crate::error::get_custom_error_class(error).unwrap()
     }),
+    shared_array_buffer_store: Some(CrossIsolateStore::default()),
     ..Default::default()
   });
 

--- a/core/runtime/tests/mod.rs
+++ b/core/runtime/tests/mod.rs
@@ -1,9 +1,9 @@
 use crate as deno_core;
 use crate::error::AnyError;
+use crate::CrossIsolateStore;
 use crate::JsRuntime;
 use crate::OpState;
 use crate::RuntimeOptions;
-use crate::CrossIsolateStore;
 use deno_ops::op;
 use serde_v8::JsBuffer;
 use std::cell::RefCell;

--- a/core/runtime/tests/serialize_deserialize_test.js
+++ b/core/runtime/tests/serialize_deserialize_test.js
@@ -17,6 +17,35 @@ function assertArrayEquals(a1, a2) {
   }
 }
 
+function testIssue20727() {
+  // https://github.com/denoland/deno/issues/20727
+  const ab = new ArrayBuffer(10);
+  Deno.core.ops.op_serialize(
+    { ab },
+    { transferredArrayBuffers: [ab] },
+  );
+
+  const data = {
+    array1: new Uint32Array([]),
+    array2: new Float32Array([]),
+  };
+
+  const transferredArrayBuffers = [
+    data.array1.buffer,
+    data.array2.buffer,
+  ];
+  const serializedMultipleTransferredBuffers = Deno.core.ops.op_serialize(
+    { id: 2, data },
+    { transferredArrayBuffers },
+  );
+  // should not throw
+  Deno.core.ops.op_deserialize(
+    serializedMultipleTransferredBuffers,
+    { transferredArrayBuffers },
+  );
+}
+
+
 function main() {
   const emptyString = "";
   const emptyStringSerialized = [255, 15, 34, 0];
@@ -69,6 +98,8 @@ function main() {
     new Uint8Array(circularObjectSerialized),
   );
   assert(deserializedCircularObject.test == deserializedCircularObject);
+
+  testIssue20727();
 }
 
 main();

--- a/core/runtime/tests/serialize_deserialize_test.js
+++ b/core/runtime/tests/serialize_deserialize_test.js
@@ -20,31 +20,36 @@ function assertArrayEquals(a1, a2) {
 function testIssue20727() {
   // https://github.com/denoland/deno/issues/20727
   const ab = new ArrayBuffer(10);
-  Deno.core.ops.op_serialize(
+  const transferList = [ab];
+  Deno.core.serialize(
     { ab },
-    { transferredArrayBuffers: [ab] },
+    { transferredArrayBuffers: transferList },
   );
 
+  // check that shared_array_buffer_store is set
+  assert(typeof transferList[0] === "number");
   const data = {
     array1: new Uint32Array([]),
     array2: new Float32Array([]),
   };
 
-  const transferredArrayBuffers = [
+  const transferListTwo = [
     data.array1.buffer,
     data.array2.buffer,
   ];
   const serializedMultipleTransferredBuffers = Deno.core.ops.op_serialize(
     { id: 2, data },
-    { transferredArrayBuffers },
+    { transferredArrayBuffers: transferListTwo },
   );
+
+  assert(typeof transferListTwo[0] === "number");
+  assert(typeof transferListTwo[1] === "number");
   // should not throw
   Deno.core.ops.op_deserialize(
     serializedMultipleTransferredBuffers,
-    { transferredArrayBuffers },
+    { transferredArrayBuffers: transferListTwo },
   );
 }
-
 
 function main() {
   const emptyString = "";


### PR DESCRIPTION
This PR fixes `op_deserialize` when multiple array buffers are transferred.

fixes  https://github.com/denoland/deno/issues/20727
