### PR TITLE
feat(example): add 'text' and 'bytes' imports to fs_module_loader.rs

### DIFF
--- a/core/examples/fs_module_loader.rs
+++ b/core/examples/fs_module_loader.rs
@@ -1,11 +1,74 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+use anyhow::anyhow;
 use anyhow::Context;
 use deno_core::anyhow::Error;
+use deno_core::v8;
+use deno_core::CustomModuleEvaluationKind;
+use deno_core::FastString;
 use deno_core::FsModuleLoader;
 use deno_core::JsRuntime;
+use deno_core::ModuleSourceCode;
 use deno_core::RuntimeOptions;
+use std::borrow::Cow;
 use std::rc::Rc;
+
+fn custom_module_evaluation_cb(
+  scope: &mut v8::HandleScope,
+  module_type: Cow<'_, str>,
+  module_name: &FastString,
+  code: ModuleSourceCode,
+) -> Result<CustomModuleEvaluationKind, Error> {
+  match &*module_type {
+    "bytes" => bytes_module(scope, code),
+    "text" => text_module(scope, module_name, code),
+    _ => Err(anyhow!(
+      "Can't import {:?} because of unknown module type {}",
+      module_name,
+      module_type
+    )),
+  }
+}
+
+fn bytes_module(
+  scope: &mut v8::HandleScope,
+  code: ModuleSourceCode,
+) -> Result<CustomModuleEvaluationKind, Error> {
+  // FsModuleLoader always returns bytes.
+  let ModuleSourceCode::Bytes(buf) = code else {
+    unreachable!()
+  };
+  let owned_buf = buf.to_vec();
+  let buf_len: usize = owned_buf.len();
+  let backing_store = v8::ArrayBuffer::new_backing_store_from_vec(owned_buf);
+  let backing_store_shared = backing_store.make_shared();
+  let ab = v8::ArrayBuffer::with_backing_store(scope, &backing_store_shared);
+  let uint8_array = v8::Uint8Array::new(scope, ab, 0, buf_len).unwrap();
+  let value: v8::Local<v8::Value> = uint8_array.into();
+  Ok(CustomModuleEvaluationKind::Synthetic(v8::Global::new(
+    scope, value,
+  )))
+}
+
+fn text_module(
+  scope: &mut v8::HandleScope,
+  module_name: &FastString,
+  code: ModuleSourceCode,
+) -> Result<CustomModuleEvaluationKind, Error> {
+  // FsModuleLoader always returns bytes.
+  let ModuleSourceCode::Bytes(buf) = code else {
+    unreachable!()
+  };
+
+  let code = std::str::from_utf8(buf.as_bytes()).with_context(|| {
+    format!("Can't convert {:?} source code to string", module_name)
+  })?;
+  let str_ = v8::String::new(scope, code).unwrap();
+  let value: v8::Local<v8::Value> = str_.into();
+  Ok(CustomModuleEvaluationKind::Synthetic(v8::Global::new(
+    scope, value,
+  )))
+}
 
 fn main() -> Result<(), Error> {
   let args: Vec<String> = std::env::args().collect();
@@ -18,6 +81,7 @@ fn main() -> Result<(), Error> {
 
   let mut js_runtime = JsRuntime::new(RuntimeOptions {
     module_loader: Some(Rc::new(FsModuleLoader)),
+    custom_module_evaluation_cb: Some(Box::new(custom_module_evaluation_cb)),
     ..Default::default()
   });
 


### PR DESCRIPTION
A little cleanup and showcase how to wire up custom
module types in the `fs_module_loader.rs` example.

Ref #402 