### PR TITLE
feat: Add RuntimeOptions::import_meta_resolve_callback

### DIFF
--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -8,7 +8,6 @@ use serde::Serialize;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::future::Future;
-use std::rc::Rc;
 
 mod loaders;
 mod map;
@@ -41,16 +40,14 @@ pub type ModuleName = FastString;
 /// Callback to customize value of `import.meta.resolve("./foo.ts")`.
 pub type ImportMetaResolveCallback = Box<
   dyn Fn(
-    // TODO(bartlomieju): this is not great, we should use `&dyn ModuleLoader`,
-    // but because we store it in `RefCell<Rc<dyn ModuleLoader>>` this is problematic.
-    &Rc<dyn ModuleLoader>,
+    &dyn ModuleLoader,
     String,
     String,
   ) -> Result<ModuleSpecifier, Error>,
 >;
 
 pub(crate) fn default_import_meta_resolve_cb(
-  loader: &Rc<dyn ModuleLoader>,
+  loader: &dyn ModuleLoader,
   specifier: String,
   referrer: String,
 ) -> Result<ModuleSpecifier, Error> {

--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -39,11 +39,7 @@ pub type ModuleName = FastString;
 
 /// Callback to customize value of `import.meta.resolve("./foo.ts")`.
 pub type ImportMetaResolveCallback = Box<
-  dyn Fn(
-    &dyn ModuleLoader,
-    String,
-    String,
-  ) -> Result<ModuleSpecifier, Error>,
+  dyn Fn(&dyn ModuleLoader, String, String) -> Result<ModuleSpecifier, Error>,
 >;
 
 pub(crate) fn default_import_meta_resolve_cb(

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -1332,7 +1332,7 @@ async fn no_duplicate_loads() {
 #[test]
 fn import_meta_resolve_cb() {
   fn import_meta_resolve_cb(
-    _loader: &Rc<dyn ModuleLoader>,
+    _loader: &dyn ModuleLoader,
     specifier: String,
     _referrer: String,
   ) -> Result<ModuleSpecifier, Error> {

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -20,6 +20,7 @@ use crate::ModuleType;
 use crate::ResolutionKind;
 use crate::RuntimeOptions;
 use crate::Snapshot;
+use anyhow::bail;
 use anyhow::Error;
 use deno_ops::op2;
 use futures::future::poll_fn;
@@ -1326,4 +1327,48 @@ async fn no_duplicate_loads() {
   #[allow(clippy::let_underscore_future)]
   let _ = runtime.mod_evaluate(a_id);
   runtime.run_event_loop(false).await.unwrap();
+}
+
+#[test]
+fn import_meta_resolve_cb() {
+  fn import_meta_resolve_cb(
+    _loader: &Rc<dyn ModuleLoader>,
+    specifier: String,
+    _referrer: String,
+  ) -> Result<ModuleSpecifier, Error> {
+    if specifier == "foo" {
+      return Ok(ModuleSpecifier::parse("foo:bar").unwrap());
+    }
+
+    if specifier == "./mod.js" {
+      return Ok(ModuleSpecifier::parse("file:///mod.js").unwrap());
+    }
+
+    bail!("unexpected")
+  }
+
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    import_meta_resolve_callback: Some(Box::new(import_meta_resolve_cb)),
+    ..Default::default()
+  });
+
+  let spec = ModuleSpecifier::parse("file:///test.js").unwrap();
+  let source = r#"
+  if (import.meta.resolve("foo") !== "foo") throw new Error();
+  if (import.meta.resolve("./mod.js") !== "file:///mod.js") throw new Error();
+  let caught = false;
+  try {
+    import.meta.resolve("boom!");
+  } catch (e) {
+    if (!(e instanceof TypeError)) throw new Error();
+  }
+  if (!caught) throw new Error();
+  "#
+  .to_string();
+  let a_id_fut = runtime.load_main_module(&spec, Some(source.into()));
+  let a_id = futures::executor::block_on(a_id_fut).unwrap();
+
+  #[allow(clippy::let_underscore_future)]
+  let _ = runtime.mod_evaluate(a_id);
+  futures::executor::block_on(runtime.run_event_loop(false)).unwrap();
 }

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -391,7 +391,7 @@ fn import_meta_resolve(
   let import_meta_resolve_result = {
     let loader = loader.borrow();
     let loader = loader.as_ref();
-    (module_map_rc.import_meta_resolve_cb)(&*loader, specifier_str, referrer)
+    (module_map_rc.import_meta_resolve_cb)(loader, specifier_str, referrer)
   };
 
   match import_meta_resolve_result {

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -390,7 +390,8 @@ fn import_meta_resolve(
 
   let import_meta_resolve_result = {
     let loader = loader.borrow();
-    (module_map_rc.import_meta_resolve_cb)(&loader, specifier_str, referrer)
+    let loader = loader.as_ref();
+    (module_map_rc.import_meta_resolve_cb)(&*loader, specifier_str, referrer)
   };
 
   match import_meta_resolve_result {


### PR DESCRIPTION
This commits adds "RuntimeOptions::import_meta_resolve_callback" option
that allows to customize behavior of `import.meta.resolve` API.

Required for https://github.com/denoland/deno/issues/21298.