### PR TITLE
refactor: Add ModuleMap::new_module_from_js_source

### DIFF
--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -1312,14 +1312,7 @@ impl ModuleMap {
     let specifier = ModuleSpecifier::parse(module_specifier)?;
     let mod_id = self
       .new_es_module(scope, false, specifier.into(), source_code, false)
-      .map_err(|e| match e {
-        ModuleError::Exception(exception) => {
-          let exception = v8::Local::new(scope, exception);
-          exception_to_err_result::<()>(scope, exception, false, true)
-            .unwrap_err()
-        }
-        ModuleError::Other(error) => error,
-      })?;
+      .map_err(|e| e.into_any_error(scope, false, true))?;
 
     self.instantiate_module(scope, mod_id).map_err(|e| {
       let exception = v8::Local::new(scope, e);

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -450,6 +450,115 @@ impl ModuleMap {
     Ok(id)
   }
 
+  /// Create and compile an ES module.
+  pub(crate) fn new_new_module(
+    &self,
+    scope: &mut v8::HandleScope,
+    main: bool,
+    name: ModuleName,
+    source: ModuleCodeString,
+    is_dynamic_import: bool,
+  ) -> Result<ModuleId, ModuleError> {
+    if main {
+      let data = self.data.borrow();
+      if let Some(main_module) = data.main_module_id {
+        let main_name = self.data.borrow().get_name_by_id(main_module).unwrap();
+        return Err(ModuleError::Other(generic_error(
+          format!("Trying to create \"main\" module ({:?}), when one already exists ({:?})",
+          name.as_ref(),
+          main_name,
+        ))));
+      }
+    }
+
+    let name_str = name.v8(scope);
+    let source_str = source.v8(scope);
+
+    let origin = module_origin(scope, name_str);
+    let source = v8::script_compiler::Source::new(source_str, Some(&origin));
+
+    let tc_scope = &mut v8::TryCatch::new(scope);
+
+    let maybe_module = v8::script_compiler::compile_module(tc_scope, source);
+
+    if tc_scope.has_caught() {
+      assert!(maybe_module.is_none());
+      let exception = tc_scope.exception().unwrap();
+      let exception = v8::Global::new(tc_scope, exception);
+      return Err(ModuleError::Exception(exception));
+    }
+
+    let module = maybe_module.unwrap();
+
+    let mut requests: Vec<ModuleRequest> = vec![];
+    let module_requests = module.get_module_requests();
+    for i in 0..module_requests.length() {
+      let module_request = v8::Local::<v8::ModuleRequest>::try_from(
+        module_requests.get(tc_scope, i).unwrap(),
+      )
+      .unwrap();
+      let import_specifier = module_request
+        .get_specifier()
+        .to_rust_string_lossy(tc_scope);
+
+      let import_attributes = module_request.get_import_assertions();
+
+      let attributes = parse_import_attributes(
+        tc_scope,
+        import_attributes,
+        ImportAttributesKind::StaticImport,
+      );
+
+      // FIXME(bartomieju): there are no stack frames if exception
+      // is thrown here
+      {
+        let state = JsRuntime::state_from(tc_scope);
+        if let Some(validate_import_attributes_cb) =
+          &state.validate_import_attributes_cb
+        {
+          (validate_import_attributes_cb)(tc_scope, &attributes);
+        }
+      }
+
+      if tc_scope.has_caught() {
+        let exception = tc_scope.exception().unwrap();
+        let exception = v8::Global::new(tc_scope, exception);
+        return Err(ModuleError::Exception(exception));
+      }
+
+      let module_specifier = match self.resolve(
+        &import_specifier,
+        name.as_ref(),
+        if is_dynamic_import {
+          ResolutionKind::DynamicImport
+        } else {
+          ResolutionKind::Import
+        },
+      ) {
+        Ok(s) => s,
+        Err(e) => return Err(ModuleError::Other(e)),
+      };
+      let requested_module_type =
+        get_requested_module_type_from_attributes(&attributes);
+      let request = ModuleRequest {
+        specifier: module_specifier.to_string(),
+        requested_module_type,
+      };
+      requests.push(request);
+    }
+
+    let handle = v8::Global::<v8::Module>::new(tc_scope, module);
+    let id = self.data.borrow_mut().create_module_info(
+      name,
+      ModuleType::JavaScript,
+      handle,
+      main,
+      requests,
+    );
+
+    Ok(id)
+  }
+
   pub(crate) fn new_json_module(
     &self,
     scope: &mut v8::HandleScope,


### PR DESCRIPTION
This commit adds "ModuleMap::new_module_from_js_source" method.

This method is pretty much the same as "ModuleMap::new_es_module", but allows to customize the 
type of the module - ie. it allows to create a module from JS source with any type - this allows for "shim"
modules. One might create a JS "shim" that acts as a proxy to a WASM module.

A drive by cleanup of "ModuleError" was done as well.

Ref https://github.com/denoland/deno_core/pull/402