### PR TITLE
fix: return "Uncaught Error" on terminate_execution() during run_event_loop

### DIFF
--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -2310,9 +2310,9 @@ impl JsRuntime {
     js_event_loop_tick_cb.call(tc_scope, undefined, args.as_slice());
 
     if let Some(exception) = tc_scope.exception() {
-        return exception_to_err_result(tc_scope, exception, false, true);
+      return exception_to_err_result(tc_scope, exception, false, true);
     }
-  
+
     if tc_scope.has_terminated() || tc_scope.is_execution_terminating() {
       return Ok(false);
     }

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -2309,12 +2309,12 @@ impl JsRuntime {
 
     js_event_loop_tick_cb.call(tc_scope, undefined, args.as_slice());
 
+    if let Some(exception) = tc_scope.exception() {
+        return exception_to_err_result(tc_scope, exception, false, true);
+    }
+  
     if tc_scope.has_terminated() || tc_scope.is_execution_terminating() {
       return Ok(false);
-    }
-
-    if let Some(exception) = tc_scope.exception() {
-      return exception_to_err_result(tc_scope, exception, false, true);
     }
 
     Ok(dispatched_ops)

--- a/core/runtime/tests/misc.rs
+++ b/core/runtime/tests/misc.rs
@@ -1236,7 +1236,10 @@ async fn terminate_execution_run_event_loop_js() {
     .execute_script_static("sleep.js", "sleep()")
     .unwrap();
 
-  let err = runtime.run_event_loop(Default::default()).await.unwrap_err();
+  let err = runtime
+    .run_event_loop(Default::default())
+    .await
+    .unwrap_err();
   assert_eq!(err.to_string(), "Uncaught Error: execution terminated");
 
   // Cancel the execution-terminating exception in order to allow script

--- a/core/runtime/tests/misc.rs
+++ b/core/runtime/tests/misc.rs
@@ -1196,3 +1196,58 @@ async fn task_spawner_cross_thread_blocking() {
     assert!(start.elapsed().as_secs() < 60);
   }
 }
+
+#[tokio::test]
+async fn terminate_execution_run_event_loop_js() {
+  #[op2(async)]
+  async fn op_async_sleep() -> Result<(), Error> {
+    tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
+    Ok(())
+  }
+  deno_core::extension!(test_ext, ops = [op_async_sleep]);
+  let mut runtime = JsRuntime::new(RuntimeOptions {
+    extensions: vec![test_ext::init_ops()],
+    ..Default::default()
+  });
+
+  // Create sleep function that waits for 2 seconds.
+  runtime
+    .execute_script_static(
+      "sleep_code.js",
+      r#"
+              const { op_async_sleep } = Deno.core.ensureFastOps(); 
+              async function sleep() {
+                await op_async_sleep();
+              }
+      "#,
+    )
+    .unwrap();
+
+  // Terminate execution after 1 second.
+  let v8_isolate_handle = runtime.v8_isolate().thread_safe_handle();
+  let terminator_thread = std::thread::spawn(move || {
+    std::thread::sleep(std::time::Duration::from_millis(1000));
+    let ok = v8_isolate_handle.terminate_execution();
+    assert!(ok);
+  });
+
+  // Start waiting period of 2 seconds.
+  runtime
+    .execute_script_static("sleep.js", "sleep()")
+    .unwrap();
+
+  let err = runtime.run_event_loop(Default::default()).await.unwrap_err();
+  assert_eq!(err.to_string(), "Uncaught Error: execution terminated");
+
+  // Cancel the execution-terminating exception in order to allow script
+  // execution again.
+  let ok = runtime.v8_isolate().cancel_terminate_execution();
+  assert!(ok);
+
+  // Verify that the isolate usable again.
+  runtime
+    .execute_script_static("simple.js", "1 + 1")
+    .expect("execution should be possible again");
+
+  terminator_thread.join().unwrap();
+}


### PR DESCRIPTION
Fix related to https://github.com/denoland/deno_core/issues/450.

After PR https://github.com/denoland/deno_core/pull/359, `run_event_loop()` stopped returning error `"Uncaught Error: execution terminated"` after `terminate_execution()` is called, instead it returns `Ok(())`.

As [is_execution_terminating()](https://docs.rs/v8/0.82.0/v8/struct.Isolate.html#method.is_execution_terminating) is not flagging the termination after `run_event_loop()` returns, it is not possible to detect the termination and act on it.

This PR restores the previous behavior. 