### PR TITLE
feat: Add JsRuntime::custom_module_evaluation_cb to support arbitrary module types

### DIFF
--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -121,6 +121,17 @@ pub(crate) fn default_import_meta_resolve_cb(
 pub type ValidateImportAttributesCb =
   Box<dyn Fn(&mut v8::HandleScope, &HashMap<String, String>)>;
 
+/// Callback to validate import attributes. If the validation fails and exception
+/// should be thrown using `scope.throw_exception()`.
+pub type CustomModuleEvaluationCb = Box<
+  dyn Fn(
+    &mut v8::HandleScope,
+    Cow<'_, str>,
+    &FastString,
+    ModuleSourceCode,
+  ) -> Result<v8::Global<v8::Value>, AnyError>,
+>;
+
 #[derive(Debug)]
 pub(crate) enum ImportAttributesKind {
   StaticImport,
@@ -177,15 +188,15 @@ pub(crate) fn get_requested_module_type_from_attributes(
 
 /// A type of module to be executed.
 ///
-/// For non-`JavaScript` modules, this value doesn't tell
-/// how to interpret the module; it is only used to validate
-/// the module against an import assertion (if one is present
-/// in the import statement).
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+/// `deno_core` supports loading and executing JavaScript and JSON modules,
+/// by default, but embedders can customize it further by providing
+/// [`CustomModuleEvaluationCb`].
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[repr(u32)]
 pub enum ModuleType {
   JavaScript,
   Json,
+  Other(Cow<'static, str>),
 }
 
 impl std::fmt::Display for ModuleType {
@@ -193,6 +204,7 @@ impl std::fmt::Display for ModuleType {
     match self {
       Self::JavaScript => write!(f, "JavaScript"),
       Self::Json => write!(f, "JSON"),
+      Self::Other(ty) => write!(f, "{}", ty),
     }
   }
 }
@@ -379,11 +391,13 @@ impl AsRef<RequestedModuleType> for RequestedModuleType {
   }
 }
 
+// TODO(bartlomieju): this is questionable. I think we should remove it.
 impl PartialEq<ModuleType> for RequestedModuleType {
   fn eq(&self, other: &ModuleType) -> bool {
     match other {
       ModuleType::JavaScript => self == &RequestedModuleType::None,
       ModuleType::Json => self == &RequestedModuleType::Json,
+      ModuleType::Other(ty) => self == &RequestedModuleType::Other(ty.clone()),
     }
   }
 }
@@ -393,6 +407,7 @@ impl From<ModuleType> for RequestedModuleType {
     match module_type {
       ModuleType::JavaScript => RequestedModuleType::None,
       ModuleType::Json => RequestedModuleType::Json,
+      ModuleType::Other(ty) => RequestedModuleType::Other(ty.clone()),
     }
   }
 }

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -17,6 +17,7 @@ use crate::include_js_files;
 use crate::inspector::JsRuntimeInspector;
 use crate::module_specifier::ModuleSpecifier;
 use crate::modules::default_import_meta_resolve_cb;
+use crate::modules::CustomModuleEvaluationCb;
 use crate::modules::ExtModuleLoader;
 use crate::modules::ImportMetaResolveCallback;
 use crate::modules::ModuleCodeString;
@@ -352,6 +353,7 @@ pub struct JsRuntimeState {
   wait_for_inspector_disconnect_callback:
     Option<WaitForInspectorDisconnectCallback>,
   pub(crate) validate_import_attributes_cb: Option<ValidateImportAttributesCb>,
+  pub(crate) custom_module_evaluation_cb: Option<CustomModuleEvaluationCb>,
   waker: Arc<AtomicWaker>,
   /// Accessed through [`JsRuntimeState::with_inspector`].
   inspector: RefCell<Option<Rc<RefCell<JsRuntimeInspector>>>>,
@@ -503,6 +505,10 @@ pub struct RuntimeOptions {
   /// more work can be scheduled from the DevTools.
   pub wait_for_inspector_disconnect_callback:
     Option<WaitForInspectorDisconnectCallback>,
+
+  /// A callback that allows to evaluate a custom type of a module - eg.
+  /// embedders might implement loading WASM or test modules.
+  pub custom_module_evaluation_cb: Option<CustomModuleEvaluationCb>,
 }
 
 impl RuntimeOptions {
@@ -666,6 +672,7 @@ impl JsRuntime {
       inspector: None.into(),
       has_inspector: false.into(),
       validate_import_attributes_cb: options.validate_import_attributes_cb,
+      custom_module_evaluation_cb: options.custom_module_evaluation_cb,
       waker,
     });
 


### PR DESCRIPTION
This commit adds "JsRuntime::custom_module_evaluation_cb" as well as "ModuleType::Other"
that allow embedders to customize and support more module types (like WASM, test or bytes).

If no callback is provided and a "ModuleType::Other" is loaded then an error is returned.

Ref https://github.com/denoland/deno_core/pull/402.