### PR TITLE
perf: use V8 Deno builtins

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -40,6 +40,12 @@
   } = window.__bootstrap.primordials;
   const { ops, asyncOps } = window.Deno.core;
 
+  // Deno specific builtins.
+  const { fromUtf8, toUtf8, isOneByte } = window;
+  delete window.fromUtf8;
+  delete window.toUtf8;
+  delete window.isOneByte;
+
   const build = {
     target: "unknown",
     arch: "unknown",
@@ -853,8 +859,8 @@ for (let i = 0; i < 10; i++) {
       specifier,
     ) => ops.op_eval_context(source, specifier),
     createHostObject: () => ops.op_create_host_object(),
-    encode: (text) => ops.op_encode(text),
-    decode: (buffer) => ops.op_decode(buffer),
+    encode: (text) => new Uint8Array(toUtf8(text)),
+    decode: (buffer, ignoreBOM = false) => fromUtf8(buffer, ignoreBOM),
     serialize: (
       value,
       options,
@@ -878,6 +884,7 @@ for (let i = 0; i < 10; i++) {
     build,
     setBuildInfo,
     currentUserCallSite,
+    isOneByte,
   });
 
   const internals = {};

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -341,6 +341,7 @@ fn v8_init(
     " --no-validate-asm",
     " --turbo_fast_api_calls",
     " --harmony-change-array-by-copy",
+    " --expose_deno_builtins",
   );
   let predictable_flags = "--predictable --random-seed=42";
   let expose_natives_flags = "--expose_gc --allow_natives_syntax";


### PR DESCRIPTION
Upto 2x faster encode/decode

```
divy@mini ~/g/deno (main)> deno run -A bench.js
decode: Hello 😃
cpu: unknown
runtime: deno 1.36.4 (aarch64-apple-darwin)

benchmark      time (avg)             (min … max)    
--------------------------------------------------
            122.27 ns/iter  (122.02 ns … 215.82 ns)  

divy@mini ~/g/deno (main)> target/release/deno run -A bench.js
decode: Hello 😃
cpu: unknown
runtime: deno 1.36.4 (aarch64-apple-darwin)

benchmark      time (avg)             (min … max)       
---------------------------------------------------
            64.02 ns/iter  (62.81 ns … 139.55 ns) 
```