### PR TITLE
feat: Disabling an op replaces it with a function that throws

### DIFF
--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -132,7 +132,8 @@ impl OpDecl {
     }
   }
 
-  /// Returns a copy of this `OpDecl` with `enabled` set to `false`.
+  /// Returns a copy of this `OpDecl` that replaces underlying functions
+  /// with noops.
   pub fn disable(self) -> Self {
     Self {
       slow_fn: bindings::empty_fn.map_fn_to(),

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -136,8 +136,8 @@ impl OpDecl {
   /// with noops.
   pub fn disable(self) -> Self {
     Self {
-      slow_fn: bindings::empty_fn.map_fn_to(),
-      slow_fn_with_metrics: bindings::empty_fn.map_fn_to(),
+      slow_fn: bindings::op_disabled_fn.map_fn_to(),
+      slow_fn_with_metrics: bindings::op_disabled_fn.map_fn_to(),
       fast_fn: None,
       fast_fn_with_metrics: None,
       ..self

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -24,7 +24,7 @@ pub(crate) fn external_references(
 ) -> v8::ExternalReferences {
   // Overallocate a bit, it's better than having to resize the vector.
   let mut references =
-    Vec::with_capacity(4 + (ops.len() * 4) + additional_references.len());
+    Vec::with_capacity(5 + (ops.len() * 4) + additional_references.len());
 
   references.push(v8::ExternalReference {
     function: call_console.map_fn_to(),
@@ -37,6 +37,9 @@ pub(crate) fn external_references(
   });
   references.push(v8::ExternalReference {
     function: empty_fn.map_fn_to(),
+  });
+  references.push(v8::ExternalReference {
+    function: op_disabled_fn.map_fn_to(),
   });
 
   for ctx in ops {
@@ -493,12 +496,22 @@ fn import_meta_resolve(
   };
 }
 
-pub fn empty_fn(
+fn empty_fn(
   _scope: &mut v8::HandleScope,
   _args: v8::FunctionCallbackArguments,
   _rv: v8::ReturnValue,
 ) {
   //Do Nothing
+}
+
+pub(crate) fn op_disabled_fn(
+  scope: &mut v8::HandleScope,
+  _args: v8::FunctionCallbackArguments,
+  _rv: v8::ReturnValue,
+) {
+  let message = v8::String::new(scope, "op is disabled").unwrap();
+  let exception = v8::Exception::error(scope, message);
+  scope.throw_exception(exception);
 }
 
 //It creates a reference to an empty function which can be mantained after the snapshots

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -263,12 +263,6 @@ pub(crate) fn initialize_context<'s>(
 
   let undefined = v8::undefined(scope);
   for op_ctx in op_ctxs {
-    // TODO(bartlomieju): https://github.com/denoland/deno_core/issues/447
-    // Do not register disabled ops.
-    if !op_ctx.decl.enabled {
-      continue;
-    }
-
     let mut op_fn = op_ctx_function(scope, op_ctx);
     let key = v8::String::new_external_onebyte_static(
       scope,
@@ -499,7 +493,7 @@ fn import_meta_resolve(
   };
 }
 
-fn empty_fn(
+pub fn empty_fn(
   _scope: &mut v8::HandleScope,
   _args: v8::FunctionCallbackArguments,
   _rv: v8::ReturnValue,

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -205,13 +205,11 @@ fn test_op_disabled() {
     extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
-  // Disabled op should be replaced with a noop function.
-  let val = runtime
+  // Disabled op should be replaced with a function that throws.
+  let err = runtime
     .execute_script_static("test.js", "Deno.core.ops.op_foo()")
-    .unwrap();
-  let scope = &mut runtime.handle_scope();
-  let local_val = v8::Local::new(scope, val);
-  assert!(local_val.is_undefined());
+    .unwrap_err();
+  assert!(err.to_string().contains("op is disabled"));
 }
 
 #[test]

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -205,12 +205,13 @@ fn test_op_disabled() {
     extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
-  let err = runtime
+  // Disabled op should be replaced with a noop function.
+  let val = runtime
     .execute_script_static("test.js", "Deno.core.ops.op_foo()")
-    .unwrap_err();
-  assert!(err
-    .to_string()
-    .contains("TypeError: Deno.core.ops.op_foo is not a function"));
+    .unwrap();
+  let scope = &mut runtime.handle_scope();
+  let local_val = v8::Local::new(scope, val);
+  assert!(local_val.is_undefined());
 }
 
 #[test]


### PR DESCRIPTION
This commit changes what "disabling" an op means. Before a disabled op
was never registered. This posed some challenges, especially as we
trying to provide "virtual ops modules" (https://github.com/denoland/deno_core/issues/223),
having ops conditionally available makes it super hard to properly
snapshot and set up the runtime.

With this change, "disabling" an op makes it throw when called.

Closes https://github.com/denoland/deno_core/issues/447