### PR TITLE
Tweak documentation of v8_set_flags

### DIFF
--- a/core/flags.rs
+++ b/core/flags.rs
@@ -1,6 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
 /// Pass the command line arguments to v8.
+/// The first element of args (which usually corresponds to the binary name) is
+/// ignored.
 /// Returns a vector of command line arguments that V8 did not understand.
 pub fn v8_set_flags(args: Vec<String>) -> Vec<String> {
   v8::V8::set_flags_from_command_line(args)


### PR DESCRIPTION
We experienced some weird V8 segfault by not adding a fake first argument as done in https://github.com/denoland/deno/blob/v1.37/cli/util/v8.rs

There's also a note about it in the documentation of `V8::set_flags_from_command_line`, which I copied here.