### PR TITLE
Revert "Upgrade rusty_v8 to 0.83.0 (#424)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "fslock"
-version = "0.2.1"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+checksum = "57eafdd0c16f57161105ae1b98a1238f97645f2f588438b2949c99a2af9616bf"
 dependencies = [
  "libc",
  "winapi",
@@ -1973,11 +1973,11 @@ checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 
 [[package]]
 name = "v8"
-version = "0.83.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e75d086d61663d00e3985fead069245600fddcc0b1318d36b2950a358e3c88"
+checksum = "f53dfb242f4c0c39ed3fc7064378a342e57b5c9bd774636ad34ffe405b808121"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 1.3.2",
  "fslock",
  "once_cell",
  "which",
@@ -1997,15 +1997,14 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "which"
-version = "5.0.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
  "either",
  "home",
  "once_cell",
  "rustix",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ deno_core = { version = "0.243.0", path = "./core" }
 deno_ops = { version = "0.119.0", path = "./ops" }
 serde_v8 = { version = "0.152.0", path = "./serde_v8" }
 
-v8 = { version = "0.83.0", default-features = false }
+v8 = { version = "0.82.0", default-features = false }
 deno_ast = { version = "1.0.0", features = ["transpiling"] }
 deno_unsync = "0.3.2"
 

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -378,6 +378,7 @@ fn v8_init(
     " --harmony-import-attributes",
     " --no-validate-asm",
     " --turbo_fast_api_calls",
+    " --harmony-change-array-by-copy",
     " --harmony-array-from_async",
     " --harmony-iterator-helpers",
   );


### PR DESCRIPTION
This reverts commit 492ffd836e930c237817c9b9a4fbc410570bff86.

This update started causing problems in globals handling in "deno".