### PR TITLE
refactor: Change signatures of JsRuntime event loop methods

### DIFF
--- a/core/examples/fs_module_loader.rs
+++ b/core/examples/fs_module_loader.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), Error> {
   let future = async move {
     let mod_id = js_runtime.load_main_module(&main_module, None).await?;
     let result = js_runtime.mod_evaluate(mod_id);
-    js_runtime.run_event_loop(false).await?;
+    js_runtime.run_event_loop(Default::default()).await?;
     result.await
   };
   runtime.block_on(future)

--- a/core/examples/op2.rs
+++ b/core/examples/op2.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), Error> {
       .await?;
 
     let result = js_runtime.mod_evaluate(mod_id);
-    js_runtime.run_event_loop(false).await?;
+    js_runtime.run_event_loop(Default::default()).await?;
     result.await
   };
 

--- a/core/examples/schedule_task.rs
+++ b/core/examples/schedule_task.rs
@@ -53,7 +53,7 @@ fn main() {
         r#"for (let i = 1; i <= 10; i++) Deno.core.ops.op_schedule_task(i);"#,
       )
       .unwrap();
-    js_runtime.run_event_loop(false).await
+    js_runtime.run_event_loop(Default::default()).await
   };
   runtime.block_on(future).unwrap();
 }

--- a/core/examples/ts_module_loader.rs
+++ b/core/examples/ts_module_loader.rs
@@ -156,7 +156,7 @@ fn main() -> Result<(), Error> {
   let future = async move {
     let mod_id = js_runtime.load_main_module(&main_module, None).await?;
     let result = js_runtime.mod_evaluate(mod_id);
-    js_runtime.run_event_loop(false).await?;
+    js_runtime.run_event_loop(Default::default()).await?;
     result.await
   };
 

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -259,7 +259,7 @@ fn test_recursive_load() {
 
   #[allow(clippy::let_underscore_future)]
   let _ = runtime.mod_evaluate(a_id);
-  futures::executor::block_on(runtime.run_event_loop(false)).unwrap();
+  futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
   let l = loads.lock();
   assert_eq!(
     l.to_vec(),
@@ -529,13 +529,13 @@ fn test_json_module() {
   runtime.instantiate_module(mod_a).unwrap();
 
   let receiver = runtime.mod_evaluate(mod_a);
-  futures::executor::block_on(runtime.run_event_loop(false)).unwrap();
+  futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
   futures::executor::block_on(receiver).unwrap();
 
   runtime.instantiate_module(mod_b).unwrap();
 
   let receiver = runtime.mod_evaluate(mod_b);
-  futures::executor::block_on(runtime.run_event_loop(false)).unwrap();
+  futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
   futures::executor::block_on(receiver).unwrap();
 }
 
@@ -697,7 +697,7 @@ async fn dyn_import_op() {
     .await
     .unwrap();
   let f = runtime.mod_evaluate(id);
-  poll_fn(|cx| runtime.poll_event_loop(cx, false))
+  poll_fn(|cx| runtime.poll_event_loop(cx, Default::default()))
     .await
     .unwrap();
   _ = f.await;
@@ -725,7 +725,7 @@ async fn dyn_import_err() {
       .unwrap();
 
     // We should get an error here.
-    let result = runtime.poll_event_loop(cx, false);
+    let result = runtime.poll_event_loop(cx, Default::default());
     assert!(matches!(result, Poll::Ready(Err(_))));
     assert_eq!(loader.counts(), ModuleLoadEventCounts::new(4, 1, 1));
     Poll::Ready(())
@@ -765,12 +765,12 @@ async fn dyn_import_ok() {
       .unwrap();
 
     assert!(matches!(
-      runtime.poll_event_loop(cx, false),
+      runtime.poll_event_loop(cx, Default::default()),
       Poll::Ready(Ok(_))
     ));
     assert_eq!(loader.counts(), ModuleLoadEventCounts::new(7, 1, 1));
     assert!(matches!(
-      runtime.poll_event_loop(cx, false),
+      runtime.poll_event_loop(cx, Default::default()),
       Poll::Ready(Ok(_))
     ));
     assert_eq!(loader.counts(), ModuleLoadEventCounts::new(7, 1, 1));
@@ -810,10 +810,10 @@ async fn dyn_import_borrow_mut_error() {
 
     // Old comments that are likely wrong:
     // First poll runs `prepare_load` hook.
-    let _ = runtime.poll_event_loop(cx, false);
+    let _ = runtime.poll_event_loop(cx, Default::default());
     assert_eq!(loader.counts(), ModuleLoadEventCounts::new(4, 1, 1));
     // Second poll triggers error
-    let _ = runtime.poll_event_loop(cx, false);
+    let _ = runtime.poll_event_loop(cx, Default::default());
     assert_eq!(loader.counts(), ModuleLoadEventCounts::new(4, 1, 1));
     Poll::Ready(())
   })
@@ -836,7 +836,7 @@ fn test_circular_load() {
     let circular1_id = result.unwrap();
     #[allow(clippy::let_underscore_future)]
     let _ = runtime.mod_evaluate(circular1_id);
-    runtime.run_event_loop(false).await.unwrap();
+    runtime.run_event_loop(Default::default()).await.unwrap();
 
     let l = loads.lock();
     assert_eq!(
@@ -917,7 +917,7 @@ fn test_redirect_load() {
     let redirect1_id = result.unwrap();
     #[allow(clippy::let_underscore_future)]
     let _ = runtime.mod_evaluate(redirect1_id);
-    runtime.run_event_loop(false).await.unwrap();
+    runtime.run_event_loop(Default::default()).await.unwrap();
     let l = loads.lock();
     assert_eq!(
       l.to_vec(),
@@ -1071,7 +1071,7 @@ if (import.meta.url != 'file:///main_with_code.js') throw Error();
 
   #[allow(clippy::let_underscore_future)]
   let _ = runtime.mod_evaluate(main_id);
-  futures::executor::block_on(runtime.run_event_loop(false)).unwrap();
+  futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
 
   let l = loads.lock();
   assert_eq!(
@@ -1157,7 +1157,7 @@ fn main_and_side_module() {
 
   #[allow(clippy::let_underscore_future)]
   let _ = runtime.mod_evaluate(main_id);
-  futures::executor::block_on(runtime.run_event_loop(false)).unwrap();
+  futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
 
   // Try to add another main module - it should error.
   let side_id_fut = runtime
@@ -1173,7 +1173,7 @@ fn main_and_side_module() {
 
   #[allow(clippy::let_underscore_future)]
   let _ = runtime.mod_evaluate(side_id);
-  futures::executor::block_on(runtime.run_event_loop(false)).unwrap();
+  futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
 }
 
 #[test]
@@ -1203,7 +1203,7 @@ fn dynamic_imports_snapshot() {
 
     #[allow(clippy::let_underscore_future)]
     let _ = runtime.mod_evaluate(main_id);
-    futures::executor::block_on(runtime.run_event_loop(false)).unwrap();
+    futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
     runtime.snapshot()
   };
 
@@ -1244,7 +1244,7 @@ fn import_meta_snapshot() {
 
     #[allow(clippy::let_underscore_future)]
     let eval_fut = runtime.mod_evaluate(main_id);
-    futures::executor::block_on(runtime.run_event_loop(false)).unwrap();
+    futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
     futures::executor::block_on(eval_fut).unwrap();
     runtime.snapshot()
   };
@@ -1366,7 +1366,7 @@ async fn no_duplicate_loads() {
   let a_id = runtime.load_main_module(&spec, None).await.unwrap();
   #[allow(clippy::let_underscore_future)]
   let _ = runtime.mod_evaluate(a_id);
-  runtime.run_event_loop(false).await.unwrap();
+  runtime.run_event_loop(Default::default()).await.unwrap();
 }
 
 #[tokio::test]
@@ -1413,7 +1413,7 @@ async fn import_meta_resolve_cb() {
     .unwrap();
   let local = LocalSet::new();
   let a = local.spawn_local(runtime.mod_evaluate(a_id));
-  let b = local.spawn_local(async move { runtime.run_event_loop(false).await });
+  let b = local.spawn_local(async move { runtime.run_event_loop(Default::default()).await });
   local.await;
 
   a.await.unwrap().unwrap();
@@ -1446,5 +1446,5 @@ if (typeof internals === "undefined") throw new Error("core missing");
 
   #[allow(clippy::let_underscore_future)]
   let _ = runtime.mod_evaluate(main_id);
-  futures::executor::block_on(runtime.run_event_loop(false)).unwrap();
+  futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
 }

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -259,7 +259,8 @@ fn test_recursive_load() {
 
   #[allow(clippy::let_underscore_future)]
   let _ = runtime.mod_evaluate(a_id);
-  futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
+  futures::executor::block_on(runtime.run_event_loop(Default::default()))
+    .unwrap();
   let l = loads.lock();
   assert_eq!(
     l.to_vec(),
@@ -529,13 +530,15 @@ fn test_json_module() {
   runtime.instantiate_module(mod_a).unwrap();
 
   let receiver = runtime.mod_evaluate(mod_a);
-  futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
+  futures::executor::block_on(runtime.run_event_loop(Default::default()))
+    .unwrap();
   futures::executor::block_on(receiver).unwrap();
 
   runtime.instantiate_module(mod_b).unwrap();
 
   let receiver = runtime.mod_evaluate(mod_b);
-  futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
+  futures::executor::block_on(runtime.run_event_loop(Default::default()))
+    .unwrap();
   futures::executor::block_on(receiver).unwrap();
 }
 
@@ -1071,7 +1074,8 @@ if (import.meta.url != 'file:///main_with_code.js') throw Error();
 
   #[allow(clippy::let_underscore_future)]
   let _ = runtime.mod_evaluate(main_id);
-  futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
+  futures::executor::block_on(runtime.run_event_loop(Default::default()))
+    .unwrap();
 
   let l = loads.lock();
   assert_eq!(
@@ -1157,7 +1161,8 @@ fn main_and_side_module() {
 
   #[allow(clippy::let_underscore_future)]
   let _ = runtime.mod_evaluate(main_id);
-  futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
+  futures::executor::block_on(runtime.run_event_loop(Default::default()))
+    .unwrap();
 
   // Try to add another main module - it should error.
   let side_id_fut = runtime
@@ -1173,7 +1178,8 @@ fn main_and_side_module() {
 
   #[allow(clippy::let_underscore_future)]
   let _ = runtime.mod_evaluate(side_id);
-  futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
+  futures::executor::block_on(runtime.run_event_loop(Default::default()))
+    .unwrap();
 }
 
 #[test]
@@ -1203,7 +1209,8 @@ fn dynamic_imports_snapshot() {
 
     #[allow(clippy::let_underscore_future)]
     let _ = runtime.mod_evaluate(main_id);
-    futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
+    futures::executor::block_on(runtime.run_event_loop(Default::default()))
+      .unwrap();
     runtime.snapshot()
   };
 
@@ -1244,7 +1251,8 @@ fn import_meta_snapshot() {
 
     #[allow(clippy::let_underscore_future)]
     let eval_fut = runtime.mod_evaluate(main_id);
-    futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
+    futures::executor::block_on(runtime.run_event_loop(Default::default()))
+      .unwrap();
     futures::executor::block_on(eval_fut).unwrap();
     runtime.snapshot()
   };
@@ -1413,7 +1421,9 @@ async fn import_meta_resolve_cb() {
     .unwrap();
   let local = LocalSet::new();
   let a = local.spawn_local(runtime.mod_evaluate(a_id));
-  let b = local.spawn_local(async move { runtime.run_event_loop(Default::default()).await });
+  let b = local.spawn_local(async move {
+    runtime.run_event_loop(Default::default()).await
+  });
   local.await;
 
   a.await.unwrap().unwrap();
@@ -1446,5 +1456,6 @@ if (typeof internals === "undefined") throw new Error("core missing");
 
   #[allow(clippy::let_underscore_future)]
   let _ = runtime.mod_evaluate(main_id);
-  futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
+  futures::executor::block_on(runtime.run_event_loop(Default::default()))
+    .unwrap();
 }

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -847,7 +847,7 @@ mod tests {
       ),
     )?;
 
-    runtime.run_event_loop(false).await?;
+    runtime.run_event_loop(Default::default()).await?;
     if FAIL.with(|b| b.get()) {
       Err(generic_error(format!("{op} test failed ({test})")))
     } else {

--- a/core/runtime/tests/error.rs
+++ b/core/runtime/tests/error.rs
@@ -32,7 +32,7 @@ async fn test_error_builder() {
         include_str!("error_builder_test.js"),
       )
       .unwrap();
-    if let Poll::Ready(Err(_)) = runtime.poll_event_loop(cx, false) {
+    if let Poll::Ready(Err(_)) = runtime.poll_event_loop(cx, Default::default()) {
       unreachable!();
     }
     Poll::Ready(())
@@ -110,7 +110,7 @@ async fn test_error_async_stack() {
     at async error_async_stack.js:4:5
     at async error_async_stack.js:9:5"#;
 
-    match runtime.poll_event_loop(cx, false) {
+    match runtime.poll_event_loop(cx, Default::default()) {
       Poll::Ready(Err(e)) => {
         assert_eq!(e.to_string(), expected_error);
       }

--- a/core/runtime/tests/error.rs
+++ b/core/runtime/tests/error.rs
@@ -32,7 +32,8 @@ async fn test_error_builder() {
         include_str!("error_builder_test.js"),
       )
       .unwrap();
-    if let Poll::Ready(Err(_)) = runtime.poll_event_loop(cx, Default::default()) {
+    if let Poll::Ready(Err(_)) = runtime.poll_event_loop(cx, Default::default())
+    {
       unreachable!();
     }
     Poll::Ready(())

--- a/core/runtime/tests/jsrealm.rs
+++ b/core/runtime/tests/jsrealm.rs
@@ -66,7 +66,7 @@ fn test_set_format_exception_callback_realms() {
         )
         .unwrap();
 
-      let result = futures::executor::block_on(runtime.run_event_loop(false));
+      let result = futures::executor::block_on(runtime.run_event_loop(Default::default()));
       assert!(result.is_err());
       let error = result.unwrap_err().downcast::<error::JsError>().unwrap();
       assert_eq!(
@@ -101,7 +101,7 @@ async fn js_realm_ref_unref_ops() {
         r#"var promise =Deno.core.opAsync("op_pending")"#,
       )
       .unwrap();
-    assert!(matches!(runtime.poll_event_loop(cx, false), Poll::Pending));
+    assert!(matches!(runtime.poll_event_loop(cx, Default::default()), Poll::Pending));
 
     main_realm
       .execute_script_static(
@@ -114,7 +114,7 @@ async fn js_realm_ref_unref_ops() {
       .unwrap();
 
     assert!(matches!(
-      runtime.poll_event_loop(cx, false),
+      runtime.poll_event_loop(cx, Default::default()),
       Poll::Ready(Ok(()))
     ));
     Poll::Ready(())

--- a/core/runtime/tests/jsrealm.rs
+++ b/core/runtime/tests/jsrealm.rs
@@ -66,7 +66,8 @@ fn test_set_format_exception_callback_realms() {
         )
         .unwrap();
 
-      let result = futures::executor::block_on(runtime.run_event_loop(Default::default()));
+      let result =
+        futures::executor::block_on(runtime.run_event_loop(Default::default()));
       assert!(result.is_err());
       let error = result.unwrap_err().downcast::<error::JsError>().unwrap();
       assert_eq!(
@@ -101,7 +102,10 @@ async fn js_realm_ref_unref_ops() {
         r#"var promise =Deno.core.opAsync("op_pending")"#,
       )
       .unwrap();
-    assert!(matches!(runtime.poll_event_loop(cx, Default::default()), Poll::Pending));
+    assert!(matches!(
+      runtime.poll_event_loop(cx, Default::default()),
+      Poll::Pending
+    ));
 
     main_realm
       .execute_script_static(

--- a/core/runtime/tests/misc.rs
+++ b/core/runtime/tests/misc.rs
@@ -107,7 +107,8 @@ async fn test_wakers_for_async_ops() {
   // Drain events until we get to Ready
   loop {
     logging_waker.woken.store(false, Ordering::SeqCst);
-    let res = runtime.poll_event_loop(&mut Context::from_waker(&waker), Default::default());
+    let res = runtime
+      .poll_event_loop(&mut Context::from_waker(&waker), Default::default());
     let ready = matches!(res, Poll::Ready(Ok(())));
     assert!(ready || logging_waker.woken.load(Ordering::SeqCst));
     if ready {
@@ -431,7 +432,8 @@ async fn test_serialize_deserialize() {
         include_ascii_string!("serialize_deserialize_test.js"),
       )
       .unwrap();
-    if let Poll::Ready(Err(_)) = runtime.poll_event_loop(cx, Default::default()) {
+    if let Poll::Ready(Err(_)) = runtime.poll_event_loop(cx, Default::default())
+    {
       unreachable!();
     }
     Poll::Ready(())
@@ -765,15 +767,27 @@ fn test_has_tick_scheduled() {
   let waker = futures::task::waker(Arc::new(ArcWakeImpl(awoken_times.clone())));
   let cx = &mut Context::from_waker(&waker);
 
-  assert!(matches!(runtime.poll_event_loop(cx, Default::default()), Poll::Pending));
+  assert!(matches!(
+    runtime.poll_event_loop(cx, Default::default()),
+    Poll::Pending
+  ));
   assert_eq!(1, MACROTASK.load(Ordering::Relaxed));
   assert_eq!(1, NEXT_TICK.load(Ordering::Relaxed));
   assert_eq!(awoken_times.swap(0, Ordering::Relaxed), 1);
-  assert!(matches!(runtime.poll_event_loop(cx, Default::default()), Poll::Pending));
+  assert!(matches!(
+    runtime.poll_event_loop(cx, Default::default()),
+    Poll::Pending
+  ));
   assert_eq!(awoken_times.swap(0, Ordering::Relaxed), 1);
-  assert!(matches!(runtime.poll_event_loop(cx, Default::default()), Poll::Pending));
+  assert!(matches!(
+    runtime.poll_event_loop(cx, Default::default()),
+    Poll::Pending
+  ));
   assert_eq!(awoken_times.swap(0, Ordering::Relaxed), 1);
-  assert!(matches!(runtime.poll_event_loop(cx, Default::default()), Poll::Pending));
+  assert!(matches!(
+    runtime.poll_event_loop(cx, Default::default()),
+    Poll::Pending
+  ));
   assert_eq!(awoken_times.swap(0, Ordering::Relaxed), 1);
 
   runtime
@@ -829,7 +843,10 @@ async fn test_unhandled_rejection_order() {
       "#,
     )
     .unwrap();
-  let err = runtime.run_event_loop(Default::default()).await.unwrap_err();
+  let err = runtime
+    .run_event_loop(Default::default())
+    .await
+    .unwrap_err();
   assert_eq!(err.to_string(), "Uncaught (in promise) 0");
 }
 
@@ -973,7 +990,10 @@ async fn test_stalled_tla() {
   #[allow(clippy::let_underscore_future)]
   let _ = runtime.mod_evaluate(module_id);
 
-  let error = runtime.run_event_loop(Default::default()).await.unwrap_err();
+  let error = runtime
+    .run_event_loop(Default::default())
+    .await
+    .unwrap_err();
   let js_error = error.downcast::<JsError>().unwrap();
   assert_eq!(
     &js_error.exception_message,
@@ -1024,7 +1044,10 @@ async fn test_dynamic_import_module_error_stack() {
   #[allow(clippy::let_underscore_future)]
   let _ = runtime.mod_evaluate(module_id);
 
-  let error = runtime.run_event_loop(Default::default()).await.unwrap_err();
+  let error = runtime
+    .run_event_loop(Default::default())
+    .await
+    .unwrap_err();
   let js_error = error.downcast::<JsError>().unwrap();
   assert_eq!(
     js_error.to_string(),

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -55,7 +55,7 @@ async fn test_async_opstate_borrow() {
       "Deno.core.opAsync(\"op_async_borrow\")",
     )
     .unwrap();
-  runtime.run_event_loop(false).await.unwrap();
+  runtime.run_event_loop(Default::default()).await.unwrap();
 }
 
 #[tokio::test]
@@ -97,7 +97,7 @@ lines: {
 "#,
     )
     .unwrap();
-  runtime.run_event_loop(false).await.unwrap();
+  runtime.run_event_loop(Default::default()).await.unwrap();
 }
 
 #[tokio::test]
@@ -140,7 +140,7 @@ lines: {
 "#,
     )
     .unwrap();
-  runtime.run_event_loop(false).await.unwrap();
+  runtime.run_event_loop(Default::default()).await.unwrap();
 }
 
 #[test]
@@ -560,7 +560,7 @@ await op_void_async_deferred();
       maybe_result
     }
 
-    event_loop_result = runtime.run_event_loop(false) => {
+    event_loop_result = runtime.run_event_loop(Default::default()) => {
       event_loop_result.unwrap();
 
       rx.await

--- a/core/runtime/tests/snapshot.rs
+++ b/core/runtime/tests/snapshot.rs
@@ -152,7 +152,8 @@ fn es_snapshot() {
 
     #[allow(clippy::let_underscore_future)]
     let _ = runtime.mod_evaluate(id);
-    futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
+    futures::executor::block_on(runtime.run_event_loop(Default::default()))
+      .unwrap();
 
     ModuleInfo {
       id,
@@ -191,7 +192,8 @@ fn es_snapshot() {
 
   #[allow(clippy::let_underscore_future)]
   let _ = runtime.mod_evaluate(id);
-  futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
+  futures::executor::block_on(runtime.run_event_loop(Default::default()))
+    .unwrap();
 
   let mut modules = vec![];
   modules.push(ModuleInfo {

--- a/core/runtime/tests/snapshot.rs
+++ b/core/runtime/tests/snapshot.rs
@@ -152,7 +152,7 @@ fn es_snapshot() {
 
     #[allow(clippy::let_underscore_future)]
     let _ = runtime.mod_evaluate(id);
-    futures::executor::block_on(runtime.run_event_loop(false)).unwrap();
+    futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
 
     ModuleInfo {
       id,
@@ -191,7 +191,7 @@ fn es_snapshot() {
 
   #[allow(clippy::let_underscore_future)]
   let _ = runtime.mod_evaluate(id);
-  futures::executor::block_on(runtime.run_event_loop(false)).unwrap();
+  futures::executor::block_on(runtime.run_event_loop(Default::default())).unwrap();
 
   let mut modules = vec![];
   modules.push(ModuleInfo {

--- a/testing/checkin/runner/mod.rs
+++ b/testing/checkin/runner/mod.rs
@@ -89,7 +89,7 @@ async fn run_integration_test_task(
   let module = runtime.load_main_module(&url, None).await?;
   let f = runtime.mod_evaluate(module);
   runtime
-    .run_event_loop2(PollEventLoopOptions {
+    .run_event_loop(PollEventLoopOptions {
       pump_v8_message_loop: true,
       wait_for_inspector: false,
     })
@@ -130,7 +130,7 @@ async fn run_unit_test_task(
   let module = runtime.load_main_module(&url, None).await?;
   let f = runtime.mod_evaluate(module);
   runtime
-    .run_event_loop2(PollEventLoopOptions {
+    .run_event_loop(PollEventLoopOptions {
       pump_v8_message_loop: true,
       wait_for_inspector: false,
     })
@@ -142,7 +142,7 @@ async fn run_unit_test_task(
     println!("Testing {name}...");
     runtime.call_and_await(&function).await?;
     runtime
-      .run_event_loop2(PollEventLoopOptions {
+      .run_event_loop(PollEventLoopOptions {
         pump_v8_message_loop: true,
         wait_for_inspector: false,
       })


### PR DESCRIPTION
This commit removes "old" event loop polling methods in favor
of "new" ones - now all methods for polling the event loop require
explicit "PollEventLoopOptions" option instead of accepting
a single bool.