### PR TITLE
refactor: add support for generic synthetic modules

### DIFF
--- a/core/modules/module_map_data.rs
+++ b/core/modules/module_map_data.rs
@@ -124,9 +124,9 @@ pub(crate) struct ModuleMapData {
   pub(crate) next_load_id: ModuleLoadId,
   /// If a main module has been loaded, points to it by index.
   pub(crate) main_module_id: Option<ModuleId>,
-  /// This store is used temporarily, to forward parsed JSON
-  /// value from `new_json_module` to `json_module_evaluation_steps`
-  pub(crate) json_value_store:
+  /// This store is used to temporarily store data that is used
+  /// to evaluate a "synthetic module".
+  pub(crate) synthetic_module_value_store:
     HashMap<v8::Global<v8::Module>, v8::Global<v8::Value>>,
 }
 

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -483,12 +483,20 @@ fn test_json_module() {
         asserted_module_type: AssertedModuleType::Json,
       },])
     );
-
+    let json_source = ascii_str!("{\"a\": \"b\", \"c\": {\"d\": 10}}");
+    let json_source_v8_str = v8::String::new_from_utf8(
+      scope,
+      json_source.as_bytes(),
+      v8::NewStringType::Normal,
+    )
+    .unwrap();
+    let json_value = { v8::json::parse(scope, json_source_v8_str).unwrap() };
     let mod_c = module_map
-      .new_json_module(
+      .new_synthetic_module(
         scope,
         ascii_str!("file:///c.json"),
-        ascii_str!("{\"a\": \"b\", \"c\": {\"d\": 10}}"),
+        ModuleType::Json,
+        json_value,
       )
       .unwrap();
     let imports = module_map.get_requested_modules(mod_c).unwrap();


### PR DESCRIPTION
This commit refactors handling of "synthetic modules". Instead of having
a very specialized method for creating JSON modules, we now have
a more generic "ModuleMap::create_synthetic_module" method that
will allow to support other synthetic modules like text/bytes/url.

This will be useful for https://github.com/denoland/deno_core/pull/344.