### PR TITLE
feat(core): add function to call a JS function with args

### DIFF
--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1195,11 +1195,27 @@ impl JsRuntime {
     &mut self,
     function: &v8::Global<v8::Function>,
   ) -> Result<v8::Global<v8::Value>, Error> {
+    self.call_with_args_and_await(function, &[]).await
+  }
+
+  /// Call a function with args. If it returns a promise, run the event loop until that
+  /// promise is settled. If the promise rejects or there is an uncaught error
+  /// in the event loop, return `Err(error)`. Or return `Ok(<await returned>)`.
+  pub async fn call_with_args_and_await(
+    &mut self,
+    function: &v8::Global<v8::Function>,
+    args: &[v8::Global<v8::Value>],
+  ) -> Result<v8::Global<v8::Value>, Error> {
     let promise = {
       let scope = &mut self.handle_scope();
+      let mut local_args: SmallVec<[v8::Local<v8::Value>; 32]> =
+        SmallVec::with_capacity(args.len());
+      for v in args {
+        local_args.push(v8::Local::new(scope, v));
+      }
       let cb = function.open(scope);
       let this = v8::undefined(scope).into();
-      let promise = cb.call(scope, this, &[]);
+      let promise = cb.call(scope, this, &local_args);
       if promise.is_none() || scope.is_execution_terminating() {
         let undefined = v8::undefined(scope).into();
         return exception_to_err_result(scope, undefined, false);

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1213,7 +1213,7 @@ impl JsRuntime {
       let promise = if args.is_empty() {
         cb.call(scope, this, &[])
       } else {
-        let mut local_args: SmallVec<[v8::Local<v8::Value>; 32]> =
+        let mut local_args: SmallVec<[v8::Local<v8::Value>; 8]> =
           SmallVec::with_capacity(args.len());
         for v in args {
           local_args.push(v8::Local::new(scope, v));


### PR DESCRIPTION
Closes https://github.com/denoland/deno_core/issues/338

This implements a new function `call_with_args_and_await` on `JsRuntime` that allows users to call a JS function from the Rust runtime with args (unlike `call_and_await`).