### PR TITLE
fix(ops): support returning non-`anyhow` `Result` from fast sync op

### DIFF
--- a/ops/op2/README.md
+++ b/ops/op2/README.md
@@ -15,6 +15,12 @@ string. At this time there is no way to avoid this copy, though the `op` code
 does attempt to avoid any allocations where possible by making use of a stack
 buffer.
 
+## Fallible `op`s
+
+An `op` function may be declared to return `Result` to indicate that the `op` is
+fallible. The error type must implement `Into<anyhow::Error>`. When the function
+returns `Err`, an exception is thrown.
+
 ## `async` calls
 
 Asynchronous calls are supported in two forms:

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -334,6 +334,8 @@ pub(crate) fn generate_fast_result_early_exit(
     let #result = match #result {
       Ok(#result) => #result,
       Err(err) => {
+        let err = err.into();
+
         // FASTCALL FALLBACK: This is where we set the errors for the slow-call error pickup path. There
         // is no code running between this and the other FASTCALL FALLBACK comment, except some V8 code
         // required to perform the fallback process. This is why the below call is safe.

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -87,6 +87,7 @@ impl op_bool {
         let result = match result {
             Ok(result) => result,
             Err(err) => {
+                let err = err.into();
                 unsafe {
                     opctx.unsafely_set_last_error_for_ops_only(err);
                 }

--- a/ops/op2/test_cases/sync/result_external.out
+++ b/ops/op2/test_cases/sync/result_external.out
@@ -82,6 +82,7 @@ impl op_external_with_result {
         let result = match result {
             Ok(result) => result,
             Err(err) => {
+                let err = err.into();
                 unsafe {
                     opctx.unsafely_set_last_error_for_ops_only(err);
                 }

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -82,6 +82,7 @@ impl op_u32_with_result {
         let result = match result {
             Ok(result) => result,
             Err(err) => {
+                let err = err.into();
                 unsafe {
                     opctx.unsafely_set_last_error_for_ops_only(err);
                 }

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -82,6 +82,7 @@ impl op_void_with_result {
         let result = match result {
             Ok(result) => result,
             Err(err) => {
+                let err = err.into();
                 unsafe {
                     opctx.unsafely_set_last_error_for_ops_only(err);
                 }
@@ -170,7 +171,7 @@ impl op_void_with_result {
         }
     }
     #[inline(always)]
-    pub fn call() -> Result<(), AnyError> {
+    pub fn call() -> std::io::Result<()> {
         Ok(())
     }
 }

--- a/ops/op2/test_cases/sync/result_void.rs
+++ b/ops/op2/test_cases/sync/result_void.rs
@@ -2,9 +2,7 @@
 #![deny(warnings)]
 deno_ops_compile_test_runner::prelude!();
 
-use deno_core::error::AnyError;
-
 #[op2(fast)]
-pub fn op_void_with_result() -> Result<(), AnyError> {
+pub fn op_void_with_result() -> std::io::Result<()> {
     Ok(())
 }


### PR DESCRIPTION
```rs
// compiles
#[op2]
pub fn op_slow_anyhow_result(_: &mut v8::HandleScope) -> anyhow::Result<()> {
    Ok(())
}

// compiles
#[op2(fast)]
pub fn op_fast_anyhow_result() -> anyhow::Result<()> {
    Ok(())
}

// compiles
#[op2]
pub fn op_slow_std_io_result(_: &mut v8::HandleScope) -> std::io::Result<()> {
    Ok(())
}

// does not compile (fixed by this PR)
#[op2(fast)]
pub fn op_fast_std_io_result() -> std::io::Result<()> {
    Ok(())
}
```
