### PR TITLE
fix(ops): partial revert of 16970b7 to fix issue #302

### DIFF
--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -21,9 +21,7 @@ use url::Url;
 use super::*;
 
 // deno_ops macros generate code assuming deno_core in scope.
-mod deno_core {
-  pub use crate::*;
-}
+use crate::deno_core;
 
 #[derive(Default)]
 struct MockLoader {

--- a/ops/op2/dispatch_async.rs
+++ b/ops/op2/dispatch_async.rs
@@ -86,16 +86,16 @@ pub(crate) fn generate_dispatch_async(
     let lazy = config.async_lazy;
     let deferred = config.async_deferred;
     output.extend(gs_quote!(generator_state(promise_id, fn_args, result, opctx, scope) => {
-      let #promise_id = ::deno_core::_ops::to_i32_option(&#fn_args.get(0)).unwrap_or_default();
+      let #promise_id = deno_core::_ops::to_i32_option(&#fn_args.get(0)).unwrap_or_default();
       // Lazy and deferred results will always return None
-      ::deno_core::_ops::#mapper(#opctx, #lazy, #deferred, #promise_id, #result, |#scope, #result| {
+      deno_core::_ops::#mapper(#opctx, #lazy, #deferred, #promise_id, #result, |#scope, #result| {
         #return_value
       });
     }));
   } else {
     output.extend(gs_quote!(generator_state(promise_id, fn_args, result, opctx, scope) => {
-      let #promise_id = ::deno_core::_ops::to_i32_option(&#fn_args.get(0)).unwrap_or_default();
-      if let Some(#result) = ::deno_core::_ops::#mapper(#opctx, false, false, #promise_id, #result, |#scope, #result| {
+      let #promise_id = deno_core::_ops::to_i32_option(&#fn_args.get(0)).unwrap_or_default();
+      if let Some(#result) = deno_core::_ops::#mapper(#opctx, false, false, #promise_id, #result, |#scope, #result| {
         #return_value
       }) {
         // Eager poll returned a value
@@ -139,7 +139,7 @@ pub(crate) fn generate_dispatch_async(
   Ok(
     gs_quote!(generator_state(info, slow_function, slow_function_metrics, opctx) => {
       #[inline(always)]
-      fn slow_function_impl(#info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
+      fn slow_function_impl(#info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
         #with_scope
         #with_retval
         #with_args
@@ -149,24 +149,24 @@ pub(crate) fn generate_dispatch_async(
         #output
       }
 
-      extern "C" fn #slow_function(#info: *const ::deno_core::v8::FunctionCallbackInfo) {
+      extern "C" fn #slow_function(#info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(#info);
       }
 
-      extern "C" fn #slow_function_metrics(#info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+      extern "C" fn #slow_function_metrics(#info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
           &*info
         });
         let #opctx = unsafe {
-          &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data()).value()
-            as *const ::deno_core::_ops::OpCtx)
+          &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+            as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_async(&#opctx, ::deno_core::_ops::OpMetricsEvent::Dispatched);
+        deno_core::_ops::dispatch_metrics_async(&#opctx, deno_core::_ops::OpMetricsEvent::Dispatched);
         let res = Self::slow_function_impl(#info);
         if res == 0 {
-          ::deno_core::_ops::dispatch_metrics_async(&#opctx, ::deno_core::_ops::OpMetricsEvent::Completed);
+          deno_core::_ops::dispatch_metrics_async(&#opctx, deno_core::_ops::OpMetricsEvent::Completed);
         } else if res == 1 {
-          ::deno_core::_ops::dispatch_metrics_async(&#opctx, ::deno_core::_ops::OpMetricsEvent::Error);
+          deno_core::_ops::dispatch_metrics_async(&#opctx, deno_core::_ops::OpMetricsEvent::Error);
         }
       }
     }),

--- a/ops/op2/dispatch_shared.rs
+++ b/ops/op2/dispatch_shared.rs
@@ -35,9 +35,9 @@ pub fn v8_intermediate_to_global_arg(
   arg: &Arg,
 ) -> TokenStream {
   let arg = match arg {
-    Arg::V8Global(_) => quote!(::deno_core::v8::Global::new(&mut #isolate, #i)),
+    Arg::V8Global(_) => quote!(deno_core::v8::Global::new(&mut #isolate, #i)),
     Arg::OptionV8Global(_) => {
-      quote!(::deno_core::v8::Global::new(&mut #isolate, #i))
+      quote!(deno_core::v8::Global::new(&mut #isolate, #i))
     }
     _ => unreachable!("Not a v8 global arg: {arg:?}"),
   };
@@ -67,7 +67,7 @@ pub fn v8_to_arg(
     throw_type_error()?
   };
   Ok(quote! {
-    let Ok(mut #arg_ident) = ::deno_core::_ops::#try_convert::<::deno_core::v8::#v8>(#arg_ident) else {
+    let Ok(mut #arg_ident) = deno_core::_ops::#try_convert::<deno_core::v8::#v8>(#arg_ident) else {
       #throw_type_error_block
     };
     #extract_intermediate
@@ -120,7 +120,7 @@ pub fn v8slice_to_buffer(
       quote!(let #arg_ident = #v8slice.to_vec().into();)
     }
     BufferType::JsBuffer => {
-      quote!(let #arg_ident = ::deno_core::serde_v8::JsBuffer::from_parts(#v8slice);)
+      quote!(let #arg_ident = deno_core::serde_v8::JsBuffer::from_parts(#v8slice);)
     }
     _ => return Err("a v8slice argument"),
   };
@@ -169,7 +169,7 @@ pub fn fast_api_typed_array_to_buffer(
   Ok(quote! {
     // SAFETY: we are certain the implied lifetime is valid here as the slices never escape the
     // fastcall
-    let #input = unsafe { ::deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(#input) }.expect("Invalid buffer");
+    let #input = unsafe { deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(#input) }.expect("Invalid buffer");
     #convert
   })
 }

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -138,7 +138,7 @@ pub(crate) fn generate_dispatch_slow(
   Ok(
     gs_quote!(generator_state(opctx, info, slow_function, slow_function_metrics) => {
       #[inline(always)]
-      fn slow_function_impl(#info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
+      fn slow_function_impl(#info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
         #with_scope
         #with_retval
         #with_args
@@ -151,25 +151,25 @@ pub(crate) fn generate_dispatch_slow(
         return 0;
       }
 
-      extern "C" fn #slow_function(#info: *const ::deno_core::v8::FunctionCallbackInfo) {
+      extern "C" fn #slow_function(#info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(#info);
       }
 
-      extern "C" fn #slow_function_metrics(#info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+      extern "C" fn #slow_function_metrics(#info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
           &*info
         });
         let #opctx = unsafe {
-          &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data()).value()
-              as *const ::deno_core::_ops::OpCtx)
+          &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+              as *const deno_core::_ops::OpCtx)
         };
 
-        ::deno_core::_ops::dispatch_metrics_slow(&#opctx, ::deno_core::_ops::OpMetricsEvent::Dispatched);
+        deno_core::_ops::dispatch_metrics_slow(&#opctx, deno_core::_ops::OpMetricsEvent::Dispatched);
         let res = Self::slow_function_impl(#info);
         if res == 0 {
-          ::deno_core::_ops::dispatch_metrics_slow(&#opctx, ::deno_core::_ops::OpMetricsEvent::Completed);
+          deno_core::_ops::dispatch_metrics_slow(&#opctx, deno_core::_ops::OpMetricsEvent::Completed);
         } else {
-          ::deno_core::_ops::dispatch_metrics_slow(&#opctx, ::deno_core::_ops::OpMetricsEvent::Error);
+          deno_core::_ops::dispatch_metrics_slow(&#opctx, deno_core::_ops::OpMetricsEvent::Error);
         }
       }
     }),
@@ -187,13 +187,13 @@ pub(crate) fn with_isolate(
 
 pub(crate) fn with_scope(generator_state: &mut GeneratorState) -> TokenStream {
   gs_quote!(generator_state(info, scope) =>
-    (let mut #scope = unsafe { ::deno_core::v8::CallbackScope::new(&*#info) };)
+    (let mut #scope = unsafe { deno_core::v8::CallbackScope::new(&*#info) };)
   )
 }
 
 pub(crate) fn with_retval(generator_state: &mut GeneratorState) -> TokenStream {
   gs_quote!(generator_state(retval, info) =>
-    (let mut #retval = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe { &*#info });)
+    (let mut #retval = deno_core::v8::ReturnValue::from_function_callback_info(unsafe { &*#info });)
   )
 }
 
@@ -201,7 +201,7 @@ pub(crate) fn with_fn_args(
   generator_state: &mut GeneratorState,
 ) -> TokenStream {
   gs_quote!(generator_state(info, fn_args) =>
-    (let #fn_args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe { &*#info });)
+    (let #fn_args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe { &*#info });)
   )
 }
 
@@ -209,8 +209,8 @@ pub(crate) fn with_opctx(generator_state: &mut GeneratorState) -> TokenStream {
   generator_state.needs_args = true;
   gs_quote!(generator_state(opctx, fn_args) =>
     (let #opctx = unsafe {
-    &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(#fn_args.data()).value()
-        as *const ::deno_core::_ops::OpCtx)
+    &*(deno_core::v8::Local::<deno_core::v8::External>::cast(#fn_args.data()).value()
+        as *const deno_core::_ops::OpCtx)
     };)
   )
 }
@@ -319,7 +319,7 @@ pub fn from_arg(
         let #arg_ident = if #arg_ident.is_null_or_undefined() {
           None
         } else {
-          Some(::deno_core::_ops::to_string(&mut #scope, &#arg_ident))
+          Some(deno_core::_ops::to_string(&mut #scope, &#arg_ident))
         };
       }
     }
@@ -327,7 +327,7 @@ pub fn from_arg(
       // Only requires isolate, not a full scope
       *needs_isolate = true;
       quote! {
-        let #arg_ident = ::deno_core::_ops::to_string(&mut #scope, &#arg_ident);
+        let #arg_ident = deno_core::_ops::to_string(&mut #scope, &#arg_ident);
       }
     }
     Arg::String(Strings::RefStr) => {
@@ -335,8 +335,8 @@ pub fn from_arg(
       *needs_isolate = true;
       quote! {
         // Trade stack space for potentially non-allocating strings
-        let mut #arg_temp: [::std::mem::MaybeUninit<u8>; ::deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); ::deno_core::_ops::STRING_STACK_BUFFER_SIZE];
-        let #arg_ident = &::deno_core::_ops::to_str(&mut #scope, &#arg_ident, &mut #arg_temp);
+        let mut #arg_temp: [::std::mem::MaybeUninit<u8>; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
+        let #arg_ident = &deno_core::_ops::to_str(&mut #scope, &#arg_ident, &mut #arg_temp);
       }
     }
     Arg::String(Strings::CowStr) => {
@@ -344,8 +344,8 @@ pub fn from_arg(
       *needs_isolate = true;
       quote! {
         // Trade stack space for potentially non-allocating strings
-        let mut #arg_temp: [::std::mem::MaybeUninit<u8>; ::deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); ::deno_core::_ops::STRING_STACK_BUFFER_SIZE];
-        let #arg_ident = ::deno_core::_ops::to_str(&mut #scope, &#arg_ident, &mut #arg_temp);
+        let mut #arg_temp: [::std::mem::MaybeUninit<u8>; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
+        let #arg_ident = deno_core::_ops::to_str(&mut #scope, &#arg_ident, &mut #arg_temp);
       }
     }
     Arg::String(Strings::CowByte) => {
@@ -355,7 +355,7 @@ pub fn from_arg(
         throw_type_error_static_string(generator_state, &arg_ident)?;
       gs_quote!(generator_state(scope) => {
         // Trade stack space for potentially non-allocating strings
-        let #arg_ident = match ::deno_core::_ops::to_cow_one_byte(&mut #scope, &#arg_ident) {
+        let #arg_ident = match deno_core::_ops::to_cow_one_byte(&mut #scope, &#arg_ident) {
           Ok(#arg_ident) => #arg_ident,
           Err(#arg_ident) => {
             #throw_exception
@@ -441,7 +441,7 @@ pub fn from_arg(
         syn::parse_str::<Type>(state).expect("Failed to reparse state type");
       quote! {
         let #arg_ident = ::std::cell::RefCell::borrow(&#opstate);
-        let #arg_ident = ::deno_core::_ops::opstate_borrow::<#state>(&#arg_ident);
+        let #arg_ident = deno_core::_ops::opstate_borrow::<#state>(&#arg_ident);
       }
     }
     Arg::State(RefType::Mut, state) => {
@@ -450,7 +450,7 @@ pub fn from_arg(
         syn::parse_str::<Type>(state).expect("Failed to reparse state type");
       quote! {
         let mut #arg_ident = ::std::cell::RefCell::borrow_mut(&#opstate);
-        let #arg_ident = ::deno_core::_ops::opstate_borrow_mut::<#state>(&mut #arg_ident);
+        let #arg_ident = deno_core::_ops::opstate_borrow_mut::<#state>(&mut #arg_ident);
       }
     }
     Arg::OptionState(RefType::Ref, state) => {
@@ -503,7 +503,7 @@ pub fn from_arg(
       let err = format_ident!("{}_err", arg_ident);
       let throw_exception = throw_type_error_string(generator_state, &err)?;
       quote! {
-        let #arg_ident = match ::deno_core::_ops::serde_v8_to_rust(&mut #scope, #arg_ident) {
+        let #arg_ident = match deno_core::_ops::serde_v8_to_rust(&mut #scope, #arg_ident) {
           Ok(t) => t,
           Err(#err) => {
             #throw_exception;
@@ -526,7 +526,7 @@ pub fn from_arg_option(
     throw_type_error(generator_state, format!("expected {numeric}"))?;
   let convert = format_ident!("to_{numeric}_option");
   Ok(quote!(
-    let Some(#arg_ident) = ::deno_core::_ops::#convert(&#arg_ident) else {
+    let Some(#arg_ident) = deno_core::_ops::#convert(&#arg_ident) else {
       #exception
     };
     let #arg_ident = #arg_ident as _;
@@ -580,9 +580,9 @@ pub fn from_arg_buffer(
 
   let to_v8_slice = if matches!(buffer_mode, BufferMode::Detach) {
     generator_state.needs_scope = true;
-    gs_quote!(generator_state(scope) => { ::deno_core::_ops::to_v8_slice_detachable::<#array>(&mut #scope, #arg_ident) })
+    gs_quote!(generator_state(scope) => { deno_core::_ops::to_v8_slice_detachable::<#array>(&mut #scope, #arg_ident) })
   } else {
-    quote!(::deno_core::_ops::to_v8_slice::<#array>(#arg_ident))
+    quote!(deno_core::_ops::to_v8_slice::<#array>(#arg_ident))
   };
 
   let make_v8slice = quote!(
@@ -619,7 +619,7 @@ pub fn from_arg_arraybuffer(
   };
 
   let make_v8slice = quote!(
-    #temp = match unsafe { ::deno_core::_ops::#to_v8_slice(#arg_ident) } {
+    #temp = match unsafe { deno_core::_ops::#to_v8_slice(#arg_ident) } {
       Ok(#arg_ident) => #arg_ident,
       Err(#err) => {
         #throw_exception
@@ -652,7 +652,7 @@ pub fn from_arg_any_buffer(
   };
 
   let make_v8slice = quote!(
-    #temp = match unsafe { ::deno_core::_ops::#to_v8_slice(#arg_ident) } {
+    #temp = match unsafe { deno_core::_ops::#to_v8_slice(#arg_ident) } {
       Ok(#arg_ident) => #arg_ident,
       Err(#err) => {
         #throw_exception
@@ -698,29 +698,29 @@ pub fn return_value_infallible(
 
   let result = match ret_type.marker() {
     ArgMarker::ArrayBuffer => {
-      gs_quote!(generator_state(result) => (::deno_core::_ops::RustToV8Marker::<::deno_core::_ops::ArrayBufferMarker, _>::from(#result)))
+      gs_quote!(generator_state(result) => (deno_core::_ops::RustToV8Marker::<deno_core::_ops::ArrayBufferMarker, _>::from(#result)))
     }
     ArgMarker::Serde => {
-      gs_quote!(generator_state(result) => (::deno_core::_ops::RustToV8Marker::<::deno_core::_ops::SerdeMarker, _>::from(#result)))
+      gs_quote!(generator_state(result) => (deno_core::_ops::RustToV8Marker::<deno_core::_ops::SerdeMarker, _>::from(#result)))
     }
     ArgMarker::Smi => {
-      gs_quote!(generator_state(result) => (::deno_core::_ops::RustToV8Marker::<::deno_core::_ops::SmiMarker, _>::from(#result)))
+      gs_quote!(generator_state(result) => (deno_core::_ops::RustToV8Marker::<deno_core::_ops::SmiMarker, _>::from(#result)))
     }
     ArgMarker::Number => {
-      gs_quote!(generator_state(result) => (::deno_core::_ops::RustToV8Marker::<::deno_core::_ops::NumberMarker, _>::from(#result)))
+      gs_quote!(generator_state(result) => (deno_core::_ops::RustToV8Marker::<deno_core::_ops::NumberMarker, _>::from(#result)))
     }
     ArgMarker::None => gs_quote!(generator_state(result) => (#result)),
   };
   let res = match ret_type.slow_retval() {
     ArgSlowRetval::RetVal => {
-      gs_quote!(generator_state(retval) => (::deno_core::_ops::RustToV8RetVal::to_v8_rv(#result, &mut #retval)))
+      gs_quote!(generator_state(retval) => (deno_core::_ops::RustToV8RetVal::to_v8_rv(#result, &mut #retval)))
     }
     ArgSlowRetval::RetValFallible => {
       generator_state.needs_scope = true;
       let err = format_ident!("{}_err", generator_state.retval);
       let throw_exception = throw_type_error_string(generator_state, &err)?;
 
-      gs_quote!(generator_state(scope, retval) => (match ::deno_core::_ops::RustToV8Fallible::to_v8_fallible(#result, &mut #scope) {
+      gs_quote!(generator_state(scope, retval) => (match deno_core::_ops::RustToV8Fallible::to_v8_fallible(#result, &mut #scope) {
         Ok(v) => #retval.set(v),
         Err(#err) => {
           #throw_exception
@@ -729,17 +729,17 @@ pub fn return_value_infallible(
     }
     ArgSlowRetval::V8Local => {
       generator_state.needs_scope = true;
-      gs_quote!(generator_state(scope, retval) => (#retval.set(::deno_core::_ops::RustToV8::to_v8(#result, &mut #scope))))
+      gs_quote!(generator_state(scope, retval) => (#retval.set(deno_core::_ops::RustToV8::to_v8(#result, &mut #scope))))
     }
     ArgSlowRetval::V8LocalNoScope => {
-      gs_quote!(generator_state(retval) => (#retval.set(::deno_core::_ops::RustToV8NoScope::to_v8(#result))))
+      gs_quote!(generator_state(retval) => (#retval.set(deno_core::_ops::RustToV8NoScope::to_v8(#result))))
     }
     ArgSlowRetval::V8LocalFalliable => {
       generator_state.needs_scope = true;
       let err = format_ident!("{}_err", generator_state.retval);
       let throw_exception = throw_type_error_string(generator_state, &err)?;
 
-      gs_quote!(generator_state(scope, retval) => (match ::deno_core::_ops::RustToV8Fallible::to_v8_fallible(#result, &mut #scope) {
+      gs_quote!(generator_state(scope, retval) => (match deno_core::_ops::RustToV8Fallible::to_v8_fallible(#result, &mut #scope) {
         Ok(v) => #retval.set(v),
         Err(#err) => {
           #throw_exception
@@ -760,28 +760,28 @@ pub fn return_value_v8_value(
   gs_extract!(generator_state(scope, result));
   let result = match ret_type.marker() {
     ArgMarker::ArrayBuffer => {
-      quote!(::deno_core::_ops::RustToV8Marker::<::deno_core::_ops::ArrayBufferMarker, _>::from(#result))
+      quote!(deno_core::_ops::RustToV8Marker::<deno_core::_ops::ArrayBufferMarker, _>::from(#result))
     }
     ArgMarker::Serde => {
-      quote!(::deno_core::_ops::RustToV8Marker::<::deno_core::_ops::SerdeMarker, _>::from(#result))
+      quote!(deno_core::_ops::RustToV8Marker::<deno_core::_ops::SerdeMarker, _>::from(#result))
     }
     ArgMarker::Smi => {
-      quote!(::deno_core::_ops::RustToV8Marker::<::deno_core::_ops::SmiMarker, _>::from(#result))
+      quote!(deno_core::_ops::RustToV8Marker::<deno_core::_ops::SmiMarker, _>::from(#result))
     }
     ArgMarker::Number => {
-      quote!(::deno_core::_ops::RustToV8Marker::<::deno_core::_ops::NumberMarker, _>::from(#result))
+      quote!(deno_core::_ops::RustToV8Marker::<deno_core::_ops::NumberMarker, _>::from(#result))
     }
     ArgMarker::None => quote!(#result),
   };
   let res = match ret_type.slow_retval() {
     ArgSlowRetval::RetVal | ArgSlowRetval::V8Local => {
-      quote!(Ok(::deno_core::_ops::RustToV8::to_v8(#result, #scope)))
+      quote!(Ok(deno_core::_ops::RustToV8::to_v8(#result, #scope)))
     }
     ArgSlowRetval::V8LocalNoScope => {
-      quote!(Ok(::deno_core::_ops::RustToV8NoScope::to_v8(#result)))
+      quote!(Ok(deno_core::_ops::RustToV8NoScope::to_v8(#result)))
     }
     ArgSlowRetval::RetValFallible | ArgSlowRetval::V8LocalFalliable => {
-      quote!(::deno_core::_ops::RustToV8Fallible::to_v8_fallible(#result, #scope))
+      quote!(deno_core::_ops::RustToV8Fallible::to_v8_fallible(#result, #scope))
     }
     ArgSlowRetval::None => return Err("a v8 return value"),
   };
@@ -835,7 +835,7 @@ pub(crate) fn throw_exception(
     #maybe_args
     #maybe_opctx
     let err = err.into();
-    let exception = ::deno_core::error::to_v8_error(
+    let exception = deno_core::error::to_v8_error(
       &mut #scope,
       #opctx.get_error_class_fn,
       &err,
@@ -861,8 +861,8 @@ fn throw_type_error(
 
   Ok(gs_quote!(generator_state(scope) => {
     #maybe_scope
-    let msg = ::deno_core::v8::String::new_from_one_byte(&mut #scope, #message.as_bytes(), ::deno_core::v8::NewStringType::Normal).unwrap();
-    let exc = ::deno_core::v8::Exception::type_error(&mut #scope, msg);
+    let msg = deno_core::v8::String::new_from_one_byte(&mut #scope, #message.as_bytes(), deno_core::v8::NewStringType::Normal).unwrap();
+    let exc = deno_core::v8::Exception::type_error(&mut #scope, msg);
     #scope.throw_exception(exc);
     return 1;
   }))
@@ -882,8 +882,8 @@ fn throw_type_error_string(
   Ok(gs_quote!(generator_state(scope) => {
     #maybe_scope
     // TODO(mmastrac): This might be allocating too much, even if it's on the error path
-    let msg = ::deno_core::v8::String::new(&mut #scope, &format!("{}", ::deno_core::anyhow::Error::from(#message))).unwrap();
-    let exc = ::deno_core::v8::Exception::type_error(&mut #scope, msg);
+    let msg = deno_core::v8::String::new(&mut #scope, &format!("{}", deno_core::anyhow::Error::from(#message))).unwrap();
+    let exc = deno_core::v8::Exception::type_error(&mut #scope, msg);
     #scope.throw_exception(exc);
     return 1;
   }))
@@ -902,8 +902,8 @@ fn throw_type_error_static_string(
 
   Ok(gs_quote!(generator_state(scope) => {
     #maybe_scope
-    let msg = ::deno_core::v8::String::new_from_one_byte(&mut #scope, #message.as_bytes(), ::deno_core::v8::NewStringType::Normal).unwrap();
-    let exc = ::deno_core::v8::Exception::type_error(&mut #scope, msg);
+    let msg = deno_core::v8::String::new_from_one_byte(&mut #scope, #message.as_bytes(), deno_core::v8::NewStringType::Normal).unwrap();
+    let exc = deno_core::v8::Exception::type_error(&mut #scope, msg);
     #scope.throw_exception(exc);
     return 1;
   }))

--- a/ops/op2/test_cases/async/async_arg_return.out
+++ b/ops/op2/test_cases/async/async_arg_return.out
@@ -23,74 +23,74 @@ impl op_async {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let result = {
             let arg0 = args.get(1usize as i32);
-            let Some(arg0) = ::deno_core::_ops::to_i32_option(&arg0) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected i32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg0 = arg0 as _;
             Self::call(arg0)
         };
-        let promise_id = ::deno_core::_ops::to_i32_option(&args.get(0))
+        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
             .unwrap_or_default();
-        if let Some(result) = ::deno_core::_ops::map_async_op_infallible(
+        if let Some(result) = deno_core::_ops::map_async_op_infallible(
             opctx,
             false,
             false,
             promise_id,
             result,
-            |scope, result| { Ok(::deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
-            ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
         return 2;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_async(
+        deno_core::_ops::dispatch_metrics_async(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else if res == 1 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/async/async_arg_return_result.out
+++ b/ops/op2/test_cases/async/async_arg_return_result.out
@@ -23,54 +23,50 @@ impl op_async {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let result = {
             let arg0 = args.get(1usize as i32);
-            let Some(arg0) = ::deno_core::_ops::to_i32_option(&arg0) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected i32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg0 = arg0 as _;
             Self::call(arg0)
         };
-        let promise_id = ::deno_core::_ops::to_i32_option(&args.get(0))
+        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
             .unwrap_or_default();
-        if let Some(result) = ::deno_core::_ops::map_async_op_fallible(
+        if let Some(result) = deno_core::_ops::map_async_op_fallible(
             opctx,
             false,
             false,
             promise_id,
             result,
-            |scope, result| { Ok(::deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
             match result {
-                Ok(result) => {
-                    ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
-                }
+                Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
                 Err(err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                     let err = err.into();
-                    let exception = ::deno_core::error::to_v8_error(
+                    let exception = deno_core::error::to_v8_error(
                         &mut scope,
                         opctx.get_error_class_fn,
                         &err,
@@ -83,31 +79,31 @@ impl op_async {
         }
         return 2;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_async(
+        deno_core::_ops::dispatch_metrics_async(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else if res == 1 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/async/async_deferred.out
+++ b/ops/op2/test_cases/async/async_deferred.out
@@ -11,18 +11,18 @@ impl deno_core::_ops::Op for op_async_deferred {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Int32, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Int32, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -40,101 +40,101 @@ impl op_async_deferred {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         promise_id: i32,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, promise_id, fast_api_callback_options);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
         promise_id: i32,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
         let result = { Self::call() };
-        ::deno_core::_ops::map_async_op_fallible(
+        deno_core::_ops::map_async_op_fallible(
             opctx,
             false,
             true,
             promise_id,
             result,
-            |scope, result| { Ok(::deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         );
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let result = { Self::call() };
-        let promise_id = ::deno_core::_ops::to_i32_option(&args.get(0))
+        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
             .unwrap_or_default();
-        ::deno_core::_ops::map_async_op_fallible(
+        deno_core::_ops::map_async_op_fallible(
             opctx,
             false,
             true,
             promise_id,
             result,
-            |scope, result| { Ok(::deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         );
         return 2;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_async(
+        deno_core::_ops::dispatch_metrics_async(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else if res == 1 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/async/async_jsbuffer.out
+++ b/ops/op2/test_cases/async/async_jsbuffer.out
@@ -23,65 +23,60 @@ impl op_async_v8_buffer {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let result = {
             let arg0 = args.get(1usize as i32);
             let mut arg0_temp;
-            arg0_temp = match unsafe { ::deno_core::_ops::to_v8_slice::<u8>(arg0) } {
+            arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
                 Ok(arg0) => arg0,
                 Err(arg0_err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             arg0_err.as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
             };
-            let arg0 = ::deno_core::serde_v8::JsBuffer::from_parts(arg0_temp);
+            let arg0 = deno_core::serde_v8::JsBuffer::from_parts(arg0_temp);
             Self::call(arg0)
         };
-        let promise_id = ::deno_core::_ops::to_i32_option(&args.get(0))
+        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
             .unwrap_or_default();
-        if let Some(result) = ::deno_core::_ops::map_async_op_infallible(
+        if let Some(result) = deno_core::_ops::map_async_op_infallible(
             opctx,
             false,
             false,
             promise_id,
             result,
             |scope, result| {
-                ::deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, scope)
+                deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, scope)
             },
         ) {
-            match ::deno_core::_ops::RustToV8Fallible::to_v8_fallible(
-                result,
-                &mut scope,
-            ) {
+            match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    let msg = ::deno_core::v8::String::new(
+                    let msg = deno_core::v8::String::new(
                             &mut scope,
-                            &format!("{}", ::deno_core::anyhow::Error::from(rv_err)),
+                            &format!("{}", deno_core::anyhow::Error::from(rv_err)),
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
@@ -90,31 +85,31 @@ impl op_async_v8_buffer {
         }
         return 2;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_async(
+        deno_core::_ops::dispatch_metrics_async(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else if res == 1 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/async/async_lazy.out
+++ b/ops/op2/test_cases/async/async_lazy.out
@@ -11,18 +11,18 @@ impl deno_core::_ops::Op for op_async_lazy {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Int32, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Int32, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -40,101 +40,101 @@ impl op_async_lazy {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         promise_id: i32,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, promise_id, fast_api_callback_options);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
         promise_id: i32,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
         let result = { Self::call() };
-        ::deno_core::_ops::map_async_op_fallible(
+        deno_core::_ops::map_async_op_fallible(
             opctx,
             true,
             false,
             promise_id,
             result,
-            |scope, result| { Ok(::deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         );
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let result = { Self::call() };
-        let promise_id = ::deno_core::_ops::to_i32_option(&args.get(0))
+        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
             .unwrap_or_default();
-        ::deno_core::_ops::map_async_op_fallible(
+        deno_core::_ops::map_async_op_fallible(
             opctx,
             true,
             false,
             promise_id,
             result,
-            |scope, result| { Ok(::deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         );
         return 2;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_async(
+        deno_core::_ops::dispatch_metrics_async(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else if res == 1 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/async/async_opstate.out
+++ b/ops/op2/test_cases/async/async_opstate.out
@@ -23,42 +23,38 @@ impl op_async_opstate {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let opstate = &opctx.state;
         let result = {
             let arg0 = opstate.clone();
             Self::call(arg0)
         };
-        let promise_id = ::deno_core::_ops::to_i32_option(&args.get(0))
+        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
             .unwrap_or_default();
-        if let Some(result) = ::deno_core::_ops::map_async_op_fallible(
+        if let Some(result) = deno_core::_ops::map_async_op_fallible(
             opctx,
             false,
             false,
             promise_id,
             result,
-            |scope, result| { Ok(::deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
             match result {
-                Ok(result) => {
-                    ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
-                }
+                Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
                 Err(err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                     let err = err.into();
-                    let exception = ::deno_core::error::to_v8_error(
+                    let exception = deno_core::error::to_v8_error(
                         &mut scope,
                         opctx.get_error_class_fn,
                         &err,
@@ -71,31 +67,31 @@ impl op_async_opstate {
         }
         return 2;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_async(
+        deno_core::_ops::dispatch_metrics_async(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else if res == 1 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/async/async_result.out
+++ b/ops/op2/test_cases/async/async_result.out
@@ -23,38 +23,34 @@ impl op_async {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let result = { Self::call() };
-        let promise_id = ::deno_core::_ops::to_i32_option(&args.get(0))
+        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
             .unwrap_or_default();
-        if let Some(result) = ::deno_core::_ops::map_async_op_fallible(
+        if let Some(result) = deno_core::_ops::map_async_op_fallible(
             opctx,
             false,
             false,
             promise_id,
             result,
-            |scope, result| { Ok(::deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
             match result {
-                Ok(result) => {
-                    ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
-                }
+                Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
                 Err(err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                     let err = err.into();
-                    let exception = ::deno_core::error::to_v8_error(
+                    let exception = deno_core::error::to_v8_error(
                         &mut scope,
                         opctx.get_error_class_fn,
                         &err,
@@ -67,31 +63,31 @@ impl op_async {
         }
         return 2;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_async(
+        deno_core::_ops::dispatch_metrics_async(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else if res == 1 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/async/async_result_impl.out
+++ b/ops/op2/test_cases/async/async_result_impl.out
@@ -23,28 +23,28 @@ impl op_async_result_impl {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let result = {
             let arg0 = args.get(1usize as i32);
-            let Some(arg0) = ::deno_core::_ops::to_i32_option(&arg0) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected i32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
@@ -54,9 +54,9 @@ impl op_async_result_impl {
         let result = match result {
             Ok(result) => result,
             Err(err) => {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                 let err = err.into();
-                let exception = ::deno_core::error::to_v8_error(
+                let exception = deno_core::error::to_v8_error(
                     &mut scope,
                     opctx.get_error_class_fn,
                     &err,
@@ -65,26 +65,22 @@ impl op_async_result_impl {
                 return 1;
             }
         };
-        let promise_id = ::deno_core::_ops::to_i32_option(&args.get(0))
+        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
             .unwrap_or_default();
-        if let Some(result) = ::deno_core::_ops::map_async_op_fallible(
+        if let Some(result) = deno_core::_ops::map_async_op_fallible(
             opctx,
             false,
             false,
             promise_id,
             result,
-            |scope, result| { Ok(::deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
             match result {
-                Ok(result) => {
-                    ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
-                }
+                Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
                 Err(err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                     let err = err.into();
-                    let exception = ::deno_core::error::to_v8_error(
+                    let exception = deno_core::error::to_v8_error(
                         &mut scope,
                         opctx.get_error_class_fn,
                         &err,
@@ -97,31 +93,31 @@ impl op_async_result_impl {
         }
         return 2;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_async(
+        deno_core::_ops::dispatch_metrics_async(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else if res == 1 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/async/async_result_smi.out
+++ b/ops/op2/test_cases/async/async_result_smi.out
@@ -23,37 +23,37 @@ impl op_async {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let result = {
             let arg0 = args.get(1usize as i32);
-            let Some(arg0) = ::deno_core::_ops::to_i32_option(&arg0) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected i32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg0 = arg0 as _;
             Self::call(arg0)
         };
-        let promise_id = ::deno_core::_ops::to_i32_option(&args.get(0))
+        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
             .unwrap_or_default();
-        if let Some(result) = ::deno_core::_ops::map_async_op_fallible(
+        if let Some(result) = deno_core::_ops::map_async_op_fallible(
             opctx,
             false,
             false,
@@ -61,9 +61,9 @@ impl op_async {
             result,
             |scope, result| {
                 Ok(
-                    ::deno_core::_ops::RustToV8::to_v8(
-                        ::deno_core::_ops::RustToV8Marker::<
-                            ::deno_core::_ops::SmiMarker,
+                    deno_core::_ops::RustToV8::to_v8(
+                        deno_core::_ops::RustToV8Marker::<
+                            deno_core::_ops::SmiMarker,
                             _,
                         >::from(result),
                         scope,
@@ -73,20 +73,18 @@ impl op_async {
         ) {
             match result {
                 Ok(result) => {
-                    ::deno_core::_ops::RustToV8RetVal::to_v8_rv(
-                        ::deno_core::_ops::RustToV8Marker::<
-                            ::deno_core::_ops::SmiMarker,
+                    deno_core::_ops::RustToV8RetVal::to_v8_rv(
+                        deno_core::_ops::RustToV8Marker::<
+                            deno_core::_ops::SmiMarker,
                             _,
                         >::from(result),
                         &mut rv,
                     )
                 }
                 Err(err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                     let err = err.into();
-                    let exception = ::deno_core::error::to_v8_error(
+                    let exception = deno_core::error::to_v8_error(
                         &mut scope,
                         opctx.get_error_class_fn,
                         &err,
@@ -99,31 +97,31 @@ impl op_async {
         }
         return 2;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_async(
+        deno_core::_ops::dispatch_metrics_async(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else if res == 1 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/async/async_v8_global.out
+++ b/ops/op2/test_cases/async/async_v8_global.out
@@ -23,77 +23,77 @@ impl op_async_v8_global {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let result = {
             let arg0 = args.get(1usize as i32);
-            let Ok(mut arg0) = ::deno_core::_ops::v8_try_convert::<
-                ::deno_core::v8::String,
+            let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
+                deno_core::v8::String,
             >(arg0) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected String".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
-            let arg0 = ::deno_core::v8::Global::new(&mut scope, arg0);
+            let arg0 = deno_core::v8::Global::new(&mut scope, arg0);
             Self::call(arg0)
         };
-        let promise_id = ::deno_core::_ops::to_i32_option(&args.get(0))
+        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
             .unwrap_or_default();
-        if let Some(result) = ::deno_core::_ops::map_async_op_infallible(
+        if let Some(result) = deno_core::_ops::map_async_op_infallible(
             opctx,
             false,
             false,
             promise_id,
             result,
-            |scope, result| { Ok(::deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
-            ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
         return 2;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_async(
+        deno_core::_ops::dispatch_metrics_async(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else if res == 1 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/async/async_void.out
+++ b/ops/op2/test_cases/async/async_void.out
@@ -23,58 +23,58 @@ impl op_async {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let result = { Self::call() };
-        let promise_id = ::deno_core::_ops::to_i32_option(&args.get(0))
+        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
             .unwrap_or_default();
-        if let Some(result) = ::deno_core::_ops::map_async_op_infallible(
+        if let Some(result) = deno_core::_ops::map_async_op_infallible(
             opctx,
             false,
             false,
             promise_id,
             result,
-            |scope, result| { Ok(::deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
         ) {
-            ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
         return 2;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_async(
+        deno_core::_ops::dispatch_metrics_async(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else if res == 1 {
-            ::deno_core::_ops::dispatch_metrics_async(
+            deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -11,18 +11,18 @@ impl deno_core::_ops::Op for op_add {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Uint32, Type::Uint32],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Uint32, Type::Uint32, Type::CallbackOptions],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -40,32 +40,32 @@ impl op_add {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: u32,
         arg1: u32,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> u32 {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: u32,
         arg1: u32,
     ) -> u32 {
@@ -77,72 +77,72 @@ impl op_add {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg0 = args.get(0usize as i32);
-            let Some(arg0) = ::deno_core::_ops::to_u32_option(&arg0) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected u32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg0 = arg0 as _;
             let arg1 = args.get(1usize as i32);
-            let Some(arg1) = ::deno_core::_ops::to_u32_option(&arg1) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected u32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg1 = arg1 as _;
             Self::call(arg0, arg1)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/add_options.out
+++ b/ops/op2/test_cases/sync/add_options.out
@@ -23,24 +23,24 @@ impl op_test_add_option {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg0 = args.get(0usize as i32);
-            let Some(arg0) = ::deno_core::_ops::to_u32_option(&arg0) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected u32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
@@ -49,17 +49,15 @@ impl op_test_add_option {
             let arg1 = if arg1.is_null_or_undefined() {
                 None
             } else {
-                let Some(arg1) = ::deno_core::_ops::to_u32_option(&arg1) else {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected u32".as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 };
@@ -68,34 +66,34 @@ impl op_test_add_option {
             };
             Self::call(arg0, arg1)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/bigint.out
+++ b/ops/op2/test_cases/sync/bigint.out
@@ -11,18 +11,18 @@ impl deno_core::_ops::Op for op_bigint {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value],
                 CType::Uint64,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Uint64,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -40,67 +40,67 @@ impl op_bigint {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> u64 {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
-    fn v8_fn_ptr_fast(_: ::deno_core::v8::Local<::deno_core::v8::Object>) -> u64 {
+    fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> u64 {
         let result = { Self::call() };
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
         let result = { Self::call() };
-        rv.set(::deno_core::_ops::RustToV8::to_v8(result, &mut scope));
+        rv.set(deno_core::_ops::RustToV8::to_v8(result, &mut scope));
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/bool.out
+++ b/ops/op2/test_cases/sync/bool.out
@@ -11,18 +11,18 @@ impl deno_core::_ops::Op for op_bool {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Bool],
                 CType::Bool,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Bool, Type::CallbackOptions],
                 CType::Bool,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -40,31 +40,31 @@ impl op_bool {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: bool,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> bool {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: bool,
     ) -> bool {
         let result = {
@@ -74,11 +74,11 @@ impl op_bool {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
@@ -86,34 +86,34 @@ impl op_bool {
             let arg0 = arg0.is_true();
             Self::call(arg0)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -11,18 +11,18 @@ impl deno_core::_ops::Op for op_bool {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Bool, Type::CallbackOptions],
                 CType::Bool,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Bool, Type::CallbackOptions],
                 CType::Bool,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -40,40 +40,40 @@ impl op_bool {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: bool,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> bool {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: bool,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> bool {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
         let result = {
             let arg0 = arg0 as _;
@@ -92,21 +92,21 @@ impl op_bool {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         if let Some(err) = unsafe { opctx.unsafely_take_last_error_for_ops_only() } {
-            let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
             let err = err.into();
-            let exception = ::deno_core::error::to_v8_error(
+            let exception = deno_core::error::to_v8_error(
                 &mut scope,
                 opctx.get_error_class_fn,
                 &err,
@@ -120,11 +120,11 @@ impl op_bool {
             Self::call(arg0)
         };
         match result {
-            Ok(result) => ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
+            Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
             Err(err) => {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                 let err = err.into();
-                let exception = ::deno_core::error::to_v8_error(
+                let exception = deno_core::error::to_v8_error(
                     &mut scope,
                     opctx.get_error_class_fn,
                     &err,
@@ -135,31 +135,31 @@ impl op_bool {
         };
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -11,9 +11,9 @@ impl deno_core::_ops::Op for op_buffers {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[
                     Type::V8Value,
                     Type::TypedArray(CType::Uint8),
@@ -26,9 +26,9 @@ impl deno_core::_ops::Op for op_buffers {
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[
                     Type::V8Value,
                     Type::TypedArray(CType::Uint8),
@@ -53,56 +53,56 @@ impl op_buffers {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg0: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg1: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg2: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg3: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg0: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg1: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg2: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg3: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
     ) -> () {
         let result = {
             let arg0 = unsafe {
-                ::deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
                     arg0,
                 )
             }
                 .expect("Invalid buffer");
             let arg0 = arg0;
             let arg1 = unsafe {
-                ::deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
                     arg1,
                 )
             }
                 .expect("Invalid buffer");
             let arg1 = arg1;
             let arg2 = unsafe {
-                ::deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
                     arg2,
                 )
             }
@@ -113,7 +113,7 @@ impl op_buffers {
                 arg2.as_mut_ptr() as _
             };
             let arg3 = unsafe {
-                ::deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
                     arg3,
                 )
             }
@@ -128,29 +128,27 @@ impl op_buffers {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg0 = args.get(0usize as i32);
             let mut arg0_temp;
-            arg0_temp = match unsafe { ::deno_core::_ops::to_v8_slice::<u8>(arg0) } {
+            arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
                 Ok(arg0) => arg0,
                 Err(arg0_err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             arg0_err.as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
@@ -158,19 +156,17 @@ impl op_buffers {
             let arg0 = arg0_temp.as_ref();
             let arg1 = args.get(1usize as i32);
             let mut arg1_temp;
-            arg1_temp = match unsafe { ::deno_core::_ops::to_v8_slice::<u8>(arg1) } {
+            arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg1) } {
                 Ok(arg1) => arg1,
                 Err(arg1_err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             arg1_err.as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
@@ -178,19 +174,17 @@ impl op_buffers {
             let arg1 = arg1_temp.as_mut();
             let arg2 = args.get(2usize as i32);
             let mut arg2_temp;
-            arg2_temp = match unsafe { ::deno_core::_ops::to_v8_slice::<u8>(arg2) } {
+            arg2_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg2) } {
                 Ok(arg2) => arg2,
                 Err(arg2_err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             arg2_err.as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
@@ -202,19 +196,17 @@ impl op_buffers {
             };
             let arg3 = args.get(3usize as i32);
             let mut arg3_temp;
-            arg3_temp = match unsafe { ::deno_core::_ops::to_v8_slice::<u8>(arg3) } {
+            arg3_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg3) } {
                 Ok(arg3) => arg3,
                 Err(arg3_err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             arg3_err.as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
@@ -226,34 +218,34 @@ impl op_buffers {
             };
             Self::call(arg0, arg1, arg2, arg3)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -274,9 +266,9 @@ impl deno_core::_ops::Op for op_buffers_32 {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[
                     Type::V8Value,
                     Type::TypedArray(CType::Uint32),
@@ -289,9 +281,9 @@ impl deno_core::_ops::Op for op_buffers_32 {
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[
                     Type::V8Value,
                     Type::TypedArray(CType::Uint32),
@@ -316,56 +308,56 @@ impl op_buffers_32 {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg0: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        arg1: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        arg2: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        arg3: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg0: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        arg1: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        arg2: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        arg3: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
     ) -> () {
         let result = {
             let arg0 = unsafe {
-                ::deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
                     arg0,
                 )
             }
                 .expect("Invalid buffer");
             let arg0 = arg0;
             let arg1 = unsafe {
-                ::deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
                     arg1,
                 )
             }
                 .expect("Invalid buffer");
             let arg1 = arg1;
             let arg2 = unsafe {
-                ::deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
                     arg2,
                 )
             }
@@ -376,7 +368,7 @@ impl op_buffers_32 {
                 arg2.as_mut_ptr() as _
             };
             let arg3 = unsafe {
-                ::deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
                     arg3,
                 )
             }
@@ -391,29 +383,27 @@ impl op_buffers_32 {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg0 = args.get(0usize as i32);
             let mut arg0_temp;
-            arg0_temp = match unsafe { ::deno_core::_ops::to_v8_slice::<u32>(arg0) } {
+            arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg0) } {
                 Ok(arg0) => arg0,
                 Err(arg0_err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             arg0_err.as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
@@ -421,19 +411,17 @@ impl op_buffers_32 {
             let arg0 = arg0_temp.as_ref();
             let arg1 = args.get(1usize as i32);
             let mut arg1_temp;
-            arg1_temp = match unsafe { ::deno_core::_ops::to_v8_slice::<u32>(arg1) } {
+            arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg1) } {
                 Ok(arg1) => arg1,
                 Err(arg1_err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             arg1_err.as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
@@ -441,19 +429,17 @@ impl op_buffers_32 {
             let arg1 = arg1_temp.as_mut();
             let arg2 = args.get(2usize as i32);
             let mut arg2_temp;
-            arg2_temp = match unsafe { ::deno_core::_ops::to_v8_slice::<u32>(arg2) } {
+            arg2_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg2) } {
                 Ok(arg2) => arg2,
                 Err(arg2_err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             arg2_err.as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
@@ -465,19 +451,17 @@ impl op_buffers_32 {
             };
             let arg3 = args.get(3usize as i32);
             let mut arg3_temp;
-            arg3_temp = match unsafe { ::deno_core::_ops::to_v8_slice::<u32>(arg3) } {
+            arg3_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg3) } {
                 Ok(arg3) => arg3,
                 Err(arg3_err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             arg3_err.as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
@@ -489,34 +473,34 @@ impl op_buffers_32 {
             };
             Self::call(arg0, arg1, arg2, arg3)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -549,11 +533,11 @@ impl op_buffers_option {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
@@ -562,22 +546,19 @@ impl op_buffers_option {
             let arg0 = if arg0.is_null_or_undefined() {
                 None
             } else {
-                arg0_temp = match unsafe { ::deno_core::_ops::to_v8_slice::<u8>(arg0) } {
+                arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
                         let mut scope = unsafe {
-                            ::deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(&*info)
                         };
-                        let msg = ::deno_core::v8::String::new_from_one_byte(
+                        let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
                                 arg0_err.as_bytes(),
-                                ::deno_core::v8::NewStringType::Normal,
+                                deno_core::v8::NewStringType::Normal,
                             )
                             .unwrap();
-                        let exc = ::deno_core::v8::Exception::type_error(
-                            &mut scope,
-                            msg,
-                        );
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                         scope.throw_exception(exc);
                         return 1;
                     }
@@ -590,59 +571,56 @@ impl op_buffers_option {
             let arg1 = if arg1.is_null_or_undefined() {
                 None
             } else {
-                arg1_temp = match unsafe { ::deno_core::_ops::to_v8_slice::<u8>(arg1) } {
+                arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg1) } {
                     Ok(arg1) => arg1,
                     Err(arg1_err) => {
                         let mut scope = unsafe {
-                            ::deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(&*info)
                         };
-                        let msg = ::deno_core::v8::String::new_from_one_byte(
+                        let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
                                 arg1_err.as_bytes(),
-                                ::deno_core::v8::NewStringType::Normal,
+                                deno_core::v8::NewStringType::Normal,
                             )
                             .unwrap();
-                        let exc = ::deno_core::v8::Exception::type_error(
-                            &mut scope,
-                            msg,
-                        );
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                         scope.throw_exception(exc);
                         return 1;
                     }
                 };
-                let arg1 = ::deno_core::serde_v8::JsBuffer::from_parts(arg1_temp);
+                let arg1 = deno_core::serde_v8::JsBuffer::from_parts(arg1_temp);
                 Some(arg1)
             };
             Self::call(arg0, arg1)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -11,9 +11,9 @@ impl deno_core::_ops::Op for op_buffers {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[
                     Type::V8Value,
                     Type::TypedArray(CType::Uint8),
@@ -25,9 +25,9 @@ impl deno_core::_ops::Op for op_buffers {
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[
                     Type::V8Value,
                     Type::TypedArray(CType::Uint8),
@@ -51,54 +51,54 @@ impl op_buffers {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg0: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg1: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg2: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg0: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg1: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg2: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
     ) -> () {
         let result = {
             let arg0 = unsafe {
-                ::deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
                     arg0,
                 )
             }
                 .expect("Invalid buffer");
             let arg0 = arg0.to_vec();
             let arg1 = unsafe {
-                ::deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
                     arg1,
                 )
             }
                 .expect("Invalid buffer");
             let arg1 = arg1.to_vec().into_boxed_slice();
             let arg2 = unsafe {
-                ::deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
                     arg2,
                 )
             }
@@ -109,29 +109,27 @@ impl op_buffers {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg0 = args.get(0usize as i32);
             let mut arg0_temp;
-            arg0_temp = match unsafe { ::deno_core::_ops::to_v8_slice::<u8>(arg0) } {
+            arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
                 Ok(arg0) => arg0,
                 Err(arg0_err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             arg0_err.as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
@@ -139,19 +137,17 @@ impl op_buffers {
             let arg0 = arg0_temp.to_vec();
             let arg1 = args.get(1usize as i32);
             let mut arg1_temp;
-            arg1_temp = match unsafe { ::deno_core::_ops::to_v8_slice::<u8>(arg1) } {
+            arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg1) } {
                 Ok(arg1) => arg1,
                 Err(arg1_err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             arg1_err.as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
@@ -159,19 +155,17 @@ impl op_buffers {
             let arg1 = arg1_temp.to_boxed_slice();
             let arg2 = args.get(2usize as i32);
             let mut arg2_temp;
-            arg2_temp = match unsafe { ::deno_core::_ops::to_v8_slice::<u8>(arg2) } {
+            arg2_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg2) } {
                 Ok(arg2) => arg2,
                 Err(arg2_err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             arg2_err.as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
@@ -179,34 +173,34 @@ impl op_buffers {
             let arg2 = arg2_temp.to_vec().into();
             Self::call(arg0, arg1, arg2)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -227,9 +221,9 @@ impl deno_core::_ops::Op for op_buffers_32 {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[
                     Type::V8Value,
                     Type::TypedArray(CType::Uint32),
@@ -240,9 +234,9 @@ impl deno_core::_ops::Op for op_buffers_32 {
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[
                     Type::V8Value,
                     Type::TypedArray(CType::Uint32),
@@ -265,45 +259,45 @@ impl op_buffers_32 {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg0: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        arg1: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg0: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        arg1: *mut ::deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
     ) -> () {
         let result = {
             let arg0 = unsafe {
-                ::deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
                     arg0,
                 )
             }
                 .expect("Invalid buffer");
             let arg0 = arg0.to_vec();
             let arg1 = unsafe {
-                ::deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
                     arg1,
                 )
             }
@@ -314,29 +308,27 @@ impl op_buffers_32 {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg0 = args.get(0usize as i32);
             let mut arg0_temp;
-            arg0_temp = match unsafe { ::deno_core::_ops::to_v8_slice::<u32>(arg0) } {
+            arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg0) } {
                 Ok(arg0) => arg0,
                 Err(arg0_err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             arg0_err.as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
@@ -344,19 +336,17 @@ impl op_buffers_32 {
             let arg0 = arg0_temp.to_vec();
             let arg1 = args.get(1usize as i32);
             let mut arg1_temp;
-            arg1_temp = match unsafe { ::deno_core::_ops::to_v8_slice::<u32>(arg1) } {
+            arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg1) } {
                 Ok(arg1) => arg1,
                 Err(arg1_err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             arg1_err.as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
@@ -364,34 +354,34 @@ impl op_buffers_32 {
             let arg1 = arg1_temp.to_boxed_slice();
             Self::call(arg0, arg1)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/buffers_out.out
+++ b/ops/op2/test_cases/sync/buffers_out.out
@@ -23,77 +23,75 @@ impl op_buffers {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg0 = args.get(0usize as i32);
             let mut arg0_temp;
-            arg0_temp = match unsafe { ::deno_core::_ops::to_v8_slice::<u8>(arg0) } {
+            arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
                 Ok(arg0) => arg0,
                 Err(arg0_err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             arg0_err.as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
             };
-            let arg0 = ::deno_core::serde_v8::JsBuffer::from_parts(arg0_temp);
+            let arg0 = deno_core::serde_v8::JsBuffer::from_parts(arg0_temp);
             Self::call(arg0)
         };
-        match ::deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
+        match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
             Ok(v) => rv.set(v),
             Err(rv_err) => {
-                let msg = ::deno_core::v8::String::new(
+                let msg = deno_core::v8::String::new(
                         &mut scope,
-                        &format!("{}", ::deno_core::anyhow::Error::from(rv_err)),
+                        &format!("{}", deno_core::anyhow::Error::from(rv_err)),
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             }
         };
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -128,12 +126,12 @@ impl op_buffers_option {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
@@ -142,71 +140,68 @@ impl op_buffers_option {
             let arg0 = if arg0.is_null_or_undefined() {
                 None
             } else {
-                arg0_temp = match unsafe { ::deno_core::_ops::to_v8_slice::<u8>(arg0) } {
+                arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
                         let mut scope = unsafe {
-                            ::deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(&*info)
                         };
-                        let msg = ::deno_core::v8::String::new_from_one_byte(
+                        let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
                                 arg0_err.as_bytes(),
-                                ::deno_core::v8::NewStringType::Normal,
+                                deno_core::v8::NewStringType::Normal,
                             )
                             .unwrap();
-                        let exc = ::deno_core::v8::Exception::type_error(
-                            &mut scope,
-                            msg,
-                        );
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                         scope.throw_exception(exc);
                         return 1;
                     }
                 };
-                let arg0 = ::deno_core::serde_v8::JsBuffer::from_parts(arg0_temp);
+                let arg0 = deno_core::serde_v8::JsBuffer::from_parts(arg0_temp);
                 Some(arg0)
             };
             Self::call(arg0)
         };
-        match ::deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
+        match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
             Ok(v) => rv.set(v),
             Err(rv_err) => {
-                let msg = ::deno_core::v8::String::new(
+                let msg = deno_core::v8::String::new(
                         &mut scope,
-                        &format!("{}", ::deno_core::anyhow::Error::from(rv_err)),
+                        &format!("{}", deno_core::anyhow::Error::from(rv_err)),
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             }
         };
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -241,41 +236,39 @@ impl op_arraybuffers {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg0 = args.get(0usize as i32);
             let mut arg0_temp;
-            arg0_temp = match unsafe { ::deno_core::_ops::to_v8_slice_buffer(arg0) } {
+            arg0_temp = match unsafe { deno_core::_ops::to_v8_slice_buffer(arg0) } {
                 Ok(arg0) => arg0,
                 Err(arg0_err) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             arg0_err.as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
             };
-            let arg0 = ::deno_core::serde_v8::JsBuffer::from_parts(arg0_temp);
+            let arg0 = deno_core::serde_v8::JsBuffer::from_parts(arg0_temp);
             Self::call(arg0)
         };
         rv.set(
-            ::deno_core::_ops::RustToV8::to_v8(
-                ::deno_core::_ops::RustToV8Marker::<
-                    ::deno_core::_ops::ArrayBufferMarker,
+            deno_core::_ops::RustToV8::to_v8(
+                deno_core::_ops::RustToV8Marker::<
+                    deno_core::_ops::ArrayBufferMarker,
                     _,
                 >::from(result),
                 &mut scope,
@@ -283,31 +276,31 @@ impl op_arraybuffers {
         );
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/cfg.out
+++ b/ops/op2/test_cases/sync/cfg.out
@@ -13,18 +13,18 @@ impl deno_core::_ops::Op for op_maybe_windows {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -42,66 +42,66 @@ impl op_maybe_windows {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
-    fn v8_fn_ptr_fast(_: ::deno_core::v8::Local<::deno_core::v8::Object>) -> () {
+    fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = { Self::call() };
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
         let result = { Self::call() };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -126,18 +126,18 @@ impl deno_core::_ops::Op for op_maybe_windows {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -155,66 +155,66 @@ impl op_maybe_windows {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
-    fn v8_fn_ptr_fast(_: ::deno_core::v8::Local<::deno_core::v8::Object>) -> () {
+    fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = { Self::call() };
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
         let result = { Self::call() };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/clippy_allow.out
+++ b/ops/op2/test_cases/sync/clippy_allow.out
@@ -13,18 +13,18 @@ impl deno_core::_ops::Op for op_extra_annotation {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -42,66 +42,66 @@ impl op_extra_annotation {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
-    fn v8_fn_ptr_fast(_: ::deno_core::v8::Local<::deno_core::v8::Object>) -> () {
+    fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = { Self::call() };
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
         let result = { Self::call() };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -124,18 +124,18 @@ impl deno_core::_ops::Op for op_clippy_internal {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -153,66 +153,66 @@ impl op_clippy_internal {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
-    fn v8_fn_ptr_fast(_: ::deno_core::v8::Local<::deno_core::v8::Object>) -> () {
+    fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = { Self::call() };
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
         let result = { Self::call() };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/doc_comment.out
+++ b/ops/op2/test_cases/sync/doc_comment.out
@@ -12,18 +12,18 @@ impl deno_core::_ops::Op for op_has_doc_comment {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -41,66 +41,66 @@ impl op_has_doc_comment {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
-    fn v8_fn_ptr_fast(_: ::deno_core::v8::Local<::deno_core::v8::Object>) -> () {
+    fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = { Self::call() };
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
         let result = { Self::call() };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/fast_alternative.out
+++ b/ops/op2/test_cases/sync/fast_alternative.out
@@ -23,37 +23,37 @@ impl op_slow {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg1 = args.get(0usize as i32);
-            let Some(arg1) = ::deno_core::_ops::to_u32_option(&arg1) else {
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected u32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg1 = arg1 as _;
             let arg2 = args.get(1usize as i32);
-            let Some(arg2) = ::deno_core::_ops::to_u32_option(&arg2) else {
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg2) = deno_core::_ops::to_u32_option(&arg2) else {
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected u32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
@@ -61,34 +61,34 @@ impl op_slow {
             let arg0 = &mut scope;
             Self::call(arg0, arg1, arg2)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -111,18 +111,18 @@ impl deno_core::_ops::Op for op_fast {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Uint32, Type::Uint32],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Uint32, Type::Uint32, Type::CallbackOptions],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -140,32 +140,32 @@ impl op_fast {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: u32,
         arg1: u32,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> u32 {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: u32,
         arg1: u32,
     ) -> u32 {
@@ -177,72 +177,72 @@ impl op_fast {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg0 = args.get(0usize as i32);
-            let Some(arg0) = ::deno_core::_ops::to_u32_option(&arg0) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected u32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg0 = arg0 as _;
             let arg1 = args.get(1usize as i32);
-            let Some(arg1) = ::deno_core::_ops::to_u32_option(&arg1) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected u32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg1 = arg1 as _;
             Self::call(arg0, arg1)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -277,37 +277,37 @@ impl<T: Trait> op_slow_generic<T> {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg1 = args.get(0usize as i32);
-            let Some(arg1) = ::deno_core::_ops::to_u32_option(&arg1) else {
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected u32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg1 = arg1 as _;
             let arg2 = args.get(1usize as i32);
-            let Some(arg2) = ::deno_core::_ops::to_u32_option(&arg2) else {
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg2) = deno_core::_ops::to_u32_option(&arg2) else {
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected u32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
@@ -315,34 +315,34 @@ impl<T: Trait> op_slow_generic<T> {
             let arg0 = &mut scope;
             Self::call(arg0, arg1, arg2)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -365,18 +365,18 @@ impl<T: Trait> deno_core::_ops::Op for op_fast_generic<T> {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Uint32, Type::Uint32],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Uint32, Type::Uint32, Type::CallbackOptions],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -394,32 +394,32 @@ impl<T: Trait> op_fast_generic<T> {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: u32,
         arg1: u32,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> u32 {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: u32,
         arg1: u32,
     ) -> u32 {
@@ -431,72 +431,72 @@ impl<T: Trait> op_fast_generic<T> {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg0 = args.get(0usize as i32);
-            let Some(arg0) = ::deno_core::_ops::to_u32_option(&arg0) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected u32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg0 = arg0 as _;
             let arg1 = args.get(1usize as i32);
-            let Some(arg1) = ::deno_core::_ops::to_u32_option(&arg1) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected u32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg1 = arg1 as _;
             Self::call(arg0, arg1)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -11,18 +11,18 @@ impl<T: Trait> deno_core::_ops::Op for op_generics<T> {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -40,66 +40,66 @@ impl<T: Trait> op_generics<T> {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
-    fn v8_fn_ptr_fast(_: ::deno_core::v8::Local<::deno_core::v8::Object>) -> () {
+    fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = { Self::call() };
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
         let result = { Self::call() };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -120,18 +120,18 @@ impl<T: Trait + 'static> deno_core::_ops::Op for op_generics_static<T> {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -149,66 +149,66 @@ impl<T: Trait + 'static> op_generics_static<T> {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
-    fn v8_fn_ptr_fast(_: ::deno_core::v8::Local<::deno_core::v8::Object>) -> () {
+    fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = { Self::call() };
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
         let result = { Self::call() };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -229,18 +229,18 @@ impl<T: Trait + 'static> deno_core::_ops::Op for op_generics_static_where<T> {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -258,66 +258,66 @@ impl<T: Trait + 'static> op_generics_static_where<T> {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
-    fn v8_fn_ptr_fast(_: ::deno_core::v8::Local<::deno_core::v8::Object>) -> () {
+    fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
         let result = { Self::call() };
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
         let result = { Self::call() };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/nofast.out
+++ b/ops/op2/test_cases/sync/nofast.out
@@ -23,72 +23,72 @@ impl op_nofast {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg0 = args.get(0usize as i32);
-            let Some(arg0) = ::deno_core::_ops::to_u32_option(&arg0) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected u32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg0 = arg0 as _;
             let arg1 = args.get(1usize as i32);
-            let Some(arg1) = ::deno_core::_ops::to_u32_option(&arg1) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected u32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg1 = arg1 as _;
             Self::call(arg0, arg1)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/op_state_attr.out
+++ b/ops/op2/test_cases/sync/op_state_attr.out
@@ -11,18 +11,18 @@ impl deno_core::_ops::Op for op_state_rc {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -40,42 +40,42 @@ impl op_state_rc {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
         let result = {
             let arg0 = ::std::cell::RefCell::borrow(&opctx.state);
-            let arg0 = ::deno_core::_ops::opstate_borrow::<Something>(&arg0);
+            let arg0 = deno_core::_ops::opstate_borrow::<Something>(&arg0);
             let arg1 = &::std::cell::RefCell::borrow(&opctx.state);
             let arg1 = arg1.try_borrow::<Something>();
             Self::call(arg0, arg1)
@@ -83,53 +83,53 @@ impl op_state_rc {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let opstate = &opctx.state;
         let result = {
             let arg0 = ::std::cell::RefCell::borrow(&opstate);
-            let arg0 = ::deno_core::_ops::opstate_borrow::<Something>(&arg0);
+            let arg0 = deno_core::_ops::opstate_borrow::<Something>(&arg0);
             let arg1 = &::std::cell::RefCell::borrow(&opstate);
             let arg1 = arg1.try_borrow::<Something>();
             Self::call(arg0, arg1)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/op_state_rc.out
+++ b/ops/op2/test_cases/sync/op_state_rc.out
@@ -11,18 +11,18 @@ impl deno_core::_ops::Op for op_state_rc {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -40,38 +40,38 @@ impl op_state_rc {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
         let result = {
             let arg0 = opctx.state.clone();
@@ -80,50 +80,50 @@ impl op_state_rc {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let opstate = &opctx.state;
         let result = {
             let arg0 = opstate.clone();
             Self::call(arg0)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -11,18 +11,18 @@ impl deno_core::_ops::Op for op_state_ref {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -40,38 +40,38 @@ impl op_state_ref {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
         let result = {
             let arg0 = &::std::cell::RefCell::borrow(&opctx.state);
@@ -80,50 +80,50 @@ impl op_state_ref {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let opstate = &opctx.state;
         let result = {
             let arg0 = &::std::cell::RefCell::borrow(&opstate);
             Self::call(arg0)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -144,18 +144,18 @@ impl deno_core::_ops::Op for op_state_mut {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -173,38 +173,38 @@ impl op_state_mut {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
         let result = {
             let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opctx.state);
@@ -213,50 +213,50 @@ impl op_state_mut {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let opstate = &opctx.state;
         let result = {
             let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opstate);
             Self::call(arg0)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -289,67 +289,67 @@ impl op_state_and_v8 {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let mut scope = unsafe { &mut *opctx.isolate };
         let opstate = &opctx.state;
         let result = {
             let arg1 = args.get(0usize as i32);
-            let Ok(mut arg1) = ::deno_core::_ops::v8_try_convert::<
-                ::deno_core::v8::Function,
+            let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
+                deno_core::v8::Function,
             >(arg1) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected Function".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
-            let arg1 = ::deno_core::v8::Global::new(&mut scope, arg1);
+            let arg1 = deno_core::v8::Global::new(&mut scope, arg1);
             let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opstate);
             Self::call(arg0, arg1)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -370,18 +370,18 @@ impl deno_core::_ops::Op for op_state_and_v8_local {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -399,45 +399,45 @@ impl op_state_and_v8_local {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg1: ::deno_core::v8::Local<::deno_core::v8::Value>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg1: deno_core::v8::Local<deno_core::v8::Value>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg1, fast_api_callback_options);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg1: ::deno_core::v8::Local<::deno_core::v8::Value>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        arg1: deno_core::v8::Local<deno_core::v8::Value>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
         let result = {
             let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opctx.state);
-            let Ok(mut arg1) = ::deno_core::_ops::v8_try_convert::<
-                ::deno_core::v8::Function,
+            let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
+                deno_core::v8::Function,
             >(arg1) else {
                 fast_api_callback_options.fallback = true;
                 return unsafe { std::mem::zeroed() };
@@ -448,31 +448,31 @@ impl op_state_and_v8_local {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let opstate = &opctx.state;
         let result = {
             let arg1 = args.get(0usize as i32);
-            let Ok(mut arg1) = ::deno_core::_ops::v8_try_convert::<
-                ::deno_core::v8::Function,
+            let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
+                deno_core::v8::Function,
             >(arg1) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected Function".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
@@ -480,34 +480,34 @@ impl op_state_and_v8_local {
             let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opstate);
             Self::call(arg0, arg1)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/result_external.out
+++ b/ops/op2/test_cases/sync/result_external.out
@@ -11,18 +11,18 @@ impl deno_core::_ops::Op for op_external_with_result {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Pointer,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Pointer,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -40,38 +40,38 @@ impl op_external_with_result {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> *mut ::std::ffi::c_void {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> *mut ::std::ffi::c_void {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
         let result = { Self::call() };
         let result = match result {
@@ -87,25 +87,25 @@ impl op_external_with_result {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         if let Some(err) = unsafe { opctx.unsafely_take_last_error_for_ops_only() } {
-            let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-            let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
                 &*info
             });
             let err = err.into();
-            let exception = ::deno_core::error::to_v8_error(
+            let exception = deno_core::error::to_v8_error(
                 &mut scope,
                 opctx.get_error_class_fn,
                 &err,
@@ -115,13 +115,13 @@ impl op_external_with_result {
         }
         let result = { Self::call() };
         match result {
-            Ok(result) => rv.set(::deno_core::_ops::RustToV8::to_v8(result, &mut scope)),
+            Ok(result) => rv.set(deno_core::_ops::RustToV8::to_v8(result, &mut scope)),
             Err(err) => {
-                let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
                     &*info
                 });
                 let err = err.into();
-                let exception = ::deno_core::error::to_v8_error(
+                let exception = deno_core::error::to_v8_error(
                     &mut scope,
                     opctx.get_error_class_fn,
                     &err,
@@ -132,31 +132,31 @@ impl op_external_with_result {
         };
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -11,18 +11,18 @@ impl deno_core::_ops::Op for op_u32_with_result {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -40,38 +40,38 @@ impl op_u32_with_result {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> u32 {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> u32 {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
         let result = { Self::call() };
         let result = match result {
@@ -87,24 +87,24 @@ impl op_u32_with_result {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         if let Some(err) = unsafe { opctx.unsafely_take_last_error_for_ops_only() } {
-            let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-            let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
                 &*info
             });
             let err = err.into();
-            let exception = ::deno_core::error::to_v8_error(
+            let exception = deno_core::error::to_v8_error(
                 &mut scope,
                 opctx.get_error_class_fn,
                 &err,
@@ -114,14 +114,14 @@ impl op_u32_with_result {
         }
         let result = { Self::call() };
         match result {
-            Ok(result) => ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
+            Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
             Err(err) => {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
                     &*info
                 });
                 let err = err.into();
-                let exception = ::deno_core::error::to_v8_error(
+                let exception = deno_core::error::to_v8_error(
                     &mut scope,
                     opctx.get_error_class_fn,
                     &err,
@@ -132,31 +132,31 @@ impl op_u32_with_result {
         };
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/result_scope.out
+++ b/ops/op2/test_cases/sync/result_scope.out
@@ -23,12 +23,12 @@ impl op_void_with_result {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
@@ -36,16 +36,14 @@ impl op_void_with_result {
             Self::call(arg0)
         };
         match result {
-            Ok(result) => ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
+            Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
             Err(err) => {
                 let opctx = unsafe {
-                    &*(::deno_core::v8::Local::<
-                        ::deno_core::v8::External,
-                    >::cast(args.data())
-                        .value() as *const ::deno_core::_ops::OpCtx)
+                    &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                        .value() as *const deno_core::_ops::OpCtx)
                 };
                 let err = err.into();
-                let exception = ::deno_core::error::to_v8_error(
+                let exception = deno_core::error::to_v8_error(
                     &mut scope,
                     opctx.get_error_class_fn,
                     &err,
@@ -56,31 +54,31 @@ impl op_void_with_result {
         };
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -11,18 +11,18 @@ impl deno_core::_ops::Op for op_void_with_result {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -40,38 +40,38 @@ impl op_void_with_result {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
         let result = { Self::call() };
         let result = match result {
@@ -87,24 +87,24 @@ impl op_void_with_result {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         if let Some(err) = unsafe { opctx.unsafely_take_last_error_for_ops_only() } {
-            let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-            let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
                 &*info
             });
             let err = err.into();
-            let exception = ::deno_core::error::to_v8_error(
+            let exception = deno_core::error::to_v8_error(
                 &mut scope,
                 opctx.get_error_class_fn,
                 &err,
@@ -114,14 +114,14 @@ impl op_void_with_result {
         }
         let result = { Self::call() };
         match result {
-            Ok(result) => ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
+            Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
             Err(err) => {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
                     &*info
                 });
                 let err = err.into();
-                let exception = ::deno_core::error::to_v8_error(
+                let exception = deno_core::error::to_v8_error(
                     &mut scope,
                     opctx.get_error_class_fn,
                     &err,
@@ -132,31 +132,31 @@ impl op_void_with_result {
         };
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/serde_v8.out
+++ b/ops/op2/test_cases/sync/serde_v8.out
@@ -23,77 +23,77 @@ impl op_serde_v8 {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg0 = args.get(0usize as i32);
-            let arg0 = match ::deno_core::_ops::serde_v8_to_rust(&mut scope, arg0) {
+            let arg0 = match deno_core::_ops::serde_v8_to_rust(&mut scope, arg0) {
                 Ok(t) => t,
                 Err(arg0_err) => {
-                    let msg = ::deno_core::v8::String::new(
+                    let msg = deno_core::v8::String::new(
                             &mut scope,
-                            &format!("{}", ::deno_core::anyhow::Error::from(arg0_err)),
+                            &format!("{}", deno_core::anyhow::Error::from(arg0_err)),
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
             };
             Self::call(arg0)
         };
-        match ::deno_core::_ops::RustToV8Fallible::to_v8_fallible(
-            ::deno_core::_ops::RustToV8Marker::<
-                ::deno_core::_ops::SerdeMarker,
+        match deno_core::_ops::RustToV8Fallible::to_v8_fallible(
+            deno_core::_ops::RustToV8Marker::<
+                deno_core::_ops::SerdeMarker,
                 _,
             >::from(result),
             &mut scope,
         ) {
             Ok(v) => rv.set(v),
             Err(rv_err) => {
-                let msg = ::deno_core::v8::String::new(
+                let msg = deno_core::v8::String::new(
                         &mut scope,
-                        &format!("{}", ::deno_core::anyhow::Error::from(rv_err)),
+                        &format!("{}", deno_core::anyhow::Error::from(rv_err)),
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             }
         };
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -11,18 +11,18 @@ impl deno_core::_ops::Op for op_smi_unsigned_return {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Int32, Type::Int32, Type::Int32, Type::Int32],
                 CType::Int32,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[
                     Type::V8Value,
                     Type::Int32,
@@ -47,34 +47,34 @@ impl op_smi_unsigned_return {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: i32,
         arg1: i32,
         arg2: i32,
         arg3: i32,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> i32 {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: i32,
         arg1: i32,
         arg2: i32,
@@ -90,106 +90,106 @@ impl op_smi_unsigned_return {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg0 = args.get(0usize as i32);
-            let Some(arg0) = ::deno_core::_ops::to_i32_option(&arg0) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected i32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg0 = arg0 as _;
             let arg1 = args.get(1usize as i32);
-            let Some(arg1) = ::deno_core::_ops::to_i32_option(&arg1) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg1) = deno_core::_ops::to_i32_option(&arg1) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected i32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg1 = arg1 as _;
             let arg2 = args.get(2usize as i32);
-            let Some(arg2) = ::deno_core::_ops::to_i32_option(&arg2) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg2) = deno_core::_ops::to_i32_option(&arg2) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected i32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg2 = arg2 as _;
             let arg3 = args.get(3usize as i32);
-            let Some(arg3) = ::deno_core::_ops::to_i32_option(&arg3) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg3) = deno_core::_ops::to_i32_option(&arg3) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected i32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg3 = arg3 as _;
             Self::call(arg0, arg1, arg2, arg3)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(
-            ::deno_core::_ops::RustToV8Marker::<
-                ::deno_core::_ops::SmiMarker,
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(
+            deno_core::_ops::RustToV8Marker::<
+                deno_core::_ops::SmiMarker,
                 _,
             >::from(result),
             &mut rv,
         );
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -212,18 +212,18 @@ impl deno_core::_ops::Op for op_smi_signed_return {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::Int32, Type::Int32, Type::Int32, Type::Int32],
                 CType::Int32,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[
                     Type::V8Value,
                     Type::Int32,
@@ -248,34 +248,34 @@ impl op_smi_signed_return {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: i32,
         arg1: i32,
         arg2: i32,
         arg3: i32,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> i32 {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: i32,
         arg1: i32,
         arg2: i32,
@@ -291,106 +291,106 @@ impl op_smi_signed_return {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg0 = args.get(0usize as i32);
-            let Some(arg0) = ::deno_core::_ops::to_i32_option(&arg0) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected i32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg0 = arg0 as _;
             let arg1 = args.get(1usize as i32);
-            let Some(arg1) = ::deno_core::_ops::to_i32_option(&arg1) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg1) = deno_core::_ops::to_i32_option(&arg1) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected i32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg1 = arg1 as _;
             let arg2 = args.get(2usize as i32);
-            let Some(arg2) = ::deno_core::_ops::to_i32_option(&arg2) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg2) = deno_core::_ops::to_i32_option(&arg2) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected i32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg2 = arg2 as _;
             let arg3 = args.get(3usize as i32);
-            let Some(arg3) = ::deno_core::_ops::to_i32_option(&arg3) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+            let Some(arg3) = deno_core::_ops::to_i32_option(&arg3) else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected i32".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg3 = arg3 as _;
             Self::call(arg0, arg1, arg2, arg3)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(
-            ::deno_core::_ops::RustToV8Marker::<
-                ::deno_core::_ops::SmiMarker,
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(
+            deno_core::_ops::RustToV8Marker::<
+                deno_core::_ops::SmiMarker,
                 _,
             >::from(result),
             &mut rv,
         );
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -425,11 +425,11 @@ impl op_smi_option {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
@@ -437,17 +437,15 @@ impl op_smi_option {
             let arg0 = if arg0.is_null_or_undefined() {
                 None
             } else {
-                let Some(arg0) = ::deno_core::_ops::to_i32_option(&arg0) else {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected i32".as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 };
@@ -456,34 +454,34 @@ impl op_smi_option {
             };
             Self::call(arg0)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/string_cow.out
+++ b/ops/op2/test_cases/sync/string_cow.out
@@ -11,18 +11,18 @@ impl deno_core::_ops::Op for op_string_cow {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::SeqOneByteString],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -40,38 +40,38 @@ impl op_string_cow {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg0: *mut ::deno_core::v8::fast_api::FastApiOneByteString,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> u32 {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg0: *mut ::deno_core::v8::fast_api::FastApiOneByteString,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
     ) -> u32 {
         let result = {
             let mut arg0_temp: [::std::mem::MaybeUninit<
                 u8,
-            >; ::deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); ::deno_core::_ops::STRING_STACK_BUFFER_SIZE];
-            let arg0 = ::deno_core::_ops::to_str_ptr(
+            >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
+            let arg0 = deno_core::_ops::to_str_ptr(
                 unsafe { &mut *arg0 },
                 &mut arg0_temp,
             );
@@ -80,54 +80,54 @@ impl op_string_cow {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let mut scope = unsafe { &mut *opctx.isolate };
         let result = {
             let arg0 = args.get(0usize as i32);
             let mut arg0_temp: [::std::mem::MaybeUninit<
                 u8,
-            >; ::deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); ::deno_core::_ops::STRING_STACK_BUFFER_SIZE];
-            let arg0 = ::deno_core::_ops::to_str(&mut scope, &arg0, &mut arg0_temp);
+            >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
+            let arg0 = deno_core::_ops::to_str(&mut scope, &arg0, &mut arg0_temp);
             Self::call(arg0)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/string_onebyte.out
+++ b/ops/op2/test_cases/sync/string_onebyte.out
@@ -11,18 +11,18 @@ impl deno_core::_ops::Op for op_string_onebyte {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::SeqOneByteString],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -40,101 +40,99 @@ impl op_string_onebyte {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg0: *mut ::deno_core::v8::fast_api::FastApiOneByteString,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> u32 {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg0: *mut ::deno_core::v8::fast_api::FastApiOneByteString,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
     ) -> u32 {
         let result = {
-            let arg0 = ::deno_core::_ops::to_cow_byte_ptr(unsafe { &mut *arg0 });
+            let arg0 = deno_core::_ops::to_cow_byte_ptr(unsafe { &mut *arg0 });
             Self::call(arg0)
         };
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let mut scope = unsafe { &mut *opctx.isolate };
         let result = {
             let arg0 = args.get(0usize as i32);
-            let arg0 = match ::deno_core::_ops::to_cow_one_byte(&mut scope, &arg0) {
+            let arg0 = match deno_core::_ops::to_cow_one_byte(&mut scope, &arg0) {
                 Ok(arg0) => arg0,
                 Err(arg0) => {
-                    let mut scope = unsafe {
-                        ::deno_core::v8::CallbackScope::new(&*info)
-                    };
-                    let msg = ::deno_core::v8::String::new_from_one_byte(
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             arg0.as_bytes(),
-                            ::deno_core::v8::NewStringType::Normal,
+                            deno_core::v8::NewStringType::Normal,
                         )
                         .unwrap();
-                    let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                     scope.throw_exception(exc);
                     return 1;
                 }
             };
             Self::call(arg0)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/string_option_return.out
+++ b/ops/op2/test_cases/sync/string_option_return.out
@@ -23,12 +23,12 @@ impl op_string_return {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
@@ -36,50 +36,50 @@ impl op_string_return {
             let arg0 = if arg0.is_null_or_undefined() {
                 None
             } else {
-                Some(::deno_core::_ops::to_string(&mut scope, &arg0))
+                Some(deno_core::_ops::to_string(&mut scope, &arg0))
             };
             Self::call(arg0)
         };
-        match ::deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
+        match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
             Ok(v) => rv.set(v),
             Err(rv_err) => {
-                let msg = ::deno_core::v8::String::new(
+                let msg = deno_core::v8::String::new(
                         &mut scope,
-                        &format!("{}", ::deno_core::anyhow::Error::from(rv_err)),
+                        &format!("{}", deno_core::anyhow::Error::from(rv_err)),
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             }
         };
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/string_owned.out
+++ b/ops/op2/test_cases/sync/string_owned.out
@@ -11,18 +11,18 @@ impl deno_core::_ops::Op for op_string_owned {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::SeqOneByteString],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -40,85 +40,85 @@ impl op_string_owned {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg0: *mut ::deno_core::v8::fast_api::FastApiOneByteString,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> u32 {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg0: *mut ::deno_core::v8::fast_api::FastApiOneByteString,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
     ) -> u32 {
         let result = {
-            let arg0 = ::deno_core::_ops::to_string_ptr(unsafe { &mut *arg0 });
+            let arg0 = deno_core::_ops::to_string_ptr(unsafe { &mut *arg0 });
             Self::call(arg0)
         };
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let mut scope = unsafe { &mut *opctx.isolate };
         let result = {
             let arg0 = args.get(0usize as i32);
-            let arg0 = ::deno_core::_ops::to_string(&mut scope, &arg0);
+            let arg0 = deno_core::_ops::to_string(&mut scope, &arg0);
             Self::call(arg0)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/string_ref.out
+++ b/ops/op2/test_cases/sync/string_ref.out
@@ -11,18 +11,18 @@ impl deno_core::_ops::Op for op_string_owned {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::SeqOneByteString],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
                 CType::Uint32,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -40,38 +40,38 @@ impl op_string_owned {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg0: *mut ::deno_core::v8::fast_api::FastApiOneByteString,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> u32 {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg0: *mut ::deno_core::v8::fast_api::FastApiOneByteString,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
     ) -> u32 {
         let result = {
             let mut arg0_temp: [::std::mem::MaybeUninit<
                 u8,
-            >; ::deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); ::deno_core::_ops::STRING_STACK_BUFFER_SIZE];
-            let arg0 = &::deno_core::_ops::to_str_ptr(
+            >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
+            let arg0 = &deno_core::_ops::to_str_ptr(
                 unsafe { &mut *arg0 },
                 &mut arg0_temp,
             );
@@ -80,54 +80,54 @@ impl op_string_owned {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
         let mut scope = unsafe { &mut *opctx.isolate };
         let result = {
             let arg0 = args.get(0usize as i32);
             let mut arg0_temp: [::std::mem::MaybeUninit<
                 u8,
-            >; ::deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); ::deno_core::_ops::STRING_STACK_BUFFER_SIZE];
-            let arg0 = &::deno_core::_ops::to_str(&mut scope, &arg0, &mut arg0_temp);
+            >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
+            let arg0 = &deno_core::_ops::to_str(&mut scope, &arg0, &mut arg0_temp);
             Self::call(arg0)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/string_return.out
+++ b/ops/op2/test_cases/sync/string_return.out
@@ -23,52 +23,52 @@ impl op_string_return {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
         let result = { Self::call() };
-        match ::deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
+        match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
             Ok(v) => rv.set(v),
             Err(rv_err) => {
-                let msg = ::deno_core::v8::String::new(
+                let msg = deno_core::v8::String::new(
                         &mut scope,
-                        &format!("{}", ::deno_core::anyhow::Error::from(rv_err)),
+                        &format!("{}", deno_core::anyhow::Error::from(rv_err)),
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             }
         };
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -103,52 +103,52 @@ impl op_string_return_ref {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
         let result = { Self::call() };
-        match ::deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
+        match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
             Ok(v) => rv.set(v),
             Err(rv_err) => {
-                let msg = ::deno_core::v8::String::new(
+                let msg = deno_core::v8::String::new(
                         &mut scope,
-                        &format!("{}", ::deno_core::anyhow::Error::from(rv_err)),
+                        &format!("{}", deno_core::anyhow::Error::from(rv_err)),
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             }
         };
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }
@@ -183,52 +183,52 @@ impl op_string_return_cow {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
         let result = { Self::call() };
-        match ::deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
+        match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
             Ok(v) => rv.set(v),
             Err(rv_err) => {
-                let msg = ::deno_core::v8::String::new(
+                let msg = deno_core::v8::String::new(
                         &mut scope,
-                        &format!("{}", ::deno_core::anyhow::Error::from(rv_err)),
+                        &format!("{}", deno_core::anyhow::Error::from(rv_err)),
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             }
         };
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/v8_global.out
+++ b/ops/op2/test_cases/sync/v8_global.out
@@ -23,61 +23,61 @@ impl op_global {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg0 = args.get(0usize as i32);
-            let Ok(mut arg0) = ::deno_core::_ops::v8_try_convert::<
-                ::deno_core::v8::String,
+            let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
+                deno_core::v8::String,
             >(arg0) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected String".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
-            let arg0 = ::deno_core::v8::Global::new(&mut scope, arg0);
+            let arg0 = deno_core::v8::Global::new(&mut scope, arg0);
             Self::call(arg0)
         };
-        rv.set(::deno_core::_ops::RustToV8::to_v8(result, &mut scope));
+        rv.set(deno_core::_ops::RustToV8::to_v8(result, &mut scope));
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/v8_handlescope.out
+++ b/ops/op2/test_cases/sync/v8_handlescope.out
@@ -23,26 +23,26 @@ impl op_handlescope {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg1 = args.get(0usize as i32);
-            let Ok(mut arg1) = ::deno_core::_ops::v8_try_convert::<
-                ::deno_core::v8::String,
+            let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
+                deno_core::v8::String,
             >(arg1) else {
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected String".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
@@ -50,34 +50,34 @@ impl op_handlescope {
             let arg0 = &mut scope;
             Self::call(arg0, arg1)
         };
-        rv.set(::deno_core::_ops::RustToV8NoScope::to_v8(result));
+        rv.set(deno_core::_ops::RustToV8NoScope::to_v8(result));
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/v8_lifetime.out
+++ b/ops/op2/test_cases/sync/v8_lifetime.out
@@ -23,60 +23,60 @@ impl op_v8_lifetime {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg0 = args.get(0usize as i32);
-            let Ok(mut arg0) = ::deno_core::_ops::v8_try_convert::<
-                ::deno_core::v8::String,
+            let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
+                deno_core::v8::String,
             >(arg0) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected String".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg0 = arg0;
             Self::call(arg0)
         };
-        rv.set(::deno_core::_ops::RustToV8NoScope::to_v8(result));
+        rv.set(deno_core::_ops::RustToV8NoScope::to_v8(result));
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -11,18 +11,18 @@ impl deno_core::_ops::Op for op_v8_lifetime {
         Self::v8_fn_ptr as _,
         Self::v8_fn_ptr_metrics as _,
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::V8Value, Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
         }),
         Some({
-            use ::deno_core::v8::fast_api::Type;
-            use ::deno_core::v8::fast_api::CType;
-            ::deno_core::v8::fast_api::FastFunction::new_with_bigint(
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
                 &[Type::V8Value, Type::V8Value, Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
@@ -40,40 +40,40 @@ impl op_v8_lifetime {
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast_metrics(
-        this: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg0: ::deno_core::v8::Local<::deno_core::v8::Value>,
-        arg1: ::deno_core::v8::Local<::deno_core::v8::Value>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: deno_core::v8::Local<deno_core::v8::Value>,
+        arg1: deno_core::v8::Local<deno_core::v8::Value>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<
-                ::deno_core::v8::External,
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
             >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const ::deno_core::_ops::OpCtx)
+                .value() as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::v8_fn_ptr_fast(this, arg0, arg1, fast_api_callback_options);
-        ::deno_core::_ops::dispatch_metrics_fast(
+        deno_core::_ops::dispatch_metrics_fast(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Completed,
+            deno_core::_ops::OpMetricsEvent::Completed,
         );
         res
     }
     #[allow(clippy::too_many_arguments)]
     fn v8_fn_ptr_fast(
-        _: ::deno_core::v8::Local<::deno_core::v8::Object>,
-        arg0: ::deno_core::v8::Local<::deno_core::v8::Value>,
-        arg1: ::deno_core::v8::Local<::deno_core::v8::Value>,
-        fast_api_callback_options: *mut ::deno_core::v8::fast_api::FastApiCallbackOptions,
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: deno_core::v8::Local<deno_core::v8::Value>,
+        arg1: deno_core::v8::Local<deno_core::v8::Value>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let result = {
-            let Ok(mut arg0) = ::deno_core::_ops::v8_try_convert_option::<
-                ::deno_core::v8::String,
+            let Ok(mut arg0) = deno_core::_ops::v8_try_convert_option::<
+                deno_core::v8::String,
             >(arg0) else {
                 fast_api_callback_options.fallback = true;
                 return unsafe { std::mem::zeroed() };
@@ -82,8 +82,8 @@ impl op_v8_lifetime {
                 None => None,
                 Some(v) => Some(::std::ops::Deref::deref(v)),
             };
-            let Ok(mut arg1) = ::deno_core::_ops::v8_try_convert_option::<
-                ::deno_core::v8::String,
+            let Ok(mut arg1) = deno_core::_ops::v8_try_convert_option::<
+                deno_core::v8::String,
             >(arg1) else {
                 fast_api_callback_options.fallback = true;
                 return unsafe { std::mem::zeroed() };
@@ -97,26 +97,26 @@ impl op_v8_lifetime {
         result as _
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg0 = args.get(0usize as i32);
-            let Ok(mut arg0) = ::deno_core::_ops::v8_try_convert_option::<
-                ::deno_core::v8::String,
+            let Ok(mut arg0) = deno_core::_ops::v8_try_convert_option::<
+                deno_core::v8::String,
             >(arg0) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected String".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
@@ -125,17 +125,17 @@ impl op_v8_lifetime {
                 Some(v) => Some(::std::ops::Deref::deref(v)),
             };
             let arg1 = args.get(1usize as i32);
-            let Ok(mut arg1) = ::deno_core::_ops::v8_try_convert_option::<
-                ::deno_core::v8::String,
+            let Ok(mut arg1) = deno_core::_ops::v8_try_convert_option::<
+                deno_core::v8::String,
             >(arg1) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected String".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
@@ -145,34 +145,34 @@ impl op_v8_lifetime {
             };
             Self::call(arg0, arg1)
         };
-        ::deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }

--- a/ops/op2/test_cases/sync/v8_string.out
+++ b/ops/op2/test_cases/sync/v8_string.out
@@ -23,76 +23,76 @@ impl op_v8_string {
         <Self as deno_core::_ops::Op>::DECL
     }
     #[inline(always)]
-    fn slow_function_impl(info: *const ::deno_core::v8::FunctionCallbackInfo) -> usize {
-        let mut rv = ::deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
             &*info
         });
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let result = {
             let arg0 = args.get(0usize as i32);
-            let Ok(mut arg0) = ::deno_core::_ops::v8_try_convert::<
-                ::deno_core::v8::String,
+            let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
+                deno_core::v8::String,
             >(arg0) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected String".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg0 = &arg0;
             let arg1 = args.get(1usize as i32);
-            let Ok(mut arg1) = ::deno_core::_ops::v8_try_convert::<
-                ::deno_core::v8::String,
+            let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
+                deno_core::v8::String,
             >(arg1) else {
-                let mut scope = unsafe { ::deno_core::v8::CallbackScope::new(&*info) };
-                let msg = ::deno_core::v8::String::new_from_one_byte(
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,
                         "expected String".as_bytes(),
-                        ::deno_core::v8::NewStringType::Normal,
+                        deno_core::v8::NewStringType::Normal,
                     )
                     .unwrap();
-                let exc = ::deno_core::v8::Exception::type_error(&mut scope, msg);
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
                 scope.throw_exception(exc);
                 return 1;
             };
             let arg1 = arg1;
             Self::call(arg0, arg1)
         };
-        rv.set(::deno_core::_ops::RustToV8NoScope::to_v8(result));
+        rv.set(deno_core::_ops::RustToV8NoScope::to_v8(result));
         return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const ::deno_core::v8::FunctionCallbackInfo) {
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
         Self::slow_function_impl(info);
     }
-    extern "C" fn v8_fn_ptr_metrics(info: *const ::deno_core::v8::FunctionCallbackInfo) {
-        let args = ::deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
             &*info
         });
         let opctx = unsafe {
-            &*(::deno_core::v8::Local::<::deno_core::v8::External>::cast(args.data())
-                .value() as *const ::deno_core::_ops::OpCtx)
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
         };
-        ::deno_core::_ops::dispatch_metrics_slow(
+        deno_core::_ops::dispatch_metrics_slow(
             &opctx,
-            ::deno_core::_ops::OpMetricsEvent::Dispatched,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
         let res = Self::slow_function_impl(info);
         if res == 0 {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Completed,
             );
         } else {
-            ::deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                ::deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Error,
             );
         }
     }


### PR DESCRIPTION
Very large looking change that effectively just replaces `::deno_core` with `deno_core` across `_dispatch` and `*.out` files

This is required for software using deno_core to compile if deno_core is being provided through a wrapper crate, such as rustyscript or js_sandbox

Below is an example of a sample that would not compile without this change:

```rust
use core_wrap::deno_core::{self, extension, op2};

#[op2]
#[string]
fn test_op2(#[string] _name: String) -> String {
    "test".to_string()
}
```