### PR TITLE
feat(op2): implement fast wasm memory ops

### DIFF
--- a/core/examples/wasm.js
+++ b/core/examples/wasm.js
@@ -3,22 +3,24 @@
 // asc wasm.ts --exportStart --initialMemory 6400 -O -o wasm.wasm
 // deno-fmt-ignore
 const bytes = new Uint8Array([
-    0,  97, 115, 109,   1,   0,   0,   0,   1,  4,   1, 96,   0,   0,   2,
-   15,   1,   3, 111, 112, 115,   7, 111, 112, 95, 119, 97, 115, 109,   0,
-    0,   3,   3,   2,   0,   0,   5,   4,   1,  0, 128, 50,   7,  36,   4,
-    7, 111, 112,  95, 119,  97, 115, 109,   0,  0,   4, 99,  97, 108, 108,
-    0,   1,   6, 109, 101, 109, 111, 114, 121,  2,   0,  6,  95, 115, 116,
-   97, 114, 116,   0,   2,  10,  10,   2,   4,  0,  16,  0,  11,   3,   0,
-    1,  11
- ]);
+  0,  97, 115, 109,   1,  0,   0,   0,   1,   8,   2,  96,
+  1, 127,   0,  96,   0,  0,   2,  16,   1,   4, 119,  97,
+  115, 109,   7, 111, 112, 95, 119,  97, 115, 109,   0,   0,
+  3,   3,   2,   0,   1,  5,   4,   1,   0, 128,  50,   7,
+  36,   4,   7, 111, 112, 95, 119,  97, 115, 109,   0,   0,
+  4,  99,  97, 108, 108,  0,   1,   6, 109, 101, 109, 111,
+  114, 121,   2,   0,   6, 95, 115, 116,  97, 114, 116,   0,
+  2,  10,  12,   2,   6,  0,  32,   0,  16,   0,  11,   3,
+  0,   1,  11,   4,  10,   0,  32,   0,  16,   0,  11,   3,
+]);
 
 const { ops } = Deno.core;
 
 const module = new WebAssembly.Module(bytes);
-const instance = new WebAssembly.Instance(module, { ops });
-ops.op_set_wasm_mem(instance.exports.memory);
+const instance = new WebAssembly.Instance(module, { wasm: ops });
+const rid = ops.op_core_set_wasm_memory(instance.exports.memory);
 
-instance.exports.call();
+instance.exports.call(rid);
 
 const memory = instance.exports.memory;
 const view = new Uint8Array(memory.buffer);

--- a/core/examples/wasm.rs
+++ b/core/examples/wasm.rs
@@ -1,60 +1,25 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-use deno_core::op;
+use deno_core::include_ascii_string;
+use deno_core::op2;
 use deno_core::Extension;
 use deno_core::JsRuntime;
 use deno_core::Op;
+use deno_core::OpState;
 use deno_core::RuntimeOptions;
-use std::mem::transmute;
-use std::ptr::NonNull;
+use deno_core::WasmMemory;
 
-// This is a hack to make the `#[op]` macro work with
-// deno_core examples.
-// You can remove this:
-
-use deno_core::*;
-
-struct WasmMemory(NonNull<v8::WasmMemoryObject>);
-
-fn wasm_memory_unchecked(state: &mut OpState) -> &mut [u8] {
-  let WasmMemory(global) = state.borrow::<WasmMemory>();
-  // SAFETY: `v8::Local` is always non-null pointer; the `HandleScope` is
-  // already on the stack, but we don't have access to it.
-  let memory_object = unsafe {
-    transmute::<NonNull<v8::WasmMemoryObject>, v8::Local<v8::WasmMemoryObject>>(
-      *global,
-    )
-  };
-  let backing_store = memory_object.buffer().get_backing_store();
-  let ptr = backing_store.data().unwrap().as_ptr() as *mut u8;
-  let len = backing_store.byte_length();
-  // SAFETY: `ptr` is a valid pointer to `len` bytes.
-  unsafe { std::slice::from_raw_parts_mut(ptr, len) }
-}
-
-#[op(wasm)]
-fn op_wasm(state: &mut OpState, memory: Option<&mut [u8]>) {
-  let memory = memory.unwrap_or_else(|| wasm_memory_unchecked(state));
+#[op2(fast)]
+fn op_wasm(state: &mut OpState, #[smi] rid: u32, #[memory] memory: WasmMemory) {
+  let memory = memory.get(state, rid).expect("invalid wasm memory");
   memory[0] = 69;
-}
-
-#[op(v8)]
-fn op_set_wasm_mem(
-  scope: &mut v8::HandleScope,
-  state: &mut OpState,
-  memory: serde_v8::Value,
-) {
-  let memory =
-    v8::Local::<v8::WasmMemoryObject>::try_from(memory.v8_value).unwrap();
-  let global = v8::Global::new(scope, memory);
-  state.put(WasmMemory(global.into_raw()));
 }
 
 fn main() {
   // Build a deno_core::Extension providing custom ops
   let ext = Extension {
     name: "my_ext",
-    ops: std::borrow::Cow::Borrowed(&[op_wasm::DECL, op_set_wasm_mem::DECL]),
+    ops: std::borrow::Cow::Borrowed(&[op_wasm::DECL]),
     ..Default::default()
   };
 

--- a/core/examples/wasm.ts
+++ b/core/examples/wasm.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
-export declare function op_wasm(): void;
+export declare function op_wasm(handle: u32): void;
 
-export function call(): void {
-  op_wasm();
+export function call(handle: u32): void {
+  op_wasm(handle)
 }

--- a/core/examples/wasm.ts
+++ b/core/examples/wasm.ts
@@ -3,5 +3,5 @@
 export declare function op_wasm(handle: u32): void;
 
 export function call(handle: u32): void {
-  op_wasm(handle)
+  op_wasm(handle);
 }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -101,6 +101,7 @@ pub use crate::ops::OpId;
 pub use crate::ops::OpResult;
 pub use crate::ops::OpState;
 pub use crate::ops::PromiseId;
+pub use crate::ops::WasmMemory;
 pub use crate::ops_builtin::op_close;
 pub use crate::ops_builtin::op_print;
 pub use crate::ops_builtin::op_resources;

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -289,3 +289,11 @@ impl DerefMut for OpState {
     &mut self.gotham_state
   }
 }
+
+pub struct WasmMemory(pub *const v8::fast_api::FastApiTypedArray<u8>);
+
+impl WasmMemory {
+  pub fn get<'s>(self) -> Option<&'s mut [u8]> {
+    unsafe { (&*self.0).get_storage_if_aligned() }
+  }
+}

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -335,7 +335,7 @@ impl WasmMemory {
     rid: ResourceId,
   ) -> Option<&'s mut [u8]> {
     match self.0 {
-      Some(mem) => unsafe { (&*mem).get_storage_if_aligned() },
+      Some(mem) => unsafe { (*mem).get_storage_if_aligned() },
       None => {
         let resource =
           state.resource_table.get::<WasmMemoryResource>(rid).ok()?;

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -4,6 +4,7 @@ use crate::error::format_file_name;
 use crate::error::type_error;
 use crate::io::BufMutView;
 use crate::io::BufView;
+use crate::ops;
 use crate::ops_builtin_v8;
 use crate::ops_metrics::OpMetrics;
 use crate::resources::ResourceId;
@@ -49,6 +50,7 @@ crate::extension!(
     op_format_file_name,
     op_is_proxy,
     op_str_byte_length,
+    ops::op_core_set_wasm_memory,
     ops_builtin_v8::op_ref_op,
     ops_builtin_v8::op_unref_op,
     ops_builtin_v8::op_set_promise_reject_callback,

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -449,6 +449,12 @@ fn map_v8_fastcall_arg_to_arg(
       *needs_opctx = true;
       quote!(let #arg_ident = #opctx.isolate;)
     }
+    Arg::Special(Special::WasmMemory) => {
+      *needs_fast_api_callback_options = true;
+      quote!(
+        let #arg_ident = #deno_core::WasmMemory(#fast_api_callback_options.wasm_memory as *const #deno_core::v8::fast_api::FastApiTypedArray<u8>);
+      )
+    }
     Arg::Ref(RefType::Ref, Special::OpState) => {
       *needs_opctx = true;
       quote!(let #arg_ident = &::std::cell::RefCell::borrow(&#opctx.state);)
@@ -603,6 +609,7 @@ fn map_arg_to_v8_fastcall_type(
     | Arg::Ref(_, Special::JsRuntimeState)
     | Arg::State(..)
     | Arg::Special(Special::Isolate)
+    | Arg::Special(Special::WasmMemory)
     | Arg::OptionState(..) => V8FastCallType::Virtual,
     // Other types + ref types are not handled
     Arg::OptionNumeric(..)

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -452,7 +452,7 @@ fn map_v8_fastcall_arg_to_arg(
     Arg::Special(Special::WasmMemory) => {
       *needs_fast_api_callback_options = true;
       quote!(
-        let #arg_ident = #deno_core::WasmMemory(#fast_api_callback_options.wasm_memory as *const #deno_core::v8::fast_api::FastApiTypedArray<u8>);
+        let #arg_ident = #deno_core::WasmMemory::new(#fast_api_callback_options.wasm_memory as *const #deno_core::v8::fast_api::FastApiTypedArray<u8>);
       )
     }
     Arg::Ref(RefType::Ref, Special::OpState) => {

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -388,7 +388,7 @@ pub fn from_arg(
       quote!(let #arg_ident = #opctx.isolate;)
     }
     Arg::Special(Special::WasmMemory) => {
-      quote!(let #arg_ident = None;)
+      quote!(let #arg_ident = #deno_core::WasmMemory::null();)
     }
     Arg::Ref(_, Special::HandleScope) => {
       *needs_scope = true;

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -387,6 +387,9 @@ pub fn from_arg(
       *needs_opctx = true;
       quote!(let #arg_ident = #opctx.isolate;)
     }
+    Arg::Special(Special::WasmMemory) => {
+      quote!(let #arg_ident = None;)
+    }
     Arg::Ref(_, Special::HandleScope) => {
       *needs_scope = true;
       quote!(let #arg_ident = &mut #scope;)

--- a/ops/op2/test_cases/sync/wasm_memory.out
+++ b/ops/op2/test_cases/sync/wasm_memory.out
@@ -1,0 +1,114 @@
+#[allow(non_camel_case_types)]
+struct op_wasm_memory {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
+impl deno_core::_ops::Op for op_wasm_memory {
+    const NAME: &'static str = stringify!(op_wasm_memory);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
+        stringify!(op_wasm_memory),
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::CallbackOptions],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::CallbackOptions],
+                CType::Void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+            )
+        }),
+    );
+}
+impl op_wasm_memory {
+    pub const fn name() -> &'static str {
+        stringify!(op_wasm_memory)
+    }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
+        );
+        let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Completed,
+        );
+        res
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let result = {
+            let arg0 = deno_core::WasmMemory(
+                fast_api_callback_options.wasm_memory
+                    as *const deno_core::v8::fast_api::FastApiTypedArray<u8>,
+            );
+            Self::call(arg0)
+        };
+        result as _
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+            &*info
+        });
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let result = {
+            let arg0 = None;
+            Self::call(arg0)
+        };
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
+        );
+        Self::v8_fn_ptr(info);
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Completed,
+        );
+    }
+    #[inline(always)]
+    fn call(_mem: WasmMemory) {
+        unimplemented!()
+    }
+}

--- a/ops/op2/test_cases/sync/wasm_memory.out
+++ b/ops/op2/test_cases/sync/wasm_memory.out
@@ -7,14 +7,14 @@ impl deno_core::_ops::Op for op_wasm_memory {
     const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
         stringify!(op_wasm_memory),
         false,
-        1usize as u8,
+        3usize as u8,
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
+                &[Type::V8Value, Type::Int32, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
@@ -23,7 +23,7 @@ impl deno_core::_ops::Op for op_wasm_memory {
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
+                &[Type::V8Value, Type::Int32, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
@@ -41,6 +41,7 @@ impl op_wasm_memory {
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
         this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg1: i32,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
@@ -54,7 +55,7 @@ impl op_wasm_memory {
             &opctx,
             deno_core::_ops::OpMetricsEvent::Dispatched,
         );
-        let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+        let res = Self::v8_fn_ptr_fast(this, arg1, fast_api_callback_options);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
             deno_core::_ops::OpMetricsEvent::Completed,
@@ -64,15 +65,24 @@ impl op_wasm_memory {
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
         _: deno_core::v8::Local<deno_core::v8::Object>,
+        arg1: i32,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
         let result = {
-            let arg0 = deno_core::WasmMemory(
+            let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opctx.state);
+            let arg1 = arg1 as _;
+            let arg2 = deno_core::WasmMemory::new(
                 fast_api_callback_options.wasm_memory
                     as *const deno_core::v8::fast_api::FastApiTypedArray<u8>,
             );
-            Self::call(arg0)
+            Self::call(arg0, arg1, arg2)
         };
         result as _
     }
@@ -83,9 +93,29 @@ impl op_wasm_memory {
         let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        let opstate = &opctx.state;
         let result = {
-            let arg0 = None;
-            Self::call(arg0)
+            let arg1 = args.get(0usize as i32);
+            let Some(arg1) = deno_core::_ops::to_i32_option(&arg1) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        "expected i32".as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return;
+            };
+            let arg1 = arg1 as _;
+            let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opstate);
+            let arg2 = deno_core::WasmMemory::null();
+            Self::call(arg0, arg1, arg2)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
     }
@@ -108,7 +138,8 @@ impl op_wasm_memory {
         );
     }
     #[inline(always)]
-    fn call(_mem: WasmMemory) {
+    fn call(state: &mut OpState, rid: ResourceId, mem: WasmMemory) {
+        let _s = mem.get(state, rid).expect("invalid wasm memory");
         unimplemented!()
     }
 }

--- a/ops/op2/test_cases/sync/wasm_memory.rs
+++ b/ops/op2/test_cases/sync/wasm_memory.rs
@@ -4,8 +4,10 @@ deno_ops_compile_test_runner::prelude!();
 
 use deno_core::v8;
 use deno_core::WasmMemory;
+use deno_core::ResourceId;
 
 #[op2(fast)]
-fn op_wasm_memory(#[memory] _mem: WasmMemory) {
+fn op_wasm_memory(state: &mut OpState, #[smi] rid: ResourceId, #[memory] mem: WasmMemory) {
+    let _s = mem.get(state, rid).expect("invalid wasm memory");
     unimplemented!()
 }

--- a/ops/op2/test_cases/sync/wasm_memory.rs
+++ b/ops/op2/test_cases/sync/wasm_memory.rs
@@ -1,0 +1,11 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+#![deny(warnings)]
+deno_ops_compile_test_runner::prelude!();
+
+use deno_core::v8;
+use deno_core::WasmMemory;
+
+#[op2(fast)]
+fn op_wasm_memory(#[memory] _mem: WasmMemory) {
+    unimplemented!()
+}

--- a/ops/op2/test_cases/sync/wasm_memory.rs
+++ b/ops/op2/test_cases/sync/wasm_memory.rs
@@ -2,8 +2,8 @@
 #![deny(warnings)]
 deno_ops_compile_test_runner::prelude!();
 
-use deno_core::v8;
 use deno_core::WasmMemory;
+use deno_core::OpState;
 use deno_core::ResourceId;
 
 #[op2(fast)]


### PR DESCRIPTION
Closes #273 

```rust
#[op2(fast)]
fn op_wasm(state: &mut OpState, #[smi] rid: u32, #[memory] memory: WasmMemory) {
  let memory = memory.get(state, rid).expect("invalid wasm memory");
  memory[0] = 69;
}
```
```js
// Save memory handle for slow call access
const handle = ops.op_core_set_wasm_memory(instance.exports.memory);

// Expose op to Wasm module
const instance = new WebAssembly.Instance(module, {
  wasm: {
    op_wasm: () => ops.op_wasm(handle),
  },
});
instance.exports.call(rid);
```