### PR TITLE
feat: Allow synthetic modules to provide multiple exports

### DIFF
--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -1,3 +1,4 @@
+use crate::FastString;
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 use crate::error::exception_to_err_result;
 use crate::error::generic_error;
@@ -351,8 +352,7 @@ impl ModuleMap {
           // synthetic module.
           CustomModuleEvaluationKind::Synthetic(value_global) => {
             let value = v8::Local::new(scope, value_global);
-            let exports =
-              vec![(v8::String::new(scope, "default").unwrap(), value)];
+            let exports = vec![(FastString::StaticAscii("default"), value)];
             self.new_synthetic_module(
               scope,
               module_url_found,
@@ -370,8 +370,7 @@ impl ModuleMap {
           ) => {
             let (url1, url2) = module_url_found.into_cheap_copy();
             let value = v8::Local::new(scope, synthetic_value);
-            let exports =
-              vec![(v8::String::new(scope, "default").unwrap(), value)];
+            let exports = vec![(FastString::StaticAscii("default"), value)];
             let _synthetic_mod_id = self.new_synthetic_module(
               scope,
               url1,
@@ -400,12 +399,20 @@ impl ModuleMap {
     scope: &mut v8::HandleScope,
     name: ModuleName,
     module_type: ModuleType,
-    exports: Vec<(v8::Local<v8::String>, v8::Local<v8::Value>)>,
+    exports: Vec<(FastString, v8::Local<v8::Value>)>,
   ) -> Result<ModuleId, ModuleError> {
     let name_str = name.v8(scope);
 
-    let export_names =
-      exports.iter().map(|(name, _)| *name).collect::<Vec<_>>();
+    let export_names = exports
+      .iter()
+      .map(|(name, _)| {
+        if let Some(buffer) = name.try_static_ascii() {
+          v8::String::new_external_onebyte_static(scope, buffer).unwrap()
+        } else {
+          v8::String::new(scope, name.as_str()).unwrap()
+        }
+      })
+      .collect::<Vec<_>>();
     let module = v8::Module::create_synthetic_module(
       scope,
       name_str,
@@ -414,12 +421,17 @@ impl ModuleMap {
     );
 
     let handle = v8::Global::<v8::Module>::new(scope, module);
-    let exports_global = exports
-      .into_iter()
-      .map(|(name, value)| {
-        (v8::Global::new(scope, name), v8::Global::new(scope, value))
-      })
-      .collect::<Vec<_>>();
+    let mut exports_global = Vec::with_capacity(exports.len());
+
+    for i in 0..exports.len() {
+      let export_name = export_names[i];
+      let (_, export_value) = exports[i];
+      exports_global.push((
+        v8::Global::new(scope, export_name),
+        v8::Global::new(scope, export_value),
+      ));
+    }
+
     self
       .data
       .borrow_mut()
@@ -604,8 +616,7 @@ impl ModuleMap {
         return Err(ModuleError::Exception(exception));
       }
     };
-    let exports =
-      vec![(v8::String::new(tc_scope, "default").unwrap(), parsed_json)];
+    let exports = vec![(FastString::StaticAscii("default"), parsed_json)];
     self.new_synthetic_module(tc_scope, name, ModuleType::Json, exports)
   }
 
@@ -1558,9 +1569,9 @@ fn synthetic_module_evaluation_steps<'a>(
     let value = v8::Local::new(tc_scope, export_value);
 
     // This should never fail
-    assert!(
-      module.set_synthetic_module_export(tc_scope, name, value).unwrap()
-    );
+    assert!(module
+      .set_synthetic_module_export(tc_scope, name, value)
+      .unwrap());
     assert!(!tc_scope.has_caught());
   }
 

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -1,4 +1,3 @@
-use crate::FastString;
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 use crate::error::exception_to_err_result;
 use crate::error::generic_error;
@@ -22,6 +21,7 @@ use crate::modules::ResolutionKind;
 use crate::runtime::exception_state::ExceptionState;
 use crate::runtime::JsRealm;
 use crate::ExtensionFileSource;
+use crate::FastString;
 use crate::JsRuntime;
 use crate::ModuleSource;
 use crate::ModuleSpecifier;

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -1558,9 +1558,8 @@ fn synthetic_module_evaluation_steps<'a>(
     let value = v8::Local::new(tc_scope, export_value);
 
     // This should never fail
-    assert_eq!(
-      module.set_synthetic_module_export(tc_scope, name, value),
-      Some(true)
+    assert!(
+      module.set_synthetic_module_export(tc_scope, name, value).unwrap()
     );
     assert!(!tc_scope.has_caught());
   }

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -351,11 +351,13 @@ impl ModuleMap {
           // synthetic module.
           CustomModuleEvaluationKind::Synthetic(value_global) => {
             let value = v8::Local::new(scope, value_global);
+            let exports =
+              vec![(v8::String::new(scope, "default").unwrap(), value)];
             self.new_synthetic_module(
               scope,
               module_url_found,
               ModuleType::Other(module_type.clone()),
-              value,
+              exports,
             )?
           }
 
@@ -368,11 +370,13 @@ impl ModuleMap {
           ) => {
             let (url1, url2) = module_url_found.into_cheap_copy();
             let value = v8::Local::new(scope, synthetic_value);
+            let exports =
+              vec![(v8::String::new(scope, "default").unwrap(), value)];
             let _synthetic_mod_id = self.new_synthetic_module(
               scope,
               url1,
               synthetic_module_type,
-              value,
+              exports,
             )?;
             self.new_module_from_js_source(
               scope,
@@ -396,11 +400,12 @@ impl ModuleMap {
     scope: &mut v8::HandleScope,
     name: ModuleName,
     module_type: ModuleType,
-    value: v8::Local<v8::Value>,
+    exports: Vec<(v8::Local<v8::String>, v8::Local<v8::Value>)>,
   ) -> Result<ModuleId, ModuleError> {
     let name_str = name.v8(scope);
 
-    let export_names = [v8::String::new(scope, "default").unwrap()];
+    let export_names =
+      exports.iter().map(|(name, _)| *name).collect::<Vec<_>>();
     let module = v8::Module::create_synthetic_module(
       scope,
       name_str,
@@ -409,12 +414,17 @@ impl ModuleMap {
     );
 
     let handle = v8::Global::<v8::Module>::new(scope, module);
-    let value_handle = v8::Global::<v8::Value>::new(scope, value);
+    let exports_global = exports
+      .into_iter()
+      .map(|(name, value)| {
+        (v8::Global::new(scope, name), v8::Global::new(scope, value))
+      })
+      .collect::<Vec<_>>();
     self
       .data
       .borrow_mut()
-      .synthetic_module_value_store
-      .insert(handle.clone(), value_handle);
+      .synthetic_module_exports_store
+      .insert(handle.clone(), exports_global);
 
     let id = self.data.borrow_mut().create_module_info(
       name,
@@ -594,7 +604,9 @@ impl ModuleMap {
         return Err(ModuleError::Exception(exception));
       }
     };
-    self.new_synthetic_module(tc_scope, name, ModuleType::Json, parsed_json)
+    let exports =
+      vec![(v8::String::new(tc_scope, "default").unwrap(), parsed_json)];
+    self.new_synthetic_module(tc_scope, name, ModuleType::Json, exports)
   }
 
   pub(crate) fn instantiate_module(
@@ -684,6 +696,7 @@ impl ModuleMap {
     if specifier.starts_with("ext:")
       && !referrer.starts_with("ext:")
       && !referrer.starts_with("node:")
+      && !referrer.starts_with("checkin:")
       && referrer != "."
       && kind != ResolutionKind::MainModule
     {
@@ -1533,23 +1546,27 @@ fn synthetic_module_evaluation_steps<'a>(
   let module_map = JsRealm::module_map_from(tc_scope);
 
   let handle = v8::Global::<v8::Module>::new(tc_scope, module);
-  let value_handle = module_map
+  let exports = module_map
     .data
     .borrow_mut()
-    .synthetic_module_value_store
+    .synthetic_module_exports_store
     .remove(&handle)
     .unwrap();
-  let value_local = v8::Local::new(tc_scope, value_handle);
 
-  let name = v8::String::new(tc_scope, "default").unwrap();
-  // This should never fail
-  assert!(
-    module.set_synthetic_module_export(tc_scope, name, value_local)
-      == Some(true)
-  );
-  assert!(!tc_scope.has_caught());
+  for (export_name, export_value) in exports {
+    let name = v8::Local::new(tc_scope, export_name);
+    let value = v8::Local::new(tc_scope, export_value);
 
-  // Since TLA is active we need to return a promise.
+    // This should never fail
+    assert_eq!(
+      module.set_synthetic_module_export(tc_scope, name, value),
+      Some(true)
+    );
+    assert!(!tc_scope.has_caught());
+  }
+
+  // Since Top-Level Await is active we need to return a promise.
+  // This promise is resolved immediately.
   let resolver = v8::PromiseResolver::new(tc_scope).unwrap();
   let undefined = v8::undefined(tc_scope);
   resolver.resolve(tc_scope, undefined.into());

--- a/core/modules/module_map_data.rs
+++ b/core/modules/module_map_data.rs
@@ -117,6 +117,23 @@ pub(crate) struct ModuleMapSnapshottedData {
   pub module_handles: Vec<v8::Global<v8::Module>>,
 }
 
+/// An array of tuples that provide module exports.
+///
+/// "default" name will make the export "default" - ie. one that can be imported
+/// with `import foo from "./virtual.js"`;.
+/// All other name provide "named exports" - ie. ones that can be imported like
+/// so: `import { name1, name2 } from "./virtual.js`.
+pub(crate) type SyntheticModuleExports =
+  Vec<(v8::Global<v8::String>, v8::Global<v8::Value>)>;
+
+// TODO(bartlomieju): add an assertion that checks for that assumption?
+// If it's true we can simplify the type to be an `Option` instead of a `HashMap`.
+/// This hash map is not expected to hold more than one element at a time.
+/// It is a temporary store, so we can forward data to
+/// `synthetic_module_evaluation_steps` callback.
+pub(crate) type SyntheticModuleExportsStore =
+  HashMap<v8::Global<v8::Module>, SyntheticModuleExports>;
+
 #[derive(Default)]
 pub(crate) struct ModuleMapData {
   /// Inverted index from module to index in `info`.
@@ -133,8 +150,7 @@ pub(crate) struct ModuleMapData {
   pub(crate) main_module_id: Option<ModuleId>,
   /// This store is used to temporarily store data that is used
   /// to evaluate a "synthetic module".
-  pub(crate) synthetic_module_value_store:
-    HashMap<v8::Global<v8::Module>, v8::Global<v8::Value>>,
+  pub(crate) synthetic_module_exports_store: SyntheticModuleExportsStore,
   pub(crate) lazy_esm_sources:
     Rc<RefCell<HashMap<&'static str, ExtensionFileSource>>>,
 }


### PR DESCRIPTION
Prerequisite for "virtual ops modules".

This allows to create synthetic modules with multiple
exports. Previously only "default" export was supported,
which was fine for JSON modules and custom evaluated
modules, but lacks flexibility needed to generate modules
for ops in an extension.