### PR TITLE
feat(core): remove ops from core.ops when using ensureFastOps

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -740,17 +740,25 @@
     setUpAsyncStub(opName);
   }
 
-  function ensureFastOps() {
+  function ensureFastOps(keep) {
     return new Proxy({}, {
       get(_target, opName) {
         if (ops[opName] === undefined) {
-          throw new Error(`Unknown or disabled op '${opName}'`);
+          ops.op_panic(`Unknown or disabled op '${opName}'`);
         }
+        let op;
         if (asyncOps[opName] !== undefined) {
-          return setUpAsyncStub(opName);
+          op = setUpAsyncStub(opName);
+          if (keep !== true) {
+            delete asyncOps[opName];
+          }
         } else {
-          return ops[opName];
+          op = ops[opName];
+          if (keep !== true) {
+            delete ops[opName];
+          }
         }
+        return op;
       },
     });
   }
@@ -766,7 +774,7 @@
     op_read_sync: readSync,
     op_write_sync: writeSync,
     op_shutdown: shutdown,
-  } = ensureFastOps();
+  } = ensureFastOps(true);
 
   const callSiteRetBuf = new Uint32Array(2);
   const callSiteRetBufU8 = new Uint8Array(callSiteRetBuf.buffer);

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -45,6 +45,7 @@ deno_core::extension!(
     op_format_file_name,
     op_is_proxy,
     op_str_byte_length,
+    op_panic,
     ops_builtin_v8::op_timer_queue,
     ops_builtin_v8::op_timer_cancel,
     ops_builtin_v8::op_timer_ref,
@@ -81,6 +82,12 @@ deno_core::extension!(
     ops_builtin_v8::op_arraybuffer_was_detached,
   ],
 );
+
+#[op2(fast)]
+pub fn op_panic(#[string] message: String) {
+  eprintln!("JS PANIC: {}", message);
+  panic!("JS PANIC: {}", message);
+}
 
 /// Return map of resources with id as key
 /// and string representation as value.


### PR DESCRIPTION
In preparation for https://github.com/denoland/deno_core/issues/223, start ensuring exclusive imports of ops in modules.

We have a fair bit of work to migrate ops to ensureFastOps which is similar in style to the eventual op import design that it will be the majority of the work.