### PR TITLE
feat(ops): support fast(op_other) for fastcall alternatives

### DIFF
--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -181,6 +181,22 @@ impl OpDecl {
       ..self
     }
   }
+
+  #[doc(hidden)]
+  pub const fn fast_fn(self) -> FastFunction {
+    let Some(f) = self.fast_fn else {
+      panic!("Not a fast function");
+    };
+    f
+  }
+
+  #[doc(hidden)]
+  pub const fn fast_fn_with_metrics(self) -> FastFunction {
+    let Some(f) = self.fast_fn_with_metrics else {
+      panic!("Not a fast function");
+    };
+    f
+  }
 }
 
 /// Declares a block of Deno `#[op]`s. The first parameter determines the name of the

--- a/ops/op2/README.md
+++ b/ops/op2/README.md
@@ -71,6 +71,17 @@ used if you really know what you are doing.
 Lazy `async(deferred)` calls _may_ be fastcalls, though the resolution will
 still happen on a slow path.
 
+## fastcalls
+
+`op2` requires fastcall-compatible ops to be annotated with `fast`. If you wish to avoid fastcalls
+for some reason (this is unlikely), you can specify `nofast` instead.
+
+You may also choose an alternate op function to use as the fastcall equivalent to a slow function. In
+this case, you can specify `fast(op_XYZ)`. The other op must be decorated with `#[op2(fast)]`, and does
+not need to be registered. When v8 optimized the slow function to a fastcall, it will switch the implementation
+over if the parameters are compatible. This is useful for a function that takes any buffer type in the slow
+path and wishes to use the very fast typed `u8` buffer for the fast path.
+
 # Parameters
 
 <!-- START ARGS -->

--- a/ops/op2/config.rs
+++ b/ops/op2/config.rs
@@ -13,6 +13,8 @@ pub(crate) struct MacroConfig {
   pub fast: bool,
   /// Do not generate a fastcall method (must be fastcall compatible).
   pub nofast: bool,
+  /// Use other ops for the fast alternatives, rather than generating one for this op.
+  pub fast_alternatives: Vec<String>,
   /// Marks an async function (either `async fn` or `fn -> impl Future`)
   pub r#async: bool,
   /// Marks an lazy async function (async must also be true)
@@ -24,13 +26,13 @@ pub(crate) struct MacroConfig {
 impl MacroConfig {
   fn from_token_trees(
     flags: Vec<TokenTree>,
-    args: Vec<Option<Vec<TokenTree>>>,
+    args: Vec<Option<Vec<impl ToTokens>>>,
   ) -> Result<Self, Op2Error> {
     let flags = flags.into_iter().zip(args.into_iter()).map(|(flag, args)| {
       if let Some(args) = args {
         let args = args
           .into_iter()
-          .map(|arg| arg.to_string())
+          .map(|arg| arg.to_token_stream().to_string())
           .collect::<Vec<_>>()
           .join(",");
         format!("{}({args})", flag.into_token_stream())
@@ -60,6 +62,18 @@ impl MacroConfig {
         config.core = true;
       } else if flag == "fast" {
         config.fast = true;
+      } else if flag.starts_with("fast(") {
+        let tokens =
+          syn::parse_str::<TokenTree>(&flag[4..])?.into_token_stream();
+        config.fast_alternatives = std::panic::catch_unwind(|| {
+          rules!(tokens => {
+            ( ( $( $types:ty ),+ ) ) => {
+              types.into_iter().map(|s| s.into_token_stream().to_string().replace(' ', ""))
+            }
+          })
+        })
+        .map_err(|_| Op2Error::PatternMatchFailed("attribute", flag))?
+        .collect::<Vec<_>>();
       } else if flag == "nofast" {
         config.nofast = true;
       } else if flag == "async" {
@@ -78,6 +92,12 @@ impl MacroConfig {
     // Test for invalid attribute combinations
     if config.fast && config.nofast {
       return Err(Op2Error::InvalidAttributeCombination("fast", "nofast"));
+    }
+    if config.fast && !config.fast_alternatives.is_empty() {
+      return Err(Op2Error::InvalidAttributeCombination("fast", "fast(...)"));
+    }
+    if config.fast_alternatives.len() > 1 {
+      return Err(Op2Error::TooManyFastAlternatives);
     }
     if config.fast
       && (config.r#async && !config.async_lazy && !config.async_deferred)
@@ -103,7 +123,7 @@ impl MacroConfig {
         () => {
           Ok(MacroConfig::default())
         }
-        ( $($flags:tt $( ( $( $args:tt ),* ) )? ),+ ) => {
+        ( $($flags:tt $( ( $( $args:ty ),* ) )? ),+ ) => {
           Self::from_token_trees(flags, args)
         }
       })
@@ -118,7 +138,7 @@ impl MacroConfig {
 
     let config = std::panic::catch_unwind(|| {
       rules!(tokens.into_token_stream() => {
-        ( ( $($flags:tt $( ( $( $args:tt ),* ) )? ),+ ) ) => {
+        ( ( $($flags:tt $( ( $( $args:ty ),* ) )? ),+ ) ) => {
           Self::from_token_trees(flags, args)
         }
       })
@@ -195,6 +215,20 @@ mod tests {
       MacroConfig {
         r#async: true,
         core: true,
+        ..Default::default()
+      },
+    );
+    test_parse(
+      "(fast(op_other1))",
+      MacroConfig {
+        fast_alternatives: vec!["op_other1".to_owned()],
+        ..Default::default()
+      },
+    );
+    test_parse(
+      "(fast(op_generic::<T>))",
+      MacroConfig {
+        fast_alternatives: vec!["op_generic::<T>".to_owned()],
         ..Default::default()
       },
     );

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -369,6 +369,18 @@ pub(crate) fn generate_dispatch_fast(
   Option<(TokenStream, TokenStream, TokenStream)>,
   V8SignatureMappingError,
 > {
+  if let Some(alternative) = config.fast_alternatives.get(0) {
+    // TODO(mmastrac): we should validate the alternatives. For now we just assume the caller knows what
+    // they are doing.
+    let alternative =
+      syn::parse_str::<Type>(alternative).expect("Failed to reparse type");
+    return Ok(Some((
+      quote!(#alternative::DECL.fast_fn()),
+      quote!(#alternative::DECL.fast_fn_with_metrics()),
+      quote!(),
+    )));
+  }
+
   // async(lazy) can be fast
   if signature.ret_val.is_async()
     && !config.async_lazy

--- a/ops/op2/mod.rs
+++ b/ops/op2/mod.rs
@@ -59,6 +59,8 @@ pub enum Op2Error {
   ShouldBeAsync,
   #[error("This op is not async and should not be marked as (async)")]
   ShouldNotBeAsync,
+  #[error("Only one fast alternative is supported in fast(...) at this time")]
+  TooManyFastAlternatives,
   #[error("The flags for this attribute were not sorted alphabetically. They should be listed as '({0})'.")]
   ImproperlySortedAttribute(String),
 }
@@ -202,7 +204,8 @@ fn generate_op2(
   let (fast_definition, fast_definition_metrics, fast_fn) =
     match generate_dispatch_fast(&config, &mut generator_state, &signature)? {
       Some((fast_definition, fast_metrics_definition, fast_fn)) => {
-        if !config.fast && !config.nofast {
+        if !config.fast && !config.nofast && config.fast_alternatives.is_empty()
+        {
           return Err(Op2Error::ShouldBeFast);
         }
         // nofast requires the function to be valid for fast

--- a/ops/op2/test_cases/sync/fast_alternative.out
+++ b/ops/op2/test_cases/sync/fast_alternative.out
@@ -1,0 +1,459 @@
+#[allow(non_camel_case_types)]
+struct op_slow {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
+impl deno_core::_ops::Op for op_slow {
+    const NAME: &'static str = stringify!(op_slow);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
+        stringify!(op_slow),
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        Some({ op_fast::DECL.fast_fn() }),
+        Some({ op_fast::DECL.fast_fn_with_metrics() }),
+    );
+}
+impl op_slow {
+    pub const fn name() -> &'static str {
+        stringify!(op_slow)
+    }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+            &*info
+        });
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        "expected u32".as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return;
+            };
+            let arg0 = arg0 as _;
+            let arg1 = args.get(1usize as i32);
+            let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        "expected u32".as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return;
+            };
+            let arg1 = arg1 as _;
+            Self::call(arg0, arg1)
+        };
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Completed,
+        );
+    }
+    #[inline(always)]
+    fn call(a: u32, b: u32) -> u32 {
+        a + b
+    }
+}
+
+#[allow(non_camel_case_types)]
+struct op_fast {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
+impl deno_core::_ops::Op for op_fast {
+    const NAME: &'static str = stringify!(op_fast);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
+        stringify!(op_fast),
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::Uint32, Type::Uint32],
+                CType::Uint32,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::Uint32, Type::Uint32, Type::CallbackOptions],
+                CType::Uint32,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+            )
+        }),
+    );
+}
+impl op_fast {
+    pub const fn name() -> &'static str {
+        stringify!(op_fast)
+    }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: u32,
+        arg1: u32,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> u32 {
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
+        );
+        let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Completed,
+        );
+        res
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: u32,
+        arg1: u32,
+    ) -> u32 {
+        let result = {
+            let arg0 = arg0 as _;
+            let arg1 = arg1 as _;
+            Self::call(arg0, arg1)
+        };
+        result as _
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+            &*info
+        });
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        "expected u32".as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return;
+            };
+            let arg0 = arg0 as _;
+            let arg1 = args.get(1usize as i32);
+            let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        "expected u32".as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return;
+            };
+            let arg1 = arg1 as _;
+            Self::call(arg0, arg1)
+        };
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Completed,
+        );
+    }
+    #[inline(always)]
+    fn call(a: u32, b: u32) -> u32 {
+        a + b
+    }
+}
+
+#[allow(non_camel_case_types)]
+struct op_slow_generic<T> {
+    _unconstructable: ::std::marker::PhantomData<(T)>,
+}
+impl<T: Trait> deno_core::_ops::Op for op_slow_generic<T> {
+    const NAME: &'static str = stringify!(op_slow_generic);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
+        stringify!(op_slow_generic),
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        Some({ op_fast_generic::<T>::DECL.fast_fn() }),
+        Some({ op_fast_generic::<T>::DECL.fast_fn_with_metrics() }),
+    );
+}
+impl<T: Trait> op_slow_generic<T> {
+    pub const fn name() -> &'static str {
+        stringify!(op_slow_generic)
+    }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+            &*info
+        });
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        "expected u32".as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return;
+            };
+            let arg0 = arg0 as _;
+            let arg1 = args.get(1usize as i32);
+            let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        "expected u32".as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return;
+            };
+            let arg1 = arg1 as _;
+            Self::call(arg0, arg1)
+        };
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Completed,
+        );
+    }
+    #[inline(always)]
+    fn call(a: u32, b: u32) -> u32 {
+        a + b
+    }
+}
+
+#[allow(non_camel_case_types)]
+struct op_fast_generic<T> {
+    _unconstructable: ::std::marker::PhantomData<(T)>,
+}
+impl<T: Trait> deno_core::_ops::Op for op_fast_generic<T> {
+    const NAME: &'static str = stringify!(op_fast_generic);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
+        stringify!(op_fast_generic),
+        false,
+        2usize as u8,
+        Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::Uint32, Type::Uint32],
+                CType::Uint32,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::Uint32, Type::Uint32, Type::CallbackOptions],
+                CType::Uint32,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+            )
+        }),
+    );
+}
+impl<T: Trait> op_fast_generic<T> {
+    pub const fn name() -> &'static str {
+        stringify!(op_fast_generic)
+    }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: u32,
+        arg1: u32,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> u32 {
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
+        );
+        let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Completed,
+        );
+        res
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: u32,
+        arg1: u32,
+    ) -> u32 {
+        let result = {
+            let arg0 = arg0 as _;
+            let arg1 = arg1 as _;
+            Self::call(arg0, arg1)
+        };
+        result as _
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+            &*info
+        });
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        "expected u32".as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return;
+            };
+            let arg0 = arg0 as _;
+            let arg1 = args.get(1usize as i32);
+            let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        "expected u32".as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return;
+            };
+            let arg1 = arg1 as _;
+            Self::call(arg0, arg1)
+        };
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Completed,
+        );
+    }
+    #[inline(always)]
+    fn call(a: u32, b: u32) -> u32 {
+        a + b
+    }
+}

--- a/ops/op2/test_cases/sync/fast_alternative.out
+++ b/ops/op2/test_cases/sync/fast_alternative.out
@@ -7,7 +7,7 @@ impl deno_core::_ops::Op for op_slow {
     const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_slow),
         false,
-        2usize as u8,
+        3usize as u8,
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({ op_fast::DECL.fast_fn() }),
@@ -23,6 +23,7 @@ impl op_slow {
         <Self as deno_core::_ops::Op>::DECL
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
         let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
@@ -30,23 +31,8 @@ impl op_slow {
             &*info
         });
         let result = {
-            let arg0 = args.get(0usize as i32);
-            let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected u32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return;
-            };
-            let arg0 = arg0 as _;
-            let arg1 = args.get(1usize as i32);
+            let arg1 = args.get(0usize as i32);
             let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                 let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected u32".as_bytes(),
@@ -58,7 +44,21 @@ impl op_slow {
                 return;
             };
             let arg1 = arg1 as _;
-            Self::call(arg0, arg1)
+            let arg2 = args.get(1usize as i32);
+            let Some(arg2) = deno_core::_ops::to_u32_option(&arg2) else {
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        "expected u32".as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return;
+            };
+            let arg2 = arg2 as _;
+            let arg0 = &mut scope;
+            Self::call(arg0, arg1, arg2)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
@@ -81,7 +81,7 @@ impl op_slow {
         );
     }
     #[inline(always)]
-    fn call(a: u32, b: u32) -> u32 {
+    fn call(_scope: &v8::HandleScope, a: u32, b: u32) -> u32 {
         a + b
     }
 }
@@ -237,7 +237,7 @@ impl<T: Trait> deno_core::_ops::Op for op_slow_generic<T> {
     const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_slow_generic),
         false,
-        2usize as u8,
+        3usize as u8,
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({ op_fast_generic::<T>::DECL.fast_fn() }),
@@ -253,6 +253,7 @@ impl<T: Trait> op_slow_generic<T> {
         <Self as deno_core::_ops::Op>::DECL
     }
     extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
         let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
@@ -260,23 +261,8 @@ impl<T: Trait> op_slow_generic<T> {
             &*info
         });
         let result = {
-            let arg0 = args.get(0usize as i32);
-            let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected u32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return;
-            };
-            let arg0 = arg0 as _;
-            let arg1 = args.get(1usize as i32);
+            let arg1 = args.get(0usize as i32);
             let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                 let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected u32".as_bytes(),
@@ -288,7 +274,21 @@ impl<T: Trait> op_slow_generic<T> {
                 return;
             };
             let arg1 = arg1 as _;
-            Self::call(arg0, arg1)
+            let arg2 = args.get(1usize as i32);
+            let Some(arg2) = deno_core::_ops::to_u32_option(&arg2) else {
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        "expected u32".as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return;
+            };
+            let arg2 = arg2 as _;
+            let arg0 = &mut scope;
+            Self::call(arg0, arg1, arg2)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
@@ -311,7 +311,7 @@ impl<T: Trait> op_slow_generic<T> {
         );
     }
     #[inline(always)]
-    fn call(a: u32, b: u32) -> u32 {
+    fn call(_scope: &v8::HandleScope, a: u32, b: u32) -> u32 {
         a + b
     }
 }

--- a/ops/op2/test_cases/sync/fast_alternative.rs
+++ b/ops/op2/test_cases/sync/fast_alternative.rs
@@ -1,0 +1,25 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+#![deny(warnings)]
+deno_ops_compile_test_runner::prelude!();
+
+#[op2(fast(op_fast))]
+fn op_slow(a: u32, b: u32) -> u32 {
+  a + b
+}
+
+#[op2(fast)]
+fn op_fast(a: u32, b: u32) -> u32 {
+  a + b
+}
+
+pub trait T {}
+
+#[op2(fast(op_fast_generic::<T>))]
+fn op_slow_generic<T: Trait>(a: u32, b: u32) -> u32 {
+  a + b
+}
+
+#[op2(fast)]
+fn op_fast_generic<T: Trait>(a: u32, b: u32) -> u32 {
+  a + b
+}

--- a/ops/op2/test_cases/sync/fast_alternative.rs
+++ b/ops/op2/test_cases/sync/fast_alternative.rs
@@ -2,8 +2,9 @@
 #![deny(warnings)]
 deno_ops_compile_test_runner::prelude!();
 
+// Unused scope would normally make this a slow-only op
 #[op2(fast(op_fast))]
-fn op_slow(a: u32, b: u32) -> u32 {
+fn op_slow(_scope: &v8::HandleScope, a: u32, b: u32) -> u32 {
   a + b
 }
 
@@ -14,8 +15,9 @@ fn op_fast(a: u32, b: u32) -> u32 {
 
 pub trait T {}
 
+// Unused scope would normally make this a slow-only op
 #[op2(fast(op_fast_generic::<T>))]
-fn op_slow_generic<T: Trait>(a: u32, b: u32) -> u32 {
+fn op_slow_generic<T: Trait>(_scope: &v8::HandleScope, a: u32, b: u32) -> u32 {
   a + b
 }
 


### PR DESCRIPTION
This is the final op2 feature to replace the last op1 ops in deno.

```rust
// Unused scope would normally make this a slow-only op
#[op2(fast(op_fast))]
fn op_slow(_scope: &v8::HandleScope, a: u32, b: u32) -> u32 {
  a + b
}

#[op2(fast)]
fn op_fast(a: u32, b: u32) -> u32 {
  a + b
}
```