### PR TITLE
feat(core): invert register_ops

### DIFF
--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -128,7 +128,7 @@ pub(crate) fn initialize_context<'s>(
   if matches!(
     init_mode,
     InitMode::FromSnapshot {
-      register_ops: false
+      skip_op_registration: true
     }
   ) {
     return context;

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -185,7 +185,7 @@ pub(crate) enum InitMode {
   New,
   /// We are using a snapshot, thus certain initialization steps are skipped.
   FromSnapshot {
-    // Do we need to register new ops.
+    // Can we skip the work of op registration?
     skip_op_registration: bool,
   },
 }

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -186,7 +186,7 @@ pub(crate) enum InitMode {
   /// We are using a snapshot, thus certain initialization steps are skipped.
   FromSnapshot {
     // Do we need to register new ops.
-    register_ops: bool,
+    skip_op_registration: bool,
   },
 }
 
@@ -195,7 +195,7 @@ impl InitMode {
     match options.startup_snapshot {
       None => Self::New,
       Some(_) => Self::FromSnapshot {
-        register_ops: options.register_ops,
+        skip_op_registration: options.skip_op_registration,
       },
     }
   }
@@ -412,7 +412,9 @@ pub struct RuntimeOptions {
 
   /// V8 snapshot that should be loaded on startup.
   pub startup_snapshot: Option<Snapshot>,
-  pub register_ops: bool,
+
+  /// Should op registration be skipped?
+  pub skip_op_registration: bool,
 
   /// Isolate creation parameters.
   pub create_params: Option<v8::CreateParams>,

--- a/core/runtime/snapshot_util.rs
+++ b/core/runtime/snapshot_util.rs
@@ -18,7 +18,7 @@ pub struct CreateSnapshotOptions {
   pub cargo_manifest_dir: &'static str,
   pub snapshot_path: PathBuf,
   pub startup_snapshot: Option<Snapshot>,
-  pub register_ops: bool,
+  pub skip_op_registration: bool,
   pub extensions: Vec<Extension>,
   pub compression_cb: Option<Box<CompressionCb>>,
   pub with_runtime_cb: Option<Box<WithRuntimeCb>>,
@@ -39,7 +39,7 @@ pub fn create_snapshot(
   let mut js_runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
     startup_snapshot: create_snapshot_options.startup_snapshot,
     extensions: create_snapshot_options.extensions,
-    register_ops: create_snapshot_options.register_ops,
+    skip_op_registration: create_snapshot_options.skip_op_registration,
     ..Default::default()
   });
   println!(

--- a/core/runtime/tests/jsrealm.rs
+++ b/core/runtime/tests/jsrealm.rs
@@ -220,7 +220,7 @@ fn js_realm_init_snapshot() {
   let mut runtime = JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(Snapshot::Boxed(snapshot)),
     extensions: vec![test_ext::init_ops()],
-    register_ops: true,
+    skip_op_registration: false,
     ..Default::default()
   });
   let realm = runtime.create_realm(Default::default()).unwrap();


### PR DESCRIPTION
`register_ops: false` is a dangerous default and probably a footgun, so let's invert this and call it `skip_op_registration`.