### PR TITLE
feat: V8TaskSpawner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "serde_v8",
  "smallvec",
  "sourcemap 7.0.1",
+ "static_assertions",
  "tokio",
  "url",
  "v8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ serde_bytes = "0.11"
 serde_json = "1"
 smallvec = "1.8"
 sourcemap = "7"
+static_assertions = "1"
 strum = { version = "0.25.0", features = ["derive"] }
 strum_macros = "0.25.0"
 testing_macros = "0.2.11"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,6 +35,7 @@ serde_json = { workspace = true, features = ["preserve_order"] }
 serde_v8.workspace = true
 smallvec.workspace = true
 sourcemap.workspace = true
+static_assertions.workspace = true
 tokio.workspace = true
 url.workspace = true
 v8.workspace = true

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -23,6 +23,7 @@ mod path;
 mod resources;
 mod runtime;
 mod source_map;
+mod tasks;
 
 // Re-exports
 pub use anyhow;
@@ -136,6 +137,8 @@ pub use crate::runtime::Snapshot;
 pub use crate::runtime::V8_WRAPPER_OBJECT_INDEX;
 pub use crate::runtime::V8_WRAPPER_TYPE_INDEX;
 pub use crate::source_map::SourceMapGetter;
+pub use crate::tasks::V8CrossThreadTaskSpawner;
+pub use crate::tasks::V8TaskSpawner;
 
 // Ensure we can use op2 in deno_core without any hackery.
 extern crate self as deno_core;

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -10,6 +10,7 @@ use crate::modules::ModuleMap;
 use crate::ops::OpCtx;
 use crate::ops::PendingOp;
 use crate::runtime::JsRuntimeState;
+use crate::tasks::V8TaskSpawnerFactory;
 use crate::JsRuntime;
 use anyhow::Error;
 use deno_unsync::JoinSet;
@@ -22,6 +23,7 @@ use std::hash::BuildHasherDefault;
 use std::hash::Hasher;
 use std::option::Option;
 use std::rc::Rc;
+use std::sync::Arc;
 use v8::Handle;
 use v8::HandleScope;
 use v8::Local;
@@ -54,6 +56,7 @@ pub(crate) struct ModEvaluate {
 
 #[derive(Default)]
 pub(crate) struct ContextState {
+  pub(crate) task_spawner_factory: Arc<V8TaskSpawnerFactory>,
   pub(crate) js_event_loop_tick_cb: Option<Rc<v8::Global<v8::Function>>>,
   pub(crate) js_build_custom_error_cb: Option<Rc<v8::Global<v8::Function>>>,
   pub(crate) js_promise_reject_cb: Option<Rc<v8::Global<v8::Function>>>,

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -623,6 +623,21 @@ impl JsRuntime {
 
     let weak = Rc::downgrade(&state_rc);
     let context_state = Rc::new(RefCell::new(ContextState::default()));
+
+    // Add the task spawners to the OpState
+    let spawner = context_state
+      .borrow()
+      .task_spawner_factory
+      .clone()
+      .new_same_thread_spawner();
+    op_state.borrow_mut().put(spawner);
+    let spawner = context_state
+      .borrow()
+      .task_spawner_factory
+      .clone()
+      .new_cross_thread_spawner();
+    op_state.borrow_mut().put(spawner);
+
     let count = ops.len();
     let mut op_ctxs = ops
       .into_iter()
@@ -1772,12 +1787,14 @@ impl EventLoopPendingState {
   ) -> Self {
     let num_unrefed_ops = state.unrefed_ops.len();
     let num_pending_ops = state.pending_ops.len();
+    let has_pending_tasks = state.task_spawner_factory.has_pending_tasks();
     let has_pending_dyn_imports = modules.has_pending_dynamic_imports();
     let has_pending_dyn_module_evaluation =
       modules.has_pending_dyn_module_evaluation();
     let has_pending_module_evaluation = state.pending_mod_evaluate.is_some();
     EventLoopPendingState {
-      has_pending_refed_ops: num_pending_ops > num_unrefed_ops,
+      has_pending_refed_ops: has_pending_tasks
+        || num_pending_ops > num_unrefed_ops,
       has_pending_dyn_imports,
       has_pending_dyn_module_evaluation,
       has_pending_module_evaluation,
@@ -1961,8 +1978,20 @@ impl JsRuntime {
     scope: &mut v8::HandleScope,
     context_state: &RefCell<ContextState>,
   ) -> Result<bool, Error> {
-    let mut context_state = context_state.borrow_mut();
     let mut dispatched_ops = false;
+
+    // Poll any pending task spawner tasks. Note that we need to poll separately because otherwise
+    // Rust will extend the lifetime of the borrow longer than we expect.
+    let tasks = context_state.borrow().task_spawner_factory.poll_inner(cx);
+    if let Poll::Ready(tasks) = tasks {
+      // TODO(mmastrac): we are using this flag
+      dispatched_ops = true;
+      for task in tasks {
+        task(scope);
+      }
+    }
+
+    let mut context_state = context_state.borrow_mut();
 
     // We return async responses to JS in unbounded batches (may change),
     // each batch is a flat vector of tuples:

--- a/core/runtime/tests/misc.rs
+++ b/core/runtime/tests/misc.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 use std::time::Duration;
+use std::time::Instant;
 use url::Url;
 
 #[test]
@@ -1073,33 +1074,42 @@ export const TEST = "foo";
   });
 }
 
-#[tokio::test]
-async fn task_spawner() {
+fn create_spawner_runtime() -> JsRuntime {
   let mut runtime = JsRuntime::new(RuntimeOptions {
     ..Default::default()
   });
-
-  let value = Rc::new(AtomicUsize::new(0));
-  let value_clone = value.clone();
   runtime
     .execute_script("main", ascii_str!("function f() { return 42; }"))
     .unwrap();
+  runtime
+}
+
+fn call_i32_function(scope: &mut v8::HandleScope) -> i32 {
+  let ctx = scope.get_current_context();
+  let global = ctx.global(scope);
+  let key = v8::String::new_external_onebyte_static(scope, b"f")
+    .unwrap()
+    .into();
+  let f: v8::Local<'_, v8::Function> =
+    global.get(scope, key).unwrap().try_into().unwrap();
+  let recv = v8::undefined(scope).into();
+  let res: v8::Local<v8::Integer> =
+    f.call(scope, recv, &[]).unwrap().try_into().unwrap();
+  res.int32_value(scope).unwrap()
+}
+
+#[tokio::test]
+async fn task_spawner() {
+  let mut runtime = create_spawner_runtime();
+  let value = Arc::new(AtomicUsize::new(0));
+  let value_clone = value.clone();
   runtime
     .op_state()
     .borrow()
     .borrow::<V8TaskSpawner>()
     .spawn(move |scope| {
-      let ctx = scope.get_current_context();
-      let global = ctx.global(scope);
-      let key = v8::String::new_external_onebyte_static(scope, b"f")
-        .unwrap()
-        .into();
-      let f: v8::Local<'_, v8::Function> =
-        global.get(scope, key).unwrap().try_into().unwrap();
-      let recv = v8::undefined(scope).into();
-      let res: v8::Local<v8::Integer> =
-        f.call(scope, recv, &[]).unwrap().try_into().unwrap();
-      value_clone.store(res.int32_value(scope).unwrap() as _, Ordering::SeqCst);
+      let res = call_i32_function(scope);
+      value_clone.store(res as _, Ordering::SeqCst);
     });
   poll_fn(|cx| runtime.poll_event_loop(cx, false))
     .await
@@ -1109,15 +1119,9 @@ async fn task_spawner() {
 
 #[tokio::test]
 async fn task_spawner_cross_thread() {
-  let mut runtime = JsRuntime::new(RuntimeOptions {
-    ..Default::default()
-  });
-
+  let mut runtime = create_spawner_runtime();
   let value = Arc::new(AtomicUsize::new(0));
   let value_clone = value.clone();
-  runtime
-    .execute_script("main", ascii_str!("function f() { return 42; }"))
-    .unwrap();
   let spawner = runtime
     .op_state()
     .borrow()
@@ -1126,21 +1130,46 @@ async fn task_spawner_cross_thread() {
 
   std::thread::spawn(move || {
     spawner.spawn(move |scope| {
-      let ctx = scope.get_current_context();
-      let global = ctx.global(scope);
-      let key = v8::String::new_external_onebyte_static(scope, b"f")
-        .unwrap()
-        .into();
-      let f: v8::Local<'_, v8::Function> =
-        global.get(scope, key).unwrap().try_into().unwrap();
-      let recv = v8::undefined(scope).into();
-      let res: v8::Local<v8::Integer> =
-        f.call(scope, recv, &[]).unwrap().try_into().unwrap();
-      value_clone.store(res.int32_value(scope).unwrap() as _, Ordering::SeqCst);
+      let res = call_i32_function(scope);
+      value_clone.store(res as _, Ordering::SeqCst);
     });
   });
-  poll_fn(|cx| runtime.poll_event_loop(cx, false))
-    .await
-    .unwrap();
-  assert_eq!(value.load(Ordering::SeqCst), 42);
+
+  // Async spin while we wait for this to complete
+  let start = Instant::now();
+  while value.load(Ordering::SeqCst) != 42 {
+    poll_fn(|cx| runtime.poll_event_loop(cx, false))
+      .await
+      .unwrap();
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    assert!(start.elapsed().as_secs() < 60);
+  }
+}
+
+#[tokio::test]
+async fn task_spawner_cross_thread_blocking() {
+  let mut runtime = create_spawner_runtime();
+
+  let value = Arc::new(AtomicUsize::new(0));
+  let value_clone = value.clone();
+  let spawner = runtime
+    .op_state()
+    .borrow()
+    .borrow::<V8CrossThreadTaskSpawner>()
+    .clone();
+
+  std::thread::spawn(move || {
+    let res = spawner.spawn_blocking(move |scope| call_i32_function(scope));
+    value_clone.store(res as _, Ordering::SeqCst);
+  });
+
+  // Async spin while we wait for this to complete
+  let start = Instant::now();
+  while value.load(Ordering::SeqCst) != 42 {
+    poll_fn(|cx| runtime.poll_event_loop(cx, false))
+      .await
+      .unwrap();
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    assert!(start.elapsed().as_secs() < 60);
+  }
 }

--- a/core/runtime/tests/misc.rs
+++ b/core/runtime/tests/misc.rs
@@ -1159,7 +1159,7 @@ async fn task_spawner_cross_thread_blocking() {
     .clone();
 
   std::thread::spawn(move || {
-    let res = spawner.spawn_blocking(move |scope| call_i32_function(scope));
+    let res = spawner.spawn_blocking(call_i32_function);
     value_clone.store(res as _, Ordering::SeqCst);
   });
 

--- a/core/tasks.rs
+++ b/core/tasks.rs
@@ -115,9 +115,9 @@ impl V8TaskSpawner {
   where
     F: FnOnce(&mut v8::HandleScope) + 'static,
   {
-    // SAFETY: we are transmuting Send into a !Send handle but we can guarantee this object will never
-    // leave the current thread because `V8TaskSpawner` is !Send.
     let task: Box<dyn FnOnce(&mut v8::HandleScope<'_>)> = Box::new(f);
+    // SAFETY: we are transmuting Send into a !Send handle but we guarantee this object will never
+    // leave the current thread because `V8TaskSpawner` is !Send.
     let task: Box<dyn FnOnce(&mut v8::HandleScope<'_>) + Send> =
       unsafe { std::mem::transmute(task) };
     self.tasks.spawn(task)

--- a/core/tasks.rs
+++ b/core/tasks.rs
@@ -196,11 +196,10 @@ impl V8CrossThreadTaskSpawner {
 
 #[cfg(test)]
 mod tests {
+  use super::*;
   use std::future::poll_fn;
-
   use tokio::task::LocalSet;
 
-  use super::*;
   #[test]
   fn test_spawner_serial() {
     let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -208,7 +207,7 @@ mod tests {
       .build()
       .unwrap();
     runtime.block_on(async {
-      let factory = Arc::new(V8TaskSpawnerFactory::default());
+      let factory = Arc::<V8TaskSpawnerFactory>::default();
       let cross_thread_spawner = factory.clone().new_cross_thread_spawner();
       let local_set = LocalSet::new();
 
@@ -242,7 +241,7 @@ mod tests {
       .build()
       .unwrap();
     runtime.block_on(async {
-      let factory = Arc::new(V8TaskSpawnerFactory::default());
+      let factory = Arc::<V8TaskSpawnerFactory>::default();
       let cross_thread_spawner = factory.clone().new_cross_thread_spawner();
       let local_set = LocalSet::new();
 

--- a/core/tasks.rs
+++ b/core/tasks.rs
@@ -1,3 +1,5 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
 use futures::task::AtomicWaker;
 use std::marker::PhantomData;
 use std::ops::DerefMut;

--- a/core/tasks.rs
+++ b/core/tasks.rs
@@ -1,0 +1,98 @@
+use std::marker::PhantomData;
+use std::ops::DerefMut;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::task::Context;
+use std::task::Poll;
+
+use futures::lock::MutexGuard;
+use futures::task::AtomicWaker;
+
+type UnsendTask = Box<dyn FnOnce(&mut v8::HandleScope) + 'static>;
+type SendTask = Box<dyn FnOnce(&mut v8::HandleScope) + Send + 'static>;
+
+#[derive(Default)]
+pub(crate) struct V8TaskSpawnerFactory {
+  // TODO(mmastrac): ideally we wouldn't box if we could use arena allocation and a max submission size
+  tasks: Mutex<Vec<SendTask>>,
+  has_tasks: AtomicBool,
+  waker: AtomicWaker,
+}
+
+impl V8TaskSpawnerFactory {
+  pub fn new_same_thread_spawner(self: Arc<Self>) -> V8TaskSpawner {
+    V8TaskSpawner {
+      tasks: self,
+      _unsend_marker: PhantomData,
+    }
+  }
+
+  pub fn new_cross_thread_spawner(self: Arc<Self>) -> V8CrossThreadTaskSpawner {
+    V8CrossThreadTaskSpawner { tasks: self }
+  }
+
+  pub fn has_pending_tasks(&self) -> bool {
+    self.has_tasks.load(std::sync::atomic::Ordering::SeqCst)
+  }
+
+  pub fn poll_inner(&self, cx: &mut Context) -> Poll<Vec<UnsendTask>> {
+    if !self
+      .has_tasks
+      .swap(false, std::sync::atomic::Ordering::SeqCst)
+    {
+      self.waker.register(cx.waker());
+      return Poll::Pending;
+    }
+    let tasks = std::mem::take(self.tasks.lock().unwrap().deref_mut());
+    // SAFETY: we are removing !Send bounds as we return the tasks here
+    let tasks = unsafe { std::mem::transmute(tasks) };
+    Poll::Ready(tasks)
+  }
+
+  fn spawn(&self, task: Box<dyn FnOnce(&mut v8::HandleScope) + Send>) {
+    self.tasks.lock().unwrap().push(task);
+    // TODO(mmastrac): can we use a looser ordering here?
+    self
+      .has_tasks
+      .store(true, std::sync::atomic::Ordering::SeqCst);
+    self.waker.wake();
+  }
+}
+
+/// Allows for submission of v8 tasks on the same thread.
+#[derive(Clone)]
+pub struct V8TaskSpawner {
+  // TODO(mmastrac): can we split the waker into a send and !send one?
+  tasks: Arc<V8TaskSpawnerFactory>,
+  _unsend_marker: PhantomData<MutexGuard<'static, ()>>,
+}
+
+impl V8TaskSpawner {
+  pub fn spawn<F>(&self, f: F)
+  where
+    F: FnOnce(&mut v8::HandleScope) + 'static,
+  {
+    // SAFETY: we are transmuting Send into a !Send handle but we can guarantee this object will never
+    // leave the current thread because `V8TaskSpawner` is !Send.
+    let task: Box<dyn FnOnce(&mut v8::HandleScope<'_>)> = Box::new(f);
+    let task: Box<dyn FnOnce(&mut v8::HandleScope<'_>) + Send> =
+      unsafe { std::mem::transmute(task) };
+    self.tasks.spawn(task)
+  }
+}
+
+/// Allows for submission of v8 tasks on any thread.
+#[derive(Clone)]
+pub struct V8CrossThreadTaskSpawner {
+  tasks: Arc<V8TaskSpawnerFactory>,
+}
+
+impl V8CrossThreadTaskSpawner {
+  pub fn spawn<F>(&self, f: F)
+  where
+    F: FnOnce(&mut v8::HandleScope) + Send + 'static,
+  {
+    self.tasks.spawn(Box::new(f))
+  }
+}

--- a/core/tasks.rs
+++ b/core/tasks.rs
@@ -141,7 +141,7 @@ impl V8CrossThreadTaskSpawner {
   /// The task is handed off to be run the next time the event loop is polled, and there are
   /// no guarantees as to when this may happen.
   ///
-  /// # Important Notes
+  /// # Safety
   ///
   /// The task shares the same [`v8::HandleScope`] as the core event loop, which means that it
   /// must maintain the scope in a valid state to avoid corrupting or destroying the runtime.

--- a/core/tasks.rs
+++ b/core/tasks.rs
@@ -150,17 +150,6 @@ impl V8CrossThreadTaskSpawner {
   /// no guarantees as to when this may happen, however the function will not return until the
   /// task has been fully run to completion.
   ///
-  /// ```
-  /// # let factory = Arc::new(V8TaskSpawnerFactory::default());
-  /// # let spawner = factory.new_cross_thread_spawner();
-  /// let mut v = vec!["string"];
-  /// // We can safely access surrounding locals in this method
-  /// let slice2 = spawner.spawn_blocking(|_| {
-  ///   v.as_mut_slice()
-  /// });
-  /// # assert_eq!(*slice2.get(0).unwrap(), "string");
-  /// ```
-  ///
   /// # Important Notes
   ///
   /// The task shares the same [`v8::HandleScope`] as the core event loop, which means that it


### PR DESCRIPTION
Provides an `OpState`-stored (for now) `V8TaskSpawner` and `V8CrossThreadTaskSpawner` that allow for submission of v8 tasks to a queue that is run alongside ops.

```
let task_spawner: &V8TaskSpawn = op_state.borrow();
task_spawner.spawn(|scope| {
  /* use scope */
});
```

This allows you submit jobs into a queue that's run just before op dispatch (timing TBD and subject to change). The task is given a scope for the current context, and may do whatever it wishes.

This will likely turn into microtask submission API in the future.