### PR TITLE
fix(core): use correct external package and fix external macro type

### DIFF
--- a/core/external.rs
+++ b/core/external.rs
@@ -5,16 +5,18 @@ use std::mem::ManuallyDrop;
 /// Define an external type.
 #[macro_export]
 macro_rules! external {
-  ($type:ident, $name:literal) => {
+  ($type:ty, $name:literal) => {
     impl $crate::external::Externalizable for $type {
       fn external_marker() -> usize {
         // Use the address of a static mut as a way to get around lack of usize-sized TypeId. Because it is mutable, the
         // compiler cannot collapse multiple definitions into one.
-        static mut DEFINITION: $crate::external::ExternalDefinition =
-          $crate::external::ExternalDefinition::new($name);
-        // Wash the pointer through black_box so the compiler cannot see what we're going to do with it and needs
-        // to assume it will be used for valid purposes.
-        let ptr = std::hint::black_box(unsafe { &mut DEFINITION } as *mut _);
+        static mut DEFINITION: $crate::ExternalDefinition =
+          $crate::ExternalDefinition::new($name);
+        // SAFETY: Wash the pointer through black_box so the compiler cannot see what we're going to do with it and needs
+        // to assume it will be used for valid purposes. We are taking the address of a static item, but we avoid taking an
+        // intermediate mutable reference to make this safe.
+        let ptr =
+          std::hint::black_box(unsafe { std::ptr::addr_of_mut!(DEFINITION) });
         ptr as usize
       }
 


### PR DESCRIPTION
- Fix the type of macro argument (was `ident` but should be `ty`)
- Tweak how we get the address of the static to be slightly less unsafe (not really an issue, miri didn't complain just saw it)
- Use the correct type for external usage (no external package -- just deno_core crate root)