### PR TITLE
feat: Add RuntimeOptions::wait_for_inspector_disconnect_callback

### DIFF
--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -346,7 +346,8 @@ pub struct JsRuntimeState {
   pub(crate) op_state: Rc<RefCell<OpState>>,
   pub(crate) shared_array_buffer_store: Option<SharedArrayBufferStore>,
   pub(crate) compiled_wasm_module_store: Option<CompiledWasmModuleStore>,
-  wait_for_inspector_disconnect_callback: Option<WaitForInspectorDisconnectCallback>,
+  wait_for_inspector_disconnect_callback:
+    Option<WaitForInspectorDisconnectCallback>,
   /// The error that was passed to a `reportUnhandledException` call.
   /// It will be retrieved by `exception_to_err_result` and used as an error
   /// instead of any other exceptions.
@@ -491,12 +492,13 @@ pub struct RuntimeOptions {
   pub import_meta_resolve_callback: Option<ImportMetaResolveCallback>,
 
   /// A callback that is called when the event loop has no more work to do,
-  /// but there are active, non-blocking inspector session (eg. Chrome 
+  /// but there are active, non-blocking inspector session (eg. Chrome
   /// DevTools inspector is connected). The embedder can use this callback
   /// to eg. print a message notifying user about program finished running.
   /// This callback can be called multiple times, eg. after the program finishes
   /// more work can be scheduled from the DevTools.
-  pub wait_for_inspector_disconnect_callback: Option<WaitForInspectorDisconnectCallback>, 
+  pub wait_for_inspector_disconnect_callback:
+    Option<WaitForInspectorDisconnectCallback>,
 }
 
 impl RuntimeOptions {
@@ -657,7 +659,8 @@ impl JsRuntime {
       source_map_cache: Default::default(),
       shared_array_buffer_store: options.shared_array_buffer_store,
       compiled_wasm_module_store: options.compiled_wasm_module_store,
-      wait_for_inspector_disconnect_callback: options.wait_for_inspector_disconnect_callback,
+      wait_for_inspector_disconnect_callback: options
+        .wait_for_inspector_disconnect_callback,
       op_state: op_state.clone(),
       // Some fields are initialized later after isolate is created
       inspector: None.into(),
@@ -900,11 +903,16 @@ impl JsRuntime {
 
   #[inline]
   pub fn wait_for_inspector_disconnect(&mut self) {
-    if let Some(callback) = self.inner.state.wait_for_inspector_disconnect_callback.as_ref() {
+    if let Some(callback) = self
+      .inner
+      .state
+      .wait_for_inspector_disconnect_callback
+      .as_ref()
+    {
       callback();
     }
   }
-  
+
   /// Returns the extensions that this runtime is using (including internal ones).
   pub fn extensions(&self) -> &Vec<Extension> {
     &self.extensions


### PR DESCRIPTION
This commit adds "RuntimeOptions::wait_for_inspector_disconnect_callback"
that allows to pass a callback that will be called when the event loop runs out of
work, but there are active, non-blocking inspector sessions - that is sessions
from "Chrome DevTools". This allows to print a message notifying user that
the program has finished, but is waiting for DevTools to disconnect to exit
the process.

PR in `deno`: https://github.com/denoland/deno/pull/21633