### PR TITLE
fix: op2 #[anybuffer] byte offset

### DIFF
--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -666,8 +666,10 @@ pub unsafe fn to_slice_buffer_any(
 ) -> Result<&mut [u8], &'static str> {
   let (data, len) = {
     if let Ok(buf) = v8::Local::<v8::ArrayBufferView>::try_from(input) {
-      (NonNull::new(buf.data()), buf.byte_length())
+      eprintln!("is array buffer view {:#?} {} {}", buf.data(), buf.byte_length(), buf.byte_offset());
+      (NonNull::new(buf.data()), buf.byte_length() - buf.byte_offset())
     } else if let Ok(buf) = v8::Local::<v8::ArrayBuffer>::try_from(input) {
+      eprintln!("is array buffer");
       (buf.data(), buf.byte_length())
     } else {
       return Err("expected ArrayBuffer or ArrayBufferView");
@@ -1834,27 +1836,32 @@ mod tests {
   }
 
   #[tokio::test]
-  pub async fn test_op_buffer_any() -> Result<(), Box<dyn std::error::Error>> {
+  pub async fn test_op_buffer_any2() -> Result<(), Box<dyn std::error::Error>> {
     run_test2(
       10000,
       "op_buffer_any",
-      "assert(op_buffer_any(new Uint8Array([1,2,3,4])) == 10);",
+      "assert(op_buffer_any(new Uint8Array([1,2,3,4], 2)) == 7);",
     )?;
-    run_test2(
-      10000,
-      "op_buffer_any",
-      "assert(op_buffer_any(new Uint8Array([1,2,3,4]).buffer) == 10);",
-    )?;
-    run_test2(
-      10000,
-      "op_buffer_any",
-      "assert(op_buffer_any(new Uint32Array([1,2,3,4,0x01010101])) == 14);",
-    )?;
-    run_test2(
-      10000,
-      "op_buffer_any",
-      "assert(op_buffer_any(new DataView(new Uint8Array([1,2,3,4]).buffer)) == 10);",
-    )?;
+    // run_test2(
+    //   10000,
+    //   "op_buffer_any",
+    //   "assert(op_buffer_any(new Uint8Array([1,2,3,4])) == 10);",
+    // )?;
+    // run_test2(
+    //   10000,
+    //   "op_buffer_any",
+    //   "assert(op_buffer_any(new Uint8Array([1,2,3,4]).buffer) == 10);",
+    // )?;
+    // run_test2(
+    //   10000,
+    //   "op_buffer_any",
+    //   "assert(op_buffer_any(new Uint32Array([1,2,3,4,0x01010101])) == 14);",
+    // )?;
+    // run_test2(
+    //   10000,
+    //   "op_buffer_any",
+    //   "assert(op_buffer_any(new DataView(new Uint8Array([1,2,3,4]).buffer)) == 10);",
+    // )?;
     Ok(())
   }
 

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -856,6 +856,7 @@ mod tests {
 
   #[op2(core, fast)]
   pub fn op_test_fail() {
+    eprintln!("op test fail");
     FAIL.with(|b| b.set(true))
   }
 
@@ -881,6 +882,11 @@ mod tests {
             const {{ op_test_fail, op_test_print_debug, {op} }} = Deno.core.ensureFastOps();
             function assert(b) {{
               if (!b) {{
+                op_test_fail();
+              }}
+            }}
+            function assertEquals(a, b) {{
+              if (a !== b) {{
                 op_test_fail();
               }}
             }}
@@ -911,6 +917,7 @@ mod tests {
       ),
     )?;
     if FAIL.with(|b| b.get()) {
+      eprintln!("test failed!!!!");
       Err(generic_error(format!("{op} test failed ({test})")))
     } else {
       Ok(())
@@ -1872,7 +1879,7 @@ mod tests {
 
   #[op2(core, fast)]
   pub fn op_buffer_any_length(#[anybuffer] buffer: &[u8]) -> u32 {
-    eprintln!("length {}", buffer.len() as u32);
+    eprintln!("length {:?} {}", buffer, buffer.len() as u32);
     buffer.len() as _
   }
 
@@ -1887,28 +1894,29 @@ mod tests {
       for (var i = 0; i < 8; i++) {
         view[i] = i;
       }
-      assert(op_buffer_any_length(view) == 6);",
+      log(op_buffer_any_length(view));
+      assertEquals(op_buffer_any_length(view), 6);",
     )?;
-    run_test2(
-      10000,
-      "op_buffer_any_length",
-      "assert(op_buffer_any_length(new Uint8Array(10)) == 10);",
-    )?;
-    run_test2(
-      10000,
-      "op_buffer_any_length",
-      "assert(op_buffer_any_length(new ArrayBuffer(10)) == 10);",
-    )?;
-    run_test2(
-      10000,
-      "op_buffer_any_length",
-      "assert(op_buffer_any_length(new Uint32Array(10)) == 40);",
-    )?;
-    run_test2(
-      10000,
-      "op_buffer_any_length",
-      "assert(op_buffer_any_length(new DataView(new ArrayBuffer(10))) == 10);",
-    )?;
+    // run_test2(
+    //   10000,
+    //   "op_buffer_any_length",
+    //   "assert(op_buffer_any_length(new Uint8Array(10)) == 10);",
+    // )?;
+    // run_test2(
+    //   10000,
+    //   "op_buffer_any_length",
+    //   "assert(op_buffer_any_length(new ArrayBuffer(10)) == 10);",
+    // )?;
+    // run_test2(
+    //   10000,
+    //   "op_buffer_any_length",
+    //   "assert(op_buffer_any_length(new Uint32Array(10)) == 40);",
+    // )?;
+    // run_test2(
+    //   10000,
+    //   "op_buffer_any_length",
+    //   "assert(op_buffer_any_length(new DataView(new ArrayBuffer(10))) == 10);",
+    // )?;
     Ok(())
   }
 

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -682,7 +682,6 @@ pub unsafe fn to_slice_buffer_any(
   } else {
     &mut []
   };
-  eprintln!("slice {:?} {}", slice, slice.len());
   Ok(slice)
 }
 
@@ -856,7 +855,6 @@ mod tests {
 
   #[op2(core, fast)]
   pub fn op_test_fail() {
-    eprintln!("op test fail");
     FAIL.with(|b| b.set(true))
   }
 
@@ -912,7 +910,6 @@ mod tests {
       ),
     )?;
     if FAIL.with(|b| b.get()) {
-      eprintln!("test failed!!!!");
       Err(generic_error(format!("{op} test failed ({test})")))
     } else {
       Ok(())

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -1850,6 +1850,16 @@ mod tests {
     run_test2(
       10000,
       "op_buffer_any",
+      "const data = new ArrayBuffer(8);
+      const view = new Uint8Array(data, 2, 4);
+      for (var i = 0; i < 8; i++) {
+        view[i] = i;
+      }
+      assert(op_buffer_any(view) == 6);",
+    )?;
+    run_test2(
+      10000,
+      "op_buffer_any",
       "assert(op_buffer_any(new Uint8Array([1,2,3,4])) == 10);",
     )?;
     run_test2(
@@ -1887,6 +1897,16 @@ mod tests {
         view[i] = i;
       }
       assert(op_buffer_any_length(view) == 6);",
+    )?;
+    run_test2(
+      10000,
+      "op_buffer_any_length",
+      "const data = new ArrayBuffer(8);
+      const view = new Uint8Array(data, 2, 4);
+      for (var i = 0; i < 8; i++) {
+        view[i] = i;
+      }
+      assert(op_buffer_any_length(view) == 4);",
     )?;
     run_test2(
       10000,

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -723,14 +723,15 @@ pub fn to_v8_slice_any(
   input: v8::Local<v8::Value>,
 ) -> Result<serde_v8::V8Slice<u8>, &'static str> {
   if let Ok(buf) = v8::Local::<v8::ArrayBufferView>::try_from(input) {
-    let byte_offset = buf.byte_offset();
+    let offset = buf.byte_offset();
+    let len = buf.byte_length();
     let Some(buf) = buf.buffer(scope) else {
       return Err("buffer missing");
     };
     return Ok(unsafe {
       serde_v8::V8Slice::<u8>::from_parts(
         buf.get_backing_store(),
-        byte_offset..buf.byte_length(),
+        offset..offset + len,
       )
     });
   }
@@ -1835,7 +1836,7 @@ mod tests {
   }
 
   #[tokio::test]
-  pub async fn test_op_buffer_any2() -> Result<(), Box<dyn std::error::Error>> {
+  pub async fn test_op_buffer_any() -> Result<(), Box<dyn std::error::Error>> {
     run_test2(
       10000,
       "op_buffer_any",


### PR DESCRIPTION
Trying to fix WPT for WS which construct `Uint8Array` with byte offset of 2 and length 8;
and expect a Uint8Array of length 6 to be returned.