### PR TITLE
build(core): add feature flag include_icu_data

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,7 +14,8 @@ description = "A modern JavaScript/TypeScript runtime built with V8, Rust, and T
 path = "lib.rs"
 
 [features]
-default = ["v8_use_custom_libcxx"]
+default = ["include_icu_data", "v8_use_custom_libcxx"]
+include_icu_data = []
 v8_use_custom_libcxx = ["v8/use_custom_libcxx"]
 include_js_files_for_snapshotting = []
 unsafe_runtime_options = []

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -345,11 +345,14 @@ fn v8_init(
   predictable: bool,
   expose_natives: bool,
 ) {
-  // Include 10MB ICU data file.
-  #[repr(C, align(16))]
-  struct IcuData([u8; 10631872]);
-  static ICU_DATA: IcuData = IcuData(*include_bytes!("icudtl.dat"));
-  v8::icu::set_common_data_73(&ICU_DATA.0).unwrap();
+  #[cfg(feature = "include_icu_data")]
+  {
+    // Include 10MB ICU data file.
+    #[repr(C, align(16))]
+    struct IcuData([u8; 10631872]);
+    static ICU_DATA: IcuData = IcuData(*include_bytes!("icudtl.dat"));
+    v8::icu::set_common_data_73(&ICU_DATA.0).unwrap();
+  }
 
   let base_flags = concat!(
     " --wasm-test-streaming",


### PR DESCRIPTION
Embedding ICU data into Deno binary is undesirable when linking with system-provided ICU (in Linux distributions) - it adds 10 MiB of unnecessary bloat.

This patch is already used in deno package for Alpine Linux.