### PR TITLE
refactor: combine LoggingModuleLoader and CountingModuleLoader

### DIFF
--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -18,9 +18,7 @@ mod recursive_load;
 mod tests;
 
 #[cfg(test)]
-pub use loaders::CountingModuleLoader;
-#[cfg(test)]
-pub use loaders::LoggingModuleLoader;
+pub use loaders::TestingModuleLoader;
 #[cfg(test)]
 pub use loaders::ModuleLoadEventCounts;
 

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 use crate::ascii_str;
 use crate::error::exception_to_err_result;
-use crate::modules::loaders::CountingModuleLoader;
+use crate::modules::loaders::TestingModuleLoader;
 use crate::modules::loaders::ModuleLoadEventCounts;
 use crate::modules::loaders::*;
 use crate::modules::AssertedModuleType;
@@ -317,7 +317,7 @@ fn test_recursive_load() {
 
 #[test]
 fn test_mods() {
-  let loader = Rc::new(CountingModuleLoader::new(NoopModuleLoader));
+  let loader = Rc::new(TestingModuleLoader::new(NoopModuleLoader));
   static DISPATCH_COUNT: AtomicUsize = AtomicUsize::new(0);
 
   #[op2(fast)]
@@ -410,7 +410,7 @@ fn test_mods() {
 
 #[test]
 fn test_json_module() {
-  let loader = Rc::new(CountingModuleLoader::new(StaticModuleLoader::new([])));
+  let loader = Rc::new(TestingModuleLoader::new(StaticModuleLoader::new([])));
   let mut runtime = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader.clone()),
     ..Default::default()
@@ -524,7 +524,7 @@ fn test_validate_import_attributes() {
     scope.throw_exception(ex);
   }
 
-  let loader = Rc::new(CountingModuleLoader::new(StaticModuleLoader::new([])));
+  let loader = Rc::new(TestingModuleLoader::new(StaticModuleLoader::new([])));
   let mut runtime = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader.clone()),
     validate_import_attributes_cb: Some(Box::new(validate_import_attrs)),
@@ -562,7 +562,7 @@ fn test_validate_import_attributes() {
 
 #[test]
 fn test_validate_import_attributes_default() {
-  let loader = Rc::new(CountingModuleLoader::new(StaticModuleLoader::new([])));
+  let loader = Rc::new(TestingModuleLoader::new(StaticModuleLoader::new([])));
   let mut runtime = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader.clone()),
     ..Default::default()
@@ -631,7 +631,7 @@ fn test_validate_import_attributes_default() {
 
 #[tokio::test]
 async fn dyn_import_err() {
-  let loader = Rc::new(CountingModuleLoader::new(StaticModuleLoader::new([])));
+  let loader = Rc::new(TestingModuleLoader::new(StaticModuleLoader::new([])));
   let mut runtime = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader.clone()),
     ..Default::default()
@@ -661,7 +661,7 @@ async fn dyn_import_err() {
 
 #[tokio::test]
 async fn dyn_import_ok() {
-  let loader = Rc::new(CountingModuleLoader::new(StaticModuleLoader::with(
+  let loader = Rc::new(TestingModuleLoader::new(StaticModuleLoader::with(
     Url::parse("file:///b.js").unwrap(),
     ascii_str!("export function b() { return 'b' }"),
   )));
@@ -708,7 +708,7 @@ async fn dyn_import_ok() {
 #[tokio::test]
 async fn dyn_import_borrow_mut_error() {
   // https://github.com/denoland/deno/issues/6054
-  let loader = Rc::new(CountingModuleLoader::new(StaticModuleLoader::with(
+  let loader = Rc::new(TestingModuleLoader::new(StaticModuleLoader::with(
     Url::parse("file:///b.js").unwrap(),
     ascii_str!("export function b() { return 'b' }"),
   )));
@@ -749,7 +749,7 @@ async fn dyn_import_borrow_mut_error() {
 // Regression test for https://github.com/denoland/deno/issues/3736.
 #[test]
 fn dyn_concurrent_circular_import() {
-  let loader = Rc::new(CountingModuleLoader::new(StaticModuleLoader::new([
+  let loader = Rc::new(TestingModuleLoader::new(StaticModuleLoader::new([
     (
       Url::parse("file:///a.js").unwrap(),
       ascii_str!("import './b.js';"),

--- a/core/runtime/tests/snapshot.rs
+++ b/core/runtime/tests/snapshot.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 use crate::extensions::Op;
 use crate::modules::AssertedModuleType;
-use crate::modules::LoggingModuleLoader;
+use crate::modules::TestingModuleLoader;
 use crate::modules::ModuleInfo;
 use crate::*;
 use anyhow::Error;
@@ -344,7 +344,7 @@ pub(crate) fn generic_preserve_snapshotted_modules_test(test_snapshot: bool) {
     ..Default::default()
   };
 
-  let loader = Rc::new(LoggingModuleLoader::new(NoopModuleLoader));
+  let loader = Rc::new(TestingModuleLoader::new(NoopModuleLoader));
 
   let mut runtime = if test_snapshot {
     let snapshot_runtime = JsRuntimeForSnapshot::new(RuntimeOptions {


### PR DESCRIPTION
This commit combines "LoggingModuleLoader" and "CountingModuleLoader"
into "TestingModuleLoader". 

They serve very similar purpose and it's better to get more data for assertions
in tests.