### PR TITLE
feat(core): speedier async stubs + template opAsync

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -292,9 +292,7 @@
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          if (opCallTracingEnabled) {
-            promise = handleOpCallTracing(opName, id, promise);
-          }
+          promise = handleOpCallTracing(opName, id, promise);
           promise[promiseIdSymbol] = id;
           return promise;
         };
@@ -316,9 +314,7 @@
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          if (opCallTracingEnabled) {
-            promise = handleOpCallTracing(opName, id, promise);
-          }
+          promise = handleOpCallTracing(opName, id, promise);
           promise[promiseIdSymbol] = id;
           return promise;
         };
@@ -340,9 +336,7 @@
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          if (opCallTracingEnabled) {
-            promise = handleOpCallTracing(opName, id, promise);
-          }
+          promise = handleOpCallTracing(opName, id, promise);
           promise[promiseIdSymbol] = id;
           return promise;
         };
@@ -364,9 +358,7 @@
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          if (opCallTracingEnabled) {
-            promise = handleOpCallTracing(opName, id, promise);
-          }
+          promise = handleOpCallTracing(opName, id, promise);
           promise[promiseIdSymbol] = id;
           return promise;
         };
@@ -388,9 +380,7 @@
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          if (opCallTracingEnabled) {
-            promise = handleOpCallTracing(opName, id, promise);
-          }
+          promise = handleOpCallTracing(opName, id, promise);
           promise[promiseIdSymbol] = id;
           return promise;
         };
@@ -412,9 +402,7 @@
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          if (opCallTracingEnabled) {
-            promise = handleOpCallTracing(opName, id, promise);
-          }
+          promise = handleOpCallTracing(opName, id, promise);
           promise[promiseIdSymbol] = id;
           return promise;
         };
@@ -436,9 +424,7 @@
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          if (opCallTracingEnabled) {
-            promise = handleOpCallTracing(opName, id, promise);
-          }
+          promise = handleOpCallTracing(opName, id, promise);
           promise[promiseIdSymbol] = id;
           return promise;
         };
@@ -460,9 +446,7 @@
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          if (opCallTracingEnabled) {
-            promise = handleOpCallTracing(opName, id, promise);
-          }
+          promise = handleOpCallTracing(opName, id, promise);
           promise[promiseIdSymbol] = id;
           return promise;
         };
@@ -484,9 +468,7 @@
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          if (opCallTracingEnabled) {
-            promise = handleOpCallTracing(opName, id, promise);
-          }
+          promise = handleOpCallTracing(opName, id, promise);
           promise[promiseIdSymbol] = id;
           return promise;
         };
@@ -508,9 +490,7 @@
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          if (opCallTracingEnabled) {
-            promise = handleOpCallTracing(opName, id, promise);
-          }
+          promise = handleOpCallTracing(opName, id, promise);
           promise[promiseIdSymbol] = id;
           return promise;
         };
@@ -553,9 +533,7 @@
       setPromise(id),
       unwrapOpError(eventLoopTick),
     );
-    if (opCallTracingEnabled) {
-      promise = handleOpCallTracing(opName, id, promise);
-    }
+    promise = handleOpCallTracing(opName, id, promise);
     promise[promiseIdSymbol] = id;
     return promise;
   }

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -91,17 +91,6 @@
     return opCallTracingEnabled;
   }
 
-  function movePromise(promiseId) {
-    const idx = promiseId % RING_SIZE;
-    // Move old promise from ring to map
-    const oldPromise = promiseRing[idx];
-    if (oldPromise !== NO_PROMISE) {
-      const oldPromiseId = promiseId - RING_SIZE;
-      MapPrototypeSet(promiseMap, oldPromiseId, oldPromise);
-    }
-    return promiseRing[idx] = NO_PROMISE;
-  }
-
   function setPromise(promiseId) {
     const idx = promiseId % RING_SIZE;
     // Move old promise from ring to map

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -262,28 +262,6 @@
     };
   }
 
-  function unwrapOpResultNewPromise(id, res, hideFunction) {
-    // .$err_class_name is a special key that should only exist on errors
-    if (res?.$err_class_name) {
-      const className = res.$err_class_name;
-      const errorBuilder = errorMap[className];
-      const err = errorBuilder ? errorBuilder(res.message) : new Error(
-        `Unregistered error class: "${className}"\n  ${res.message}\n  Classes of errors returned from ops should be registered via Deno.core.registerErrorClass().`,
-      );
-      // Set .code if error was a known OS error, see error_codes.rs
-      if (res.code) {
-        err.code = res.code;
-      }
-      // Strip unwrapOpResult() and errorBuilder() calls from stack trace
-      ErrorCaptureStackTrace(err, hideFunction);
-      return PromiseReject(err);
-    }
-    const promise = PromiseResolve(res);
-    promise[promiseIdSymbol] = id;
-    return promise;
-  }
-
-
   // This function is called once per async stub
   function asyncStub(opName, args) {
     setUpAsyncStub(opName);
@@ -299,230 +277,240 @@
       /* DO NOT MODIFY: use rebuild_async_stubs.js to regenerate */
       case 0:
         fn = function async_op_0() {
-          const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
+          const id = (nextPromiseId + 1) & 0xffffffff;
           try {
             const maybeResult = originalOp(id);
             if (maybeResult !== undefined) {
-              movePromise(id);
-              return unwrapOpResultNewPromise(id, maybeResult, async_op_0);
+              return PromiseResolve(maybeResult);
             }
           } catch (err) {
-            movePromise(id);
             ErrorCaptureStackTrace(err, async_op_0);
             return PromiseReject(err);
           }
+          nextPromiseId = id;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          promise = handleOpCallTracing(opName, id, promise);
+          if (opCallTracingEnabled) {
+            promise = handleOpCallTracing(opName, id, promise);
+          }
           promise[promiseIdSymbol] = id;
           return promise;
         };
         break;
       case 1:
         fn = function async_op_1(a) {
-          const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
+          const id = (nextPromiseId + 1) & 0xffffffff;
           try {
             const maybeResult = originalOp(id, a);
             if (maybeResult !== undefined) {
-              movePromise(id);
-              return unwrapOpResultNewPromise(id, maybeResult, async_op_1);
+              return PromiseResolve(maybeResult);
             }
           } catch (err) {
-            movePromise(id);
             ErrorCaptureStackTrace(err, async_op_1);
             return PromiseReject(err);
           }
+          nextPromiseId = id;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          promise = handleOpCallTracing(opName, id, promise);
+          if (opCallTracingEnabled) {
+            promise = handleOpCallTracing(opName, id, promise);
+          }
           promise[promiseIdSymbol] = id;
           return promise;
         };
         break;
       case 2:
         fn = function async_op_2(a, b) {
-          const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
+          const id = (nextPromiseId + 1) & 0xffffffff;
           try {
             const maybeResult = originalOp(id, a, b);
             if (maybeResult !== undefined) {
-              movePromise(id);
-              return unwrapOpResultNewPromise(id, maybeResult, async_op_2);
+              return PromiseResolve(maybeResult);
             }
           } catch (err) {
-            movePromise(id);
             ErrorCaptureStackTrace(err, async_op_2);
             return PromiseReject(err);
           }
+          nextPromiseId = id;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          promise = handleOpCallTracing(opName, id, promise);
+          if (opCallTracingEnabled) {
+            promise = handleOpCallTracing(opName, id, promise);
+          }
           promise[promiseIdSymbol] = id;
           return promise;
         };
         break;
       case 3:
         fn = function async_op_3(a, b, c) {
-          const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
+          const id = (nextPromiseId + 1) & 0xffffffff;
           try {
             const maybeResult = originalOp(id, a, b, c);
             if (maybeResult !== undefined) {
-              movePromise(id);
-              return unwrapOpResultNewPromise(id, maybeResult, async_op_3);
+              return PromiseResolve(maybeResult);
             }
           } catch (err) {
-            movePromise(id);
             ErrorCaptureStackTrace(err, async_op_3);
             return PromiseReject(err);
           }
+          nextPromiseId = id;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          promise = handleOpCallTracing(opName, id, promise);
+          if (opCallTracingEnabled) {
+            promise = handleOpCallTracing(opName, id, promise);
+          }
           promise[promiseIdSymbol] = id;
           return promise;
         };
         break;
       case 4:
         fn = function async_op_4(a, b, c, d) {
-          const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
+          const id = (nextPromiseId + 1) & 0xffffffff;
           try {
             const maybeResult = originalOp(id, a, b, c, d);
             if (maybeResult !== undefined) {
-              movePromise(id);
-              return unwrapOpResultNewPromise(id, maybeResult, async_op_4);
+              return PromiseResolve(maybeResult);
             }
           } catch (err) {
-            movePromise(id);
             ErrorCaptureStackTrace(err, async_op_4);
             return PromiseReject(err);
           }
+          nextPromiseId = id;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          promise = handleOpCallTracing(opName, id, promise);
+          if (opCallTracingEnabled) {
+            promise = handleOpCallTracing(opName, id, promise);
+          }
           promise[promiseIdSymbol] = id;
           return promise;
         };
         break;
       case 5:
         fn = function async_op_5(a, b, c, d, e) {
-          const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
+          const id = (nextPromiseId + 1) & 0xffffffff;
           try {
             const maybeResult = originalOp(id, a, b, c, d, e);
             if (maybeResult !== undefined) {
-              movePromise(id);
-              return unwrapOpResultNewPromise(id, maybeResult, async_op_5);
+              return PromiseResolve(maybeResult);
             }
           } catch (err) {
-            movePromise(id);
             ErrorCaptureStackTrace(err, async_op_5);
             return PromiseReject(err);
           }
+          nextPromiseId = id;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          promise = handleOpCallTracing(opName, id, promise);
+          if (opCallTracingEnabled) {
+            promise = handleOpCallTracing(opName, id, promise);
+          }
           promise[promiseIdSymbol] = id;
           return promise;
         };
         break;
       case 6:
         fn = function async_op_6(a, b, c, d, e, f) {
-          const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
+          const id = (nextPromiseId + 1) & 0xffffffff;
           try {
             const maybeResult = originalOp(id, a, b, c, d, e, f);
             if (maybeResult !== undefined) {
-              movePromise(id);
-              return unwrapOpResultNewPromise(id, maybeResult, async_op_6);
+              return PromiseResolve(maybeResult);
             }
           } catch (err) {
-            movePromise(id);
             ErrorCaptureStackTrace(err, async_op_6);
             return PromiseReject(err);
           }
+          nextPromiseId = id;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          promise = handleOpCallTracing(opName, id, promise);
+          if (opCallTracingEnabled) {
+            promise = handleOpCallTracing(opName, id, promise);
+          }
           promise[promiseIdSymbol] = id;
           return promise;
         };
         break;
       case 7:
         fn = function async_op_7(a, b, c, d, e, f, g) {
-          const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
+          const id = (nextPromiseId + 1) & 0xffffffff;
           try {
             const maybeResult = originalOp(id, a, b, c, d, e, f, g);
             if (maybeResult !== undefined) {
-              movePromise(id);
-              return unwrapOpResultNewPromise(id, maybeResult, async_op_7);
+              return PromiseResolve(maybeResult);
             }
           } catch (err) {
-            movePromise(id);
             ErrorCaptureStackTrace(err, async_op_7);
             return PromiseReject(err);
           }
+          nextPromiseId = id;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          promise = handleOpCallTracing(opName, id, promise);
+          if (opCallTracingEnabled) {
+            promise = handleOpCallTracing(opName, id, promise);
+          }
           promise[promiseIdSymbol] = id;
           return promise;
         };
         break;
       case 8:
         fn = function async_op_8(a, b, c, d, e, f, g, h) {
-          const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
+          const id = (nextPromiseId + 1) & 0xffffffff;
           try {
             const maybeResult = originalOp(id, a, b, c, d, e, f, g, h);
             if (maybeResult !== undefined) {
-              movePromise(id);
-              return unwrapOpResultNewPromise(id, maybeResult, async_op_8);
+              return PromiseResolve(maybeResult);
             }
           } catch (err) {
-            movePromise(id);
             ErrorCaptureStackTrace(err, async_op_8);
             return PromiseReject(err);
           }
+          nextPromiseId = id;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          promise = handleOpCallTracing(opName, id, promise);
+          if (opCallTracingEnabled) {
+            promise = handleOpCallTracing(opName, id, promise);
+          }
           promise[promiseIdSymbol] = id;
           return promise;
         };
         break;
       case 9:
         fn = function async_op_9(a, b, c, d, e, f, g, h, i) {
-          const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
+          const id = (nextPromiseId + 1) & 0xffffffff;
           try {
             const maybeResult = originalOp(id, a, b, c, d, e, f, g, h, i);
             if (maybeResult !== undefined) {
-              movePromise(id);
-              return unwrapOpResultNewPromise(id, maybeResult, async_op_9);
+              return PromiseResolve(maybeResult);
             }
           } catch (err) {
-            movePromise(id);
             ErrorCaptureStackTrace(err, async_op_9);
             return PromiseReject(err);
           }
+          nextPromiseId = id;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
           );
-          promise = handleOpCallTracing(opName, id, promise);
+          if (opCallTracingEnabled) {
+            promise = handleOpCallTracing(opName, id, promise);
+          }
           promise[promiseIdSymbol] = id;
           return promise;
         };
@@ -547,26 +535,27 @@
   /* BEGIN TEMPLATE opAsync */
   /* DO NOT MODIFY: use rebuild_async_stubs.js to regenerate */
   function opAsync(opName, ...args) {
-    const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
+    const id = (nextPromiseId + 1) & 0xffffffff;
     try {
       const maybeResult = asyncOps[opName](id, ...new SafeArrayIterator(args));
       if (maybeResult !== undefined) {
-        movePromise(id);
-        return unwrapOpResultNewPromise(id, maybeResult, opAsync);
+        return PromiseResolve(maybeResult);
       }
     } catch (err) {
-      movePromise(id);
       if (!ReflectHas(asyncOps, opName)) {
         return PromiseReject(new TypeError(`${opName} is not a registered op`));
       }
       ErrorCaptureStackTrace(err, opAsync);
       return PromiseReject(err);
     }
+    nextPromiseId = id;
     let promise = PromisePrototypeThen(
       setPromise(id),
       unwrapOpError(eventLoopTick),
     );
-    promise = handleOpCallTracing(opName, id, promise);
+    if (opCallTracingEnabled) {
+      promise = handleOpCallTracing(opName, id, promise);
+    }
     promise[promiseIdSymbol] = id;
     return promise;
   }

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -71,7 +71,7 @@
   registerErrorClass("TypeError", TypeError);
   registerErrorClass("URIError", URIError);
 
-  let nextPromiseId = 0xffffffff;
+  let nextPromiseId = 0;
   const promiseMap = new SafeMap();
   const RING_SIZE = 4 * 1024;
   const NO_PROMISE = null; // Alias to null is faster than plain nulls
@@ -266,7 +266,7 @@
       /* DO NOT MODIFY: use rebuild_async_stubs.js to regenerate */
       case 0:
         fn = function async_op_0() {
-          const id = (nextPromiseId + 1) & 0xffffffff;
+          const id = nextPromiseId;
           try {
             const maybeResult = originalOp(id);
             if (maybeResult !== undefined) {
@@ -276,7 +276,7 @@
             ErrorCaptureStackTrace(err, async_op_0);
             return PromiseReject(err);
           }
-          nextPromiseId = id;
+          nextPromiseId = (id + 1) & 0xffffffff;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
@@ -288,7 +288,7 @@
         break;
       case 1:
         fn = function async_op_1(a) {
-          const id = (nextPromiseId + 1) & 0xffffffff;
+          const id = nextPromiseId;
           try {
             const maybeResult = originalOp(id, a);
             if (maybeResult !== undefined) {
@@ -298,7 +298,7 @@
             ErrorCaptureStackTrace(err, async_op_1);
             return PromiseReject(err);
           }
-          nextPromiseId = id;
+          nextPromiseId = (id + 1) & 0xffffffff;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
@@ -310,7 +310,7 @@
         break;
       case 2:
         fn = function async_op_2(a, b) {
-          const id = (nextPromiseId + 1) & 0xffffffff;
+          const id = nextPromiseId;
           try {
             const maybeResult = originalOp(id, a, b);
             if (maybeResult !== undefined) {
@@ -320,7 +320,7 @@
             ErrorCaptureStackTrace(err, async_op_2);
             return PromiseReject(err);
           }
-          nextPromiseId = id;
+          nextPromiseId = (id + 1) & 0xffffffff;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
@@ -332,7 +332,7 @@
         break;
       case 3:
         fn = function async_op_3(a, b, c) {
-          const id = (nextPromiseId + 1) & 0xffffffff;
+          const id = nextPromiseId;
           try {
             const maybeResult = originalOp(id, a, b, c);
             if (maybeResult !== undefined) {
@@ -342,7 +342,7 @@
             ErrorCaptureStackTrace(err, async_op_3);
             return PromiseReject(err);
           }
-          nextPromiseId = id;
+          nextPromiseId = (id + 1) & 0xffffffff;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
@@ -354,7 +354,7 @@
         break;
       case 4:
         fn = function async_op_4(a, b, c, d) {
-          const id = (nextPromiseId + 1) & 0xffffffff;
+          const id = nextPromiseId;
           try {
             const maybeResult = originalOp(id, a, b, c, d);
             if (maybeResult !== undefined) {
@@ -364,7 +364,7 @@
             ErrorCaptureStackTrace(err, async_op_4);
             return PromiseReject(err);
           }
-          nextPromiseId = id;
+          nextPromiseId = (id + 1) & 0xffffffff;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
@@ -376,7 +376,7 @@
         break;
       case 5:
         fn = function async_op_5(a, b, c, d, e) {
-          const id = (nextPromiseId + 1) & 0xffffffff;
+          const id = nextPromiseId;
           try {
             const maybeResult = originalOp(id, a, b, c, d, e);
             if (maybeResult !== undefined) {
@@ -386,7 +386,7 @@
             ErrorCaptureStackTrace(err, async_op_5);
             return PromiseReject(err);
           }
-          nextPromiseId = id;
+          nextPromiseId = (id + 1) & 0xffffffff;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
@@ -398,7 +398,7 @@
         break;
       case 6:
         fn = function async_op_6(a, b, c, d, e, f) {
-          const id = (nextPromiseId + 1) & 0xffffffff;
+          const id = nextPromiseId;
           try {
             const maybeResult = originalOp(id, a, b, c, d, e, f);
             if (maybeResult !== undefined) {
@@ -408,7 +408,7 @@
             ErrorCaptureStackTrace(err, async_op_6);
             return PromiseReject(err);
           }
-          nextPromiseId = id;
+          nextPromiseId = (id + 1) & 0xffffffff;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
@@ -420,7 +420,7 @@
         break;
       case 7:
         fn = function async_op_7(a, b, c, d, e, f, g) {
-          const id = (nextPromiseId + 1) & 0xffffffff;
+          const id = nextPromiseId;
           try {
             const maybeResult = originalOp(id, a, b, c, d, e, f, g);
             if (maybeResult !== undefined) {
@@ -430,7 +430,7 @@
             ErrorCaptureStackTrace(err, async_op_7);
             return PromiseReject(err);
           }
-          nextPromiseId = id;
+          nextPromiseId = (id + 1) & 0xffffffff;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
@@ -442,7 +442,7 @@
         break;
       case 8:
         fn = function async_op_8(a, b, c, d, e, f, g, h) {
-          const id = (nextPromiseId + 1) & 0xffffffff;
+          const id = nextPromiseId;
           try {
             const maybeResult = originalOp(id, a, b, c, d, e, f, g, h);
             if (maybeResult !== undefined) {
@@ -452,7 +452,7 @@
             ErrorCaptureStackTrace(err, async_op_8);
             return PromiseReject(err);
           }
-          nextPromiseId = id;
+          nextPromiseId = (id + 1) & 0xffffffff;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
@@ -464,7 +464,7 @@
         break;
       case 9:
         fn = function async_op_9(a, b, c, d, e, f, g, h, i) {
-          const id = (nextPromiseId + 1) & 0xffffffff;
+          const id = nextPromiseId;
           try {
             const maybeResult = originalOp(id, a, b, c, d, e, f, g, h, i);
             if (maybeResult !== undefined) {
@@ -474,7 +474,7 @@
             ErrorCaptureStackTrace(err, async_op_9);
             return PromiseReject(err);
           }
-          nextPromiseId = id;
+          nextPromiseId = (id + 1) & 0xffffffff;
           let promise = PromisePrototypeThen(
             setPromise(id),
             unwrapOpError(eventLoopTick),
@@ -504,7 +504,7 @@
   /* BEGIN TEMPLATE opAsync */
   /* DO NOT MODIFY: use rebuild_async_stubs.js to regenerate */
   function opAsync(opName, ...args) {
-    const id = (nextPromiseId + 1) & 0xffffffff;
+    const id = nextPromiseId;
     try {
       const maybeResult = asyncOps[opName](id, ...new SafeArrayIterator(args));
       if (maybeResult !== undefined) {
@@ -517,7 +517,7 @@
       ErrorCaptureStackTrace(err, opAsync);
       return PromiseReject(err);
     }
-    nextPromiseId = id;
+    nextPromiseId = (id + 1) & 0xffffffff;
     let promise = PromisePrototypeThen(
       setPromise(id),
       unwrapOpError(eventLoopTick),

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -283,42 +283,6 @@
     return promise;
   }
 
-  /*
-Basic codegen.
-
-TODO(mmastrac): automate this (handlebars?)
-
-let s = "";
-const vars = "abcdefghijklm";
-for (let i = 0; i < 10; i++) {
-  let args = "";
-  for (let j = 0; j < i; j++) {
-    args += `${vars[j]},`;
-  }
-  s += `
-      case ${i}:
-        fn = function async_op_${i}(${args}) {
-          const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
-          try {
-            const maybeResult = originalOp(id, ${args});
-            if (maybeResult !== undefined) {
-              movePromise(id);
-              return unwrapOpResultNewPromise(id, maybeResult, async_op_${i});
-            }
-          } catch (err) {
-            movePromise(id);
-            ErrorCaptureStackTrace(err, async_op_${i});
-            return PromiseReject(err);
-          }
-          let promise = PromisePrototypeThen(setPromise(id), unwrapOpError(eventLoopTick));
-          promise = handleOpCallTracing(opName, id, promise);
-          promise[promiseIdSymbol] = id;
-          return promise;
-        };
-        break;
-  `;
-}
-  */
 
   // This function is called once per async stub
   function asyncStub(opName, args) {
@@ -331,6 +295,8 @@ for (let i = 0; i < 10; i++) {
     let fn;
     // The body of this switch statement can be generated using the script above.
     switch (originalOp.length - 1) {
+      /* BEGIN TEMPLATE setUpAsyncStub */
+      /* DO NOT MODIFY: use rebuild_async_stubs.js to regenerate */
       case 0:
         fn = function async_op_0() {
           const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
@@ -354,7 +320,6 @@ for (let i = 0; i < 10; i++) {
           return promise;
         };
         break;
-
       case 1:
         fn = function async_op_1(a) {
           const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
@@ -378,7 +343,6 @@ for (let i = 0; i < 10; i++) {
           return promise;
         };
         break;
-
       case 2:
         fn = function async_op_2(a, b) {
           const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
@@ -402,7 +366,6 @@ for (let i = 0; i < 10; i++) {
           return promise;
         };
         break;
-
       case 3:
         fn = function async_op_3(a, b, c) {
           const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
@@ -426,7 +389,6 @@ for (let i = 0; i < 10; i++) {
           return promise;
         };
         break;
-
       case 4:
         fn = function async_op_4(a, b, c, d) {
           const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
@@ -450,7 +412,6 @@ for (let i = 0; i < 10; i++) {
           return promise;
         };
         break;
-
       case 5:
         fn = function async_op_5(a, b, c, d, e) {
           const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
@@ -474,7 +435,6 @@ for (let i = 0; i < 10; i++) {
           return promise;
         };
         break;
-
       case 6:
         fn = function async_op_6(a, b, c, d, e, f) {
           const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
@@ -498,7 +458,6 @@ for (let i = 0; i < 10; i++) {
           return promise;
         };
         break;
-
       case 7:
         fn = function async_op_7(a, b, c, d, e, f, g) {
           const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
@@ -522,7 +481,6 @@ for (let i = 0; i < 10; i++) {
           return promise;
         };
         break;
-
       case 8:
         fn = function async_op_8(a, b, c, d, e, f, g, h) {
           const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
@@ -546,7 +504,6 @@ for (let i = 0; i < 10; i++) {
           return promise;
         };
         break;
-
       case 9:
         fn = function async_op_9(a, b, c, d, e, f, g, h, i) {
           const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
@@ -570,6 +527,7 @@ for (let i = 0; i < 10; i++) {
           return promise;
         };
         break;
+      /* END TEMPLATE */
 
       default:
         throw new Error(
@@ -586,18 +544,20 @@ for (let i = 0; i < 10; i++) {
     return (ops[opName] = fn);
   }
 
-  function opAsync(name, ...args) {
+  /* BEGIN TEMPLATE opAsync */
+  /* DO NOT MODIFY: use rebuild_async_stubs.js to regenerate */
+  function opAsync(opName, ...args) {
     const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
     try {
-      const maybeResult = asyncOps[name](id, ...new SafeArrayIterator(args));
+      const maybeResult = asyncOps[opName](id, ...new SafeArrayIterator(args));
       if (maybeResult !== undefined) {
         movePromise(id);
         return unwrapOpResultNewPromise(id, maybeResult, opAsync);
       }
     } catch (err) {
       movePromise(id);
-      if (!ReflectHas(asyncOps, name)) {
-        return PromiseReject(new TypeError(`${name} is not a registered op`));
+      if (!ReflectHas(asyncOps, opName)) {
+        return PromiseReject(new TypeError(`${opName} is not a registered op`));
       }
       ErrorCaptureStackTrace(err, opAsync);
       return PromiseReject(err);
@@ -606,10 +566,11 @@ for (let i = 0; i < 10; i++) {
       setPromise(id),
       unwrapOpError(eventLoopTick),
     );
-    promise = handleOpCallTracing(name, id, promise);
+    promise = handleOpCallTracing(opName, id, promise);
     promise[promiseIdSymbol] = id;
     return promise;
   }
+  /* END TEMPLATE */
 
   function handleOpCallTracing(opName, promiseId, p) {
     if (opCallTracingEnabled) {

--- a/core/benches/ops/async.rs
+++ b/core/benches/ops/async.rs
@@ -210,8 +210,7 @@ fn bench_op_async_void_deferred_return(b: &mut Bencher) {
   );
 }
 
-/// Tests the overhead of execute_script, but also returns a value so we can make sure things are
-/// working.
+/// Tests the overhead of opAsync.
 fn bench_op_async_void_indirect(b: &mut Bencher) {
   bench_op(
     b,

--- a/core/benches/ops/async.rs
+++ b/core/benches/ops/async.rs
@@ -210,6 +210,18 @@ fn bench_op_async_void_deferred_return(b: &mut Bencher) {
   );
 }
 
+/// Tests the overhead of execute_script, but also returns a value so we can make sure things are
+/// working.
+fn bench_op_async_void_indirect(b: &mut Bencher) {
+  bench_op(
+    b,
+    BENCH_COUNT,
+    "op_async_void",
+    0,
+    "accum += await opAsync('op_async_void');",
+  );
+}
+
 macro_rules! bench_void {
   ($bench:ident, $op:ident) => {
     fn $bench(b: &mut Bencher) {
@@ -254,6 +266,7 @@ benchmark_group!(
   bench_op_async_yield_lazy_nofast,
   bench_op_async_yield_deferred,
   bench_op_async_yield_deferred_nofast,
+  bench_op_async_void_indirect,
   bench_op_async_void,
   bench_op_async_void_lazy,
   bench_op_async_void_lazy_nofast,

--- a/core/benches/ops/async_harness.js
+++ b/core/benches/ops/async_harness.js
@@ -9,6 +9,7 @@ async function run() {
   const LARGE_STRING_UTF8_1000 = "\u1000".repeat(1000);
   const BUFFER = new Uint8Array(1024);
   const ARRAYBUFFER = new ArrayBuffer(1024);
+  const opAsync = Deno.core.opAsync;
   const { __OP__: op } = Deno.core.ensureFastOps();
   const { op_make_external } = Deno.core.ensureFastOps();
   const EXTERNAL = op_make_external();

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -216,6 +216,7 @@ mod tests {
 
   // If the deno command is available, we ensure the async stubs are correctly rebuilt.
   #[test]
+  #[cfg(not(windows))]
   fn test_rebuild_async_stubs() {
     // Check for deno first
     if let Err(e) = Command::new("deno").arg("--version").status() {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -192,7 +192,7 @@ macro_rules! located_script_name {
 
 #[cfg(test)]
 mod tests {
-  use std::process::Command;
+  use std::process::{Command, Stdio};
 
   use super::*;
 
@@ -216,16 +216,22 @@ mod tests {
 
   // If the deno command is available, we ensure the async stubs are correctly rebuilt.
   #[test]
-  #[cfg(not(windows))]
   fn test_rebuild_async_stubs() {
     // Check for deno first
-    if let Err(e) = Command::new("deno").arg("--version").status() {
+    if let Err(e) = Command::new("deno")
+      .arg("--version")
+      .stderr(Stdio::null())
+      .stdout(Stdio::null())
+      .status()
+    {
       eprintln!("Ignoring test because we couldn't find deno: {e:?}");
     }
     let status = Command::new("deno")
       .args(["run", "-A", "rebuild_async_stubs.js", "--check"])
+      .stderr(Stdio::null())
+      .stdout(Stdio::null())
       .status()
       .unwrap();
-    assert!(status.success(), "Failed to check async stubs");
+    assert!(status.success(), "Async stubs were not updated, or 'rebuild_async_stubs.js' failed for some other reason");
   }
 }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -192,6 +192,8 @@ macro_rules! located_script_name {
 
 #[cfg(test)]
 mod tests {
+  use std::process::Command;
+
   use super::*;
 
   #[test]
@@ -210,5 +212,19 @@ mod tests {
   #[test]
   fn test_v8_version() {
     assert!(v8_version().len() > 3);
+  }
+
+  // If the deno command is available, we ensure the async stubs are correctly rebuilt.
+  #[test]
+  fn test_rebuild_async_stubs() {
+    // Check for deno first
+    if let Err(e) = Command::new("deno").arg("--version").status() {
+      eprintln!("Ignoring test because we couldn't find deno: {e:?}");
+    }
+    let status = Command::new("deno")
+      .args(&["run", "-A", "rebuild_async_stubs.js", "--check"])
+      .status()
+      .unwrap();
+    assert!(status.success(), "Failed to check async stubs");
   }
 }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -222,7 +222,7 @@ mod tests {
       eprintln!("Ignoring test because we couldn't find deno: {e:?}");
     }
     let status = Command::new("deno")
-      .args(&["run", "-A", "rebuild_async_stubs.js", "--check"])
+      .args(["run", "-A", "rebuild_async_stubs.js", "--check"])
       .status()
       .unwrap();
     assert!(status.success(), "Failed to check async stubs");

--- a/core/rebuild_async_stubs.js
+++ b/core/rebuild_async_stubs.js
@@ -6,7 +6,7 @@ const doNotModify =
 
 // The template function we build opAsync and op_async_N functions from
 function __TEMPLATE__(__ARGS_PARAM__) {
-  const id = (nextPromiseId + 1) & 0xffffffff;
+  const id = nextPromiseId;
   try {
     const maybeResult = __OP__(__ARGS__);
     if (maybeResult !== undefined) {
@@ -17,7 +17,7 @@ function __TEMPLATE__(__ARGS_PARAM__) {
     ErrorCaptureStackTrace(err, __TEMPLATE__);
     return PromiseReject(err);
   }
-  nextPromiseId = id;
+  nextPromiseId = (id + 1) & 0xffffffff;
   let promise = PromisePrototypeThen(
     setPromise(id),
     unwrapOpError(eventLoopTick),

--- a/core/rebuild_async_stubs.js
+++ b/core/rebuild_async_stubs.js
@@ -27,7 +27,7 @@ function __TEMPLATE__(__ARGS_PARAM__) {
   return promise;
 }
 
-const coreJsPath = new URL("01_core.js", import.meta.url).pathname;
+const coreJsPath = new URL("01_core.js", import.meta.url);
 const coreJs = Deno.readTextFileSync(coreJsPath);
 
 const corePristine = coreJs.replaceAll(

--- a/core/rebuild_async_stubs.js
+++ b/core/rebuild_async_stubs.js
@@ -83,4 +83,13 @@ const coreOutput = corePristine
   )
   .replace(/[\t ]+TEMPLATE-opAsync/, opAsync.replaceAll(/^/gm, opAsyncIndent));
 
-Deno.writeTextFileSync(coreJsPath, coreOutput);
+if (Deno.args[0] === '--check') {
+  if (coreOutput !== coreJs) {
+    Deno.writeTextFileSync('/tmp/mismatch.txt', coreOutput);
+    throw new Error("Mismatch between pristine and updated source (wrote mismatch to /tmp/mismatch.txt)");
+  } else {
+    console.log("✅ Templated sections would not change");
+  }
+} else {
+  Deno.writeTextFileSync(coreJsPath, coreOutput);
+}

--- a/core/rebuild_async_stubs.js
+++ b/core/rebuild_async_stubs.js
@@ -83,10 +83,12 @@ const coreOutput = corePristine
   )
   .replace(/[\t ]+TEMPLATE-opAsync/, opAsync.replaceAll(/^/gm, opAsyncIndent));
 
-if (Deno.args[0] === '--check') {
+if (Deno.args[0] === "--check") {
   if (coreOutput !== coreJs) {
-    Deno.writeTextFileSync('/tmp/mismatch.txt', coreOutput);
-    throw new Error("Mismatch between pristine and updated source (wrote mismatch to /tmp/mismatch.txt)");
+    Deno.writeTextFileSync("/tmp/mismatch.txt", coreOutput);
+    throw new Error(
+      "Mismatch between pristine and updated source (wrote mismatch to /tmp/mismatch.txt)",
+    );
   } else {
     console.log("✅ Templated sections would not change");
   }

--- a/core/rebuild_async_stubs.js
+++ b/core/rebuild_async_stubs.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env deno run --allow-read --allow-write
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+const doNotModify =
+  "/* DO NOT MODIFY: use rebuild_async_stubs.js to regenerate */\n";
+
+// The template function we build opAsync and op_async_N functions from
+function __TEMPLATE__(__ARGS_PARAM__) {
+  const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
+  try {
+    const maybeResult = __OP__(__ARGS__);
+    if (maybeResult !== undefined) {
+      movePromise(id);
+      return unwrapOpResultNewPromise(id, maybeResult, __TEMPLATE__);
+    }
+  } catch (err) {
+    movePromise(id);
+    __ERR__;
+    ErrorCaptureStackTrace(err, __TEMPLATE__);
+    return PromiseReject(err);
+  }
+  let promise = PromisePrototypeThen(
+    setPromise(id),
+    unwrapOpError(eventLoopTick),
+  );
+  promise = handleOpCallTracing(opName, id, promise);
+  promise[promiseIdSymbol] = id;
+  return promise;
+}
+
+const coreJsPath = new URL("01_core.js", import.meta.url).pathname;
+const coreJs = Deno.readTextFileSync(coreJsPath);
+
+const corePristine = coreJs.replaceAll(
+  /\/\* BEGIN TEMPLATE ([^ ]+) \*\/.*?\/\* END TEMPLATE \*\//smg,
+  "TEMPLATE-$1",
+);
+const templateString = __TEMPLATE__.toString();
+let asyncStubCases = "/* BEGIN TEMPLATE setUpAsyncStub */\n";
+asyncStubCases += doNotModify;
+const vars = "abcdefghijklm";
+for (let i = 0; i < 10; i++) {
+  let args = "id";
+  for (let j = 0; j < i; j++) {
+    args += `, ${vars[j]}`;
+  }
+  const name = `async_op_${i}`;
+  // Replace the name and args, and add a two-space indent
+  const func = `fn = ${templateString}`
+    .replaceAll(/__TEMPLATE__/g, name)
+    .replaceAll(/__ARGS__/g, args)
+    .replaceAll(/__ARGS_PARAM__/g, args.replace(/id(, )?/, ""))
+    .replaceAll(/__OP__/g, "originalOp")
+    .replaceAll(/[\s]*__ERR__;/g, "")
+    .replaceAll(/^/gm, "  ");
+  asyncStubCases += `
+case ${i}:
+${func};
+  break;
+  `.trim() + "\n";
+}
+asyncStubCases += "/* END TEMPLATE */";
+
+const opAsync = "/* BEGIN TEMPLATE opAsync */\n" + doNotModify +
+  templateString
+    .replaceAll(/__TEMPLATE__/g, "opAsync")
+    .replaceAll(/__ARGS_PARAM__/g, "opName, ...args")
+    .replaceAll(/__ARGS__/g, "id, ...new SafeArrayIterator(args)")
+    .replaceAll(/__OP__/g, "asyncOps[opName]")
+    .replaceAll(
+      /__ERR__;/g,
+      "if (!ReflectHas(asyncOps, opName)) {\n      return PromiseReject(new TypeError(`${opName} is not a registered op`));\n    }",
+    ) +
+  "\n/* END TEMPLATE */";
+
+const asyncStubIndent =
+  corePristine.match(/^([\t ]+)(?=TEMPLATE-setUpAsyncStub)/m)[0];
+const opAsyncIndent = corePristine.match(/^([\t ]+)(?=TEMPLATE-opAsync)/m)[0];
+
+const coreOutput = corePristine
+  .replace(
+    /[\t ]+TEMPLATE-setUpAsyncStub/,
+    asyncStubCases.replaceAll(/^/gm, asyncStubIndent),
+  )
+  .replace(/[\t ]+TEMPLATE-opAsync/, opAsync.replaceAll(/^/gm, opAsyncIndent));
+
+Deno.writeTextFileSync(coreJsPath, coreOutput);

--- a/core/rebuild_async_stubs.js
+++ b/core/rebuild_async_stubs.js
@@ -22,9 +22,7 @@ function __TEMPLATE__(__ARGS_PARAM__) {
     setPromise(id),
     unwrapOpError(eventLoopTick),
   );
-  if (opCallTracingEnabled) {
-    promise = handleOpCallTracing(opName, id, promise);
-  }
+  promise = handleOpCallTracing(opName, id, promise);
   promise[promiseIdSymbol] = id;
   return promise;
 }

--- a/core/rebuild_async_stubs.js
+++ b/core/rebuild_async_stubs.js
@@ -6,24 +6,25 @@ const doNotModify =
 
 // The template function we build opAsync and op_async_N functions from
 function __TEMPLATE__(__ARGS_PARAM__) {
-  const id = (nextPromiseId = (nextPromiseId + 1) & 0xffffffff);
+  const id = (nextPromiseId + 1) & 0xffffffff;
   try {
     const maybeResult = __OP__(__ARGS__);
     if (maybeResult !== undefined) {
-      movePromise(id);
-      return unwrapOpResultNewPromise(id, maybeResult, __TEMPLATE__);
+      return PromiseResolve(maybeResult);
     }
   } catch (err) {
-    movePromise(id);
     __ERR__;
     ErrorCaptureStackTrace(err, __TEMPLATE__);
     return PromiseReject(err);
   }
+  nextPromiseId = id;
   let promise = PromisePrototypeThen(
     setPromise(id),
     unwrapOpError(eventLoopTick),
   );
-  promise = handleOpCallTracing(opName, id, promise);
+  if (opCallTracingEnabled) {
+    promise = handleOpCallTracing(opName, id, promise);
+  }
   promise[promiseIdSymbol] = id;
   return promise;
 }

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -354,7 +354,7 @@ fn ops_in_js_have_proper_names() {
   runtime.execute_script_static("test", src).unwrap();
 }
 
-/// Dipatch more promises than the ring can hold, but wait for them all the queue up first.
+/// Dipatch more promises than the ring can hold, but wait for them all to queue up first.
 #[tokio::test]
 async fn test_dispatch_many_ops() {
   #[op2(async)]

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -11,11 +11,11 @@ use anyhow::Error;
 use futures::Future;
 use log::debug;
 use pretty_assertions::assert_eq;
-use tokio::sync::Barrier;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
+use tokio::sync::Barrier;
 use url::Url;
 
 #[tokio::test]

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -358,7 +358,7 @@ fn ops_in_js_have_proper_names() {
 #[tokio::test]
 async fn test_dispatch_many_ops() {
   #[op2(async)]
-  async fn op_wait(state: Rc<RefCell<OpState>>) -> () {
+  async fn op_wait(state: Rc<RefCell<OpState>>) {
     let barrier: Rc<Barrier> = state.borrow().borrow::<Rc<Barrier>>().clone();
     barrier.wait().await;
   }

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -423,23 +423,6 @@ fn test_dispatch() {
 }
 
 #[test]
-fn test_op_async_promise_id() {
-  let (mut runtime, _dispatch_count) = setup(Mode::Async);
-  runtime
-    .execute_script_static(
-      "filename.js",
-      r#"
-
-      const p = Deno.core.opAsync("op_test", 42);
-      if (p[Symbol.for("Deno.core.internalPromiseId")] == undefined) {
-        throw new Error("missing id on returned promise");
-      }
-      "#,
-    )
-    .unwrap();
-}
-
-#[test]
 fn test_dispatch_no_zero_copy_buf() {
   let (mut runtime, dispatch_count) = setup(Mode::AsyncZeroCopy(false));
   runtime


### PR DESCRIPTION
Adds a new template system for op async dispatch generation, and starts generating opAsync from it as well so we can play with performance more easily.

First pass at optimization: 5% improvement in async dispatch by avoiding allocation of promise IDs and generally doing less work in the async handlers.

Before:

```
test bench_op_async_void                  ... bench:      80,853 ns/iter (+/- 2,123)
```

After:

```
test bench_op_async_void                  ... bench:      76,799 ns/iter (+/- 1,158)
```
