### PR TITLE
feat: add 'requested_module_type' to ModuleLoader::load

### DIFF
--- a/core/examples/ts_module_loader.rs
+++ b/core/examples/ts_module_loader.rs
@@ -26,6 +26,7 @@ use deno_core::ModuleSourceCode;
 use deno_core::ModuleSourceFuture;
 use deno_core::ModuleSpecifier;
 use deno_core::ModuleType;
+use deno_core::RequestedModuleType;
 use deno_core::ResolutionKind;
 use deno_core::RuntimeOptions;
 use deno_core::SourceMapGetter;
@@ -67,6 +68,7 @@ impl ModuleLoader for TypescriptModuleLoader {
     module_specifier: &ModuleSpecifier,
     _maybe_referrer: Option<&ModuleSpecifier>,
     _is_dyn_import: bool,
+    _requested_module_type: RequestedModuleType,
   ) -> Pin<Box<ModuleSourceFuture>> {
     let source_maps = self.source_maps.clone();
     fn load(

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -101,6 +101,7 @@ pub use crate::modules::ModuleSourceCode;
 pub use crate::modules::ModuleSourceFuture;
 pub use crate::modules::ModuleType;
 pub use crate::modules::NoopModuleLoader;
+pub use crate::modules::RequestedModuleType;
 pub use crate::modules::ResolutionKind;
 pub use crate::modules::StaticModuleLoader;
 pub use crate::modules::ValidateImportAttributesCb;

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -1459,7 +1459,9 @@ impl ModuleMap {
 
     let specifier = ModuleSpecifier::parse(module_specifier)?;
     let source = futures::executor::block_on(async {
-      loader.load(&specifier, None, false).await
+      loader
+        .load(&specifier, None, false, RequestedModuleType::None)
+        .await
     })?;
 
     self.lazy_load_es_module_from_code(

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -279,6 +279,12 @@ impl ModuleMap {
       module_url_specified
     };
 
+    // TODO(bartlomieju): I have a hunch that this is wrong - write a test
+    // that tries to "confuse" the type system, by first requesting a module
+    // with type `RequestedModuleType::Other("foo".into)``, and then the loader
+    // actually returns `ModuleType::Other("bar".into())`. See if it leads to
+    // unexpected result in how `ModuleMap` is structured and verify how
+    // querying the module map works (`ModuleMap::get_by_id`, `ModuleMap::get_by_name`).
     let requested_module_type = RequestedModuleType::from(module_type.clone());
     let maybe_module_id = self.get_id(&module_url_found, requested_module_type);
 

--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -340,17 +340,41 @@ pub enum ResolutionKind {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[repr(u8)]
-pub(crate) enum RequestedModuleType {
+pub enum RequestedModuleType {
   /// There was no attribute specified in the import statement.
+  ///
+  /// Example:
+  /// ```ignore
+  /// import foo from "./foo.js";
+  ///
+  /// const bar = await import("bar");
+  /// ```
   None,
 
-  /// `type` attribute had value `json`. This is the only known module type
-  /// in `deno_core`. Embedders should use `Other` variant for custom module
+  /// The `type` attribute had value `json`. This is the only known module type
+  /// in `deno_core`.
+  ///
+  /// Embedders should use `Other` variant for custom module
   /// types like `wasm`, `bytes` or `text`.
+  ///
+  /// Example:
+  /// ```ignore
+  /// import jsonData from "./data.json" with { type: "json" };
+  ///
+  /// const jsonData2 = await import"./data2.json", { with { type: "json" } });
+  /// ```
   Json,
 
-  // IMPORTANT: If you add any additional enum values here, you must update `to_v8`` below!
-  /// Non-well-known module type.
+  /// An arbitrary module type. It is up to the embedder to handle (or deny) it.
+  /// If [`CustomModuleEvaluationCb`] was not passed when creating a runtime,
+  /// then all "other" module types cause an error to be returned.
+  ///
+  /// Example:
+  /// ```ignore
+  /// import text from "./log.txt" with { type: "text" };
+  ///
+  /// const imgData = await import(`./images/${name}.png`, { with: { type: "bytes" }});
+  /// ```
   Other(Cow<'static, str>),
 }
 

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -239,6 +239,7 @@ impl ModuleLoader for MockLoader {
     module_specifier: &ModuleSpecifier,
     _maybe_referrer: Option<&ModuleSpecifier>,
     _is_dyn_import: bool,
+    _requested_module_type: RequestedModuleType,
   ) -> Pin<Box<ModuleSourceFuture>> {
     let mut loads = self.loads.lock();
     loads.push(module_specifier.to_string());
@@ -1438,6 +1439,7 @@ async fn no_duplicate_loads() {
       module_specifier: &ModuleSpecifier,
       _maybe_referrer: Option<&ModuleSpecifier>,
       _is_dyn_import: bool,
+      _requested_module_type: RequestedModuleType,
     ) -> Pin<Box<ModuleSourceFuture>> {
       let found_specifier =
         if module_specifier.as_str() == "https://example.com/foo.js" {

--- a/testing/checkin/runner/ts_module_loader.rs
+++ b/testing/checkin/runner/ts_module_loader.rs
@@ -21,6 +21,7 @@ use deno_core::ModuleSourceCode;
 use deno_core::ModuleSourceFuture;
 use deno_core::ModuleSpecifier;
 use deno_core::ModuleType;
+use deno_core::RequestedModuleType;
 use deno_core::ResolutionKind;
 use deno_core::SourceMapGetter;
 
@@ -63,6 +64,7 @@ impl ModuleLoader for TypescriptModuleLoader {
     module_specifier: &ModuleSpecifier,
     _maybe_referrer: Option<&ModuleSpecifier>,
     _is_dyn_import: bool,
+    _requested_module_type: RequestedModuleType,
   ) -> Pin<Box<ModuleSourceFuture>> {
     let source_maps = self.source_maps.clone();
     fn load(


### PR DESCRIPTION
This commit adds additional argument to "ModuleLoader::load" method that
is "RequestedModuleType". This argument can be used by the embedder to 
decide if the loaded module should be refused (eg. trying to load a module
with type "json", but the actual MIME type is not "application/json").

In a follow up I might extract `is_dyn_import` and `requested_module_type`
into a helper struct (maybe `LoadMetadata`).

Ref https://github.com/denoland/deno_core/pull/402