### PR TITLE
feat: Import attributes validation callback

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -97,6 +97,7 @@ pub use crate::modules::ModuleType;
 pub use crate::modules::NoopModuleLoader;
 pub use crate::modules::ResolutionKind;
 pub use crate::modules::StaticModuleLoader;
+pub use crate::modules::ValidateImportAttributesCb;
 pub use crate::normalize_path::normalize_path;
 pub use crate::ops::OpError;
 pub use crate::ops::OpId;

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -1,5 +1,4 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-use crate::JsRuntime;
 use crate::error::exception_to_err_result;
 use crate::error::generic_error;
 use crate::error::throw_type_error;
@@ -22,6 +21,7 @@ use crate::modules::RecursiveModuleLoad;
 use crate::modules::ResolutionKind;
 use crate::runtime::JsRealm;
 use crate::runtime::SnapshottedData;
+use crate::JsRuntime;
 use anyhow::Error;
 use futures::future::FutureExt;
 use futures::stream::FuturesUnordered;

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -1,5 +1,5 @@
-use crate::JsRuntime;
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+use crate::JsRuntime;
 use crate::error::exception_to_err_result;
 use crate::error::generic_error;
 use crate::error::throw_type_error;

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -5,7 +5,7 @@ use crate::error::throw_type_error;
 use crate::fast_string::FastString;
 use crate::modules::get_asserted_module_type_from_assertions;
 use crate::modules::parse_import_assertions;
-use crate::modules::validate_import_assertions;
+use crate::modules::validate_import_attributes;
 use crate::modules::ImportAssertionsKind;
 use crate::modules::ModuleCode;
 use crate::modules::ModuleError;
@@ -505,7 +505,7 @@ impl ModuleMap {
 
       // FIXME(bartomieju): there are no stack frames if exception
       // is thrown here
-      validate_import_assertions(tc_scope, &assertions);
+      validate_import_attributes(tc_scope, &assertions);
       if tc_scope.has_caught() {
         let exception = tc_scope.exception().unwrap();
         let exception = v8::Global::new(tc_scope, exception);

--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -51,7 +51,8 @@ pub type ModuleName = FastString;
 
 /// Callback to validate import attributes. If the validation fails and exception
 /// should be thrown using `scope.throw_exception()`.
-pub type ValidateImportAttributesCb = Box<dyn Fn(&mut v8::HandleScope, &HashMap<String, String>)>;
+pub type ValidateImportAttributesCb =
+  Box<dyn Fn(&mut v8::HandleScope, &HashMap<String, String>)>;
 
 const SUPPORTED_TYPE_ASSERTIONS: &[&str] = &["json"];
 

--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -63,16 +63,22 @@ pub(crate) fn validate_import_attributes(
   assertions: &HashMap<String, String>,
 ) {
   for (key, value) in assertions {
-    if key == "type" && !SUPPORTED_TYPE_ASSERTIONS.contains(&value.as_str()) {
-      let message = v8::String::new(
-        scope,
-        &format!("\"{value}\" is not a valid module type."),
-      )
-      .unwrap();
-      let exception = v8::Exception::type_error(scope, message);
-      scope.throw_exception(exception);
-      return;
-    }
+    let msg = if key != "type" {
+      Some(format!("\"{key}\" attribute is not supported."))
+    } else if !SUPPORTED_TYPE_ASSERTIONS.contains(&value.as_str()) {
+      Some(format!("\"{value}\" is not a valid module type."))
+    } else {
+      None
+    };
+
+    let Some(msg) = msg else {
+      continue;
+    };
+
+    let message = v8::String::new(scope, &msg).unwrap();
+    let exception = v8::Exception::type_error(scope, message);
+    scope.throw_exception(exception);
+    return;
   }
 }
 

--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -51,8 +51,9 @@ pub type ModuleName = FastString;
 
 const SUPPORTED_TYPE_ASSERTIONS: &[&str] = &["json"];
 
-/// Throws V8 exception if assertions are invalid
-pub(crate) fn validate_import_assertions(
+/// Throws a `TypeError` if `type` attribute is not equal to "json". Allows
+/// all other attributes.
+pub(crate) fn validate_import_attributes(
   scope: &mut v8::HandleScope,
   assertions: &HashMap<String, String>,
 ) {

--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -49,6 +49,10 @@ pub(crate) type ModuleLoadId = i32;
 pub type ModuleCode = FastString;
 pub type ModuleName = FastString;
 
+/// Callback to validate import attributes. If the validation fails and exception
+/// should be thrown using `scope.throw_exception()`.
+pub type ValidateImportAttributesCb = Box<dyn Fn(&mut v8::HandleScope, &HashMap<String, String>)>;
+
 const SUPPORTED_TYPE_ASSERTIONS: &[&str] = &["json"];
 
 /// Throws a `TypeError` if `type` attribute is not equal to "json". Allows

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -498,7 +498,10 @@ fn test_json_module() {
 
 #[test]
 fn test_validate_import_attributes() {
-  fn validate_import_attrs(scope: &mut v8::HandleScope, _attrs: &HashMap<String, String>) {
+  fn validate_import_attrs(
+    scope: &mut v8::HandleScope,
+    _attrs: &HashMap<String, String>,
+  ) {
     let msg = v8::String::new(scope, "boom!").unwrap();
     let ex = v8::Exception::type_error(scope, msg);
     scope.throw_exception(ex);
@@ -535,7 +538,8 @@ fn test_validate_import_attributes() {
       unreachable!();
     };
     let exception = v8::Local::new(scope, exc);
-    let err = exception_to_err_result::<()>(scope, exception, false).unwrap_err();
+    let err =
+      exception_to_err_result::<()>(scope, exception, false).unwrap_err();
     assert_eq!(err.to_string(), "Uncaught TypeError: boom!");
   }
 }

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -11,7 +11,7 @@ use crate::error::throw_type_error;
 use crate::error::JsStackFrame;
 use crate::modules::get_asserted_module_type_from_assertions;
 use crate::modules::parse_import_assertions;
-use crate::modules::validate_import_assertions;
+use crate::modules::validate_import_attributes;
 use crate::modules::ImportAssertionsKind;
 use crate::modules::ModuleMap;
 use crate::modules::ResolutionKind;
@@ -291,7 +291,7 @@ pub fn host_import_module_dynamically_callback<'s>(
 
   {
     let tc_scope = &mut v8::TryCatch::new(scope);
-    validate_import_assertions(tc_scope, &assertions);
+    validate_import_attributes(tc_scope, &assertions);
     if tc_scope.has_caught() {
       let e = tc_scope.exception().unwrap();
       resolver.reject(tc_scope, e);

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -11,7 +11,6 @@ use crate::error::throw_type_error;
 use crate::error::JsStackFrame;
 use crate::modules::get_asserted_module_type_from_assertions;
 use crate::modules::parse_import_assertions;
-use crate::modules::validate_import_attributes;
 use crate::modules::ImportAssertionsKind;
 use crate::modules::ModuleMap;
 use crate::modules::ResolutionKind;
@@ -291,7 +290,12 @@ pub fn host_import_module_dynamically_callback<'s>(
 
   {
     let tc_scope = &mut v8::TryCatch::new(scope);
-    validate_import_attributes(tc_scope, &assertions);
+    {
+      let state_rc = JsRuntime::state_from(tc_scope);
+      let state = state_rc.borrow();
+      (state.validate_import_attributes_cb)(tc_scope, &assertions);
+    }
+
     if tc_scope.has_caught() {
       let e = tc_scope.exception().unwrap();
       resolver.reject(tc_scope, e);

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -456,6 +456,10 @@ pub struct RuntimeOptions {
   /// An optional instance of `FeatureChecker`. If one is not provided, the
   /// default instance will be created that has no features enabled.
   pub feature_checker: Option<Arc<FeatureChecker>>,
+
+  /// A callback that can be used to validate import attributes received at
+  /// the import site.
+  pub validate_import_attributes_cb: Option<ValidateImportAttributesCb>,
 }
 
 impl RuntimeOptions {
@@ -603,7 +607,7 @@ impl JsRuntime {
       // SAFETY: we just asserted that layout has non-0 size.
       unsafe { std::alloc::alloc(layout) as *mut _ };
 
-    let validate_import_attributes_cb = Box::new(crate::modules::validate_import_attributes);
+    let validate_import_attributes_cb = options.validate_import_attributes_cb.unwrap_or_else(|| Box::new(crate::modules::validate_import_attributes));
 
     let state_rc = Rc::new(RefCell::new(JsRuntimeState {
       dyn_module_evaluate_idle_counter: 0,

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -458,7 +458,8 @@ pub struct RuntimeOptions {
   pub feature_checker: Option<Arc<FeatureChecker>>,
 
   /// A callback that can be used to validate import attributes received at
-  /// the import site.
+  /// the import site. If not callback is provided, a default one is used. The
+  /// default callback only allows `"type"` attribute, with a value of `"json"`.
   pub validate_import_attributes_cb: Option<ValidateImportAttributesCb>,
 }
 

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -607,7 +607,9 @@ impl JsRuntime {
       // SAFETY: we just asserted that layout has non-0 size.
       unsafe { std::alloc::alloc(layout) as *mut _ };
 
-    let validate_import_attributes_cb = options.validate_import_attributes_cb.unwrap_or_else(|| Box::new(crate::modules::validate_import_attributes));
+    let validate_import_attributes_cb = options
+      .validate_import_attributes_cb
+      .unwrap_or_else(|| Box::new(crate::modules::validate_import_attributes));
 
     let state_rc = Rc::new(RefCell::new(JsRuntimeState {
       dyn_module_evaluate_idle_counter: 0,


### PR DESCRIPTION
Closes https://github.com/denoland/deno_core/issues/326

This commit adds `RuntimeOptions.validate_import_attributes_cb` that can be
used to customize which import attributes are allowed.