### PR TITLE
feat: Change CustomModuleEvaluationCb to return an enum

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -90,6 +90,7 @@ pub use crate::module_specifier::resolve_url;
 pub use crate::module_specifier::resolve_url_or_path;
 pub use crate::module_specifier::ModuleResolutionError;
 pub use crate::module_specifier::ModuleSpecifier;
+pub use crate::modules::CustomModuleEvaluationKind;
 pub use crate::modules::ExtModuleLoaderCb;
 pub use crate::modules::FsModuleLoader;
 pub use crate::modules::ModuleCodeBytes;

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -247,6 +247,11 @@ impl ModuleMap {
   }
 
   #[cfg(test)]
+  pub fn get_data(&self) -> &RefCell<ModuleMapData> {
+    &self.data
+  }
+
+  #[cfg(test)]
   pub fn assert_module_map(&self, modules: &Vec<super::ModuleInfo>) {
     self.data.borrow().assert_module_map(modules);
   }

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -379,7 +379,7 @@ impl ModuleMap {
               main,
               ModuleType::Other(module_type.clone()),
               url2,
-              computed_src.into(),
+              computed_src,
               dynamic,
             )?
           }

--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -145,7 +145,7 @@ pub enum CustomModuleEvaluationKind {
   ///    the source of JS objects - this module is set up first.
   ComputedAndSynthetic(
     // Source code of computed module,
-    String,
+    FastString,
     // Synthetic module value
     v8::Global<v8::Value>,
     // Synthetic module type

--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -130,8 +130,28 @@ pub type CustomModuleEvaluationCb = Box<
     Cow<'_, str>,
     &FastString,
     ModuleSourceCode,
-  ) -> Result<v8::Global<v8::Value>, AnyError>,
+  ) -> Result<CustomModuleEvaluationKind, AnyError>,
 >;
+
+pub enum CustomModuleEvaluationKind {
+  /// This evaluation results in a single, "synthetic" module.
+  Synthetic(v8::Global<v8::Value>),
+
+  /// This evaluation results in creation of two modules:
+  ///  - a "computed" module - some JavaScript that most likely is rendered and
+  ///    uses the "synthetic" module - this module's ID is returned from
+  ///    [`new_module`] call.
+  ///  - a "synthetic" module - a kind of a helper module that abstracts
+  ///    the source of JS objects - this module is set up first.
+  ComputedAndSynthetic(
+    // Source code of computed module,
+    String,
+    // Synthetic module value
+    v8::Global<v8::Value>,
+    // Synthetic module type
+    ModuleType,
+  ),
+}
 
 #[derive(Debug)]
 pub(crate) enum ImportAttributesKind {

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -5,6 +5,7 @@ use crate::error::generic_error;
 use crate::modules::loaders::ModuleLoadEventCounts;
 use crate::modules::loaders::TestingModuleLoader;
 use crate::modules::loaders::*;
+use crate::modules::CustomModuleEvaluationKind;
 use crate::modules::ModuleCodeBytes;
 use crate::modules::ModuleError;
 use crate::modules::ModuleRequest;
@@ -754,7 +755,7 @@ fn test_custom_module_type_callback() {
     module_type: Cow<'_, str>,
     _module_name: &FastString,
     module_code: ModuleSourceCode,
-  ) -> Result<v8::Global<v8::Value>, Error> {
+  ) -> Result<CustomModuleEvaluationKind, Error> {
     if module_type != "bytes" {
       return Err(generic_error(format!(
         "Can't load '{}' module",
@@ -772,7 +773,8 @@ fn test_custom_module_type_callback() {
     let ab = v8::ArrayBuffer::with_backing_store(scope, &backing_store_shared);
     let uint8_array = v8::Uint8Array::new(scope, ab, 0, buf_len).unwrap();
     let value: v8::Local<v8::Value> = uint8_array.into();
-    Ok(v8::Global::new(scope, value))
+    let value_global = v8::Global::new(scope, value);
+    Ok(CustomModuleEvaluationKind::Synthetic(value_global))
   }
 
   let loader = Rc::new(TestingModuleLoader::new(StaticModuleLoader::new([])));

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -8,6 +8,7 @@ use crate::modules::loaders::*;
 use crate::modules::CustomModuleEvaluationKind;
 use crate::modules::ModuleCodeBytes;
 use crate::modules::ModuleError;
+use crate::modules::ModuleInfo;
 use crate::modules::ModuleRequest;
 use crate::modules::ModuleSourceCode;
 use crate::modules::RequestedModuleType;
@@ -749,7 +750,7 @@ fn test_custom_module_type_default() {
 }
 
 #[test]
-fn test_custom_module_type_callback() {
+fn test_custom_module_type_callback_synthetic() {
   fn custom_eval_cb(
     scope: &mut v8::HandleScope,
     module_type: Cow<'_, str>,
@@ -828,6 +829,106 @@ fn test_custom_module_type_callback() {
       )
       .unwrap()
   };
+}
+
+#[test]
+fn test_custom_module_type_callback_computed() {
+  fn custom_eval_cb(
+    scope: &mut v8::HandleScope,
+    module_type: Cow<'_, str>,
+    module_name: &FastString,
+    module_code: ModuleSourceCode,
+  ) -> Result<CustomModuleEvaluationKind, Error> {
+    if module_type != "foobar" {
+      return Err(generic_error(format!(
+        "Can't load '{}' module",
+        module_type
+      )));
+    }
+
+    let buf = match module_code {
+      ModuleSourceCode::Bytes(buf) => buf.to_vec(),
+      ModuleSourceCode::String(str_) => str_.as_bytes().to_vec(),
+    };
+    let buf_len: usize = buf.len();
+    let backing_store = v8::ArrayBuffer::new_backing_store_from_vec(buf);
+    let backing_store_shared = backing_store.make_shared();
+    let ab = v8::ArrayBuffer::with_backing_store(scope, &backing_store_shared);
+    let uint8_array = v8::Uint8Array::new(scope, ab, 0, buf_len).unwrap();
+    let value: v8::Local<v8::Value> = uint8_array.into();
+    let value_global = v8::Global::new(scope, value);
+
+    let computed_src = format!(
+      r#"
+import bytes from "{}" with {{ type: "foobar-synth" }};
+
+export const foo = bytes;
+    "#,
+      module_name.as_str()
+    );
+    Ok(CustomModuleEvaluationKind::ComputedAndSynthetic(
+      computed_src.into(),
+      value_global,
+      ModuleType::Other("foobar-synth".into()),
+    ))
+  }
+
+  let loader = Rc::new(TestingModuleLoader::new(StaticModuleLoader::new([])));
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    module_loader: Some(loader.clone()),
+    custom_module_evaluation_cb: Some(Box::new(custom_eval_cb)),
+    ..Default::default()
+  });
+
+  let module_map = runtime.module_map().clone();
+
+  let mod_id = {
+    let scope = &mut runtime.handle_scope();
+    let specifier_a = ascii_str!("file:///b.png");
+    module_map
+      .new_module(
+        scope,
+        true,
+        false,
+        ModuleSource {
+          code: ModuleSourceCode::Bytes(ModuleCodeBytes::Static(&[])),
+          module_url_found: None,
+          module_url_specified: specifier_a,
+          module_type: ModuleType::Other("foobar".into()),
+        },
+      )
+      .unwrap()
+  };
+
+  let data = module_map.get_data();
+  let data = data.borrow();
+  let info = data.info.get(mod_id).unwrap();
+  assert_eq!(
+    info,
+    &ModuleInfo {
+      id: mod_id,
+      main: true,
+      name: ascii_str!("file:///b.png"),
+      requests: vec![ModuleRequest {
+        specifier: "file:///b.png".to_string(),
+        requested_module_type: RequestedModuleType::Other(
+          "foobar-synth".into()
+        )
+      }],
+      module_type: RequestedModuleType::Other("foobar".into()),
+    }
+  );
+  let info = data.info.get(mod_id - 1).unwrap();
+  assert_eq!(
+    info,
+    &ModuleInfo {
+      id: mod_id - 1,
+      main: false,
+      name: ascii_str!("file:///b.png"),
+      requests: vec![],
+      module_type: RequestedModuleType::Other("foobar-synth".into()),
+    }
+  );
 }
 
 #[tokio::test]


### PR DESCRIPTION
This commit changes "CustomModuleEvaluationCb" to return an enum
that tells how to interpret the return value.

In addition to evaluating the returned value as a synthetic module like before
(using "CustomModuleEvaluationKind::Synthetic"), now users can evaluate a
synthetic module and a "computed" module that uses the synthetic module
(using "CustomModuleEvaluationKind::ComputedAndSynthetic").

Ref https://github.com/denoland/deno_core/pull/402