### PR TITLE
Reduce ambiguous paths in macros

### DIFF
--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -211,7 +211,7 @@ impl OpDecl {
 #[macro_export]
 macro_rules! ops {
   ($name:ident, parameters = [ $( $param:ident : $type:ident ),+ ], ops = [ $( $(#[$m:meta])* $( $op:ident )::+ $( < $op_param:ident > )?  ),+ $(,)? ]) => {
-    pub(crate) fn $name < $( $param : $type + 'static ),+ > () -> Vec<$crate::OpDecl> {
+    pub(crate) fn $name < $( $param : $type + 'static ),+ > () -> ::std::vec::Vec<$crate::OpDecl> {
       vec![
       $(
         $( #[ $m ] )*
@@ -221,7 +221,7 @@ macro_rules! ops {
     }
   };
   ($name:ident, [ $( $(#[$m:meta])* $( $op:ident )::+ ),+ $(,)? ] ) => {
-    pub(crate) fn $name() -> Vec<$crate::OpDecl> {
+    pub(crate) fn $name() -> ::std::Vec<$crate::OpDecl> {
       use $crate::Op;
       vec![
         $( $( #[ $m ] )* $( $op )::+ :: DECL, )+
@@ -323,36 +323,36 @@ macro_rules! extension {
         use $crate::Op;
         $crate::Extension {
           // Computed at compile-time, may be modified at runtime with `Cow`:
-          name: stringify!($name),
-          deps: &[ $( $( stringify!($dep) ),* )? ],
+          name: ::std::stringify!($name),
+          deps: &[ $( $( ::std::stringify!($dep) ),* )? ],
           // Use intermediary `const`s here to disable user expressions which
           // can't be evaluated at compile-time.
           js_files: {
-            const V: std::borrow::Cow<'static, [$crate::ExtensionFileSource]> = std::borrow::Cow::Borrowed(&$crate::or!($($crate::include_js_files!( $name $( dir $dir_js , )? $( $js , )* ))?, []));
+            const V: ::std::borrow::Cow<'static, [$crate::ExtensionFileSource]> = ::std::borrow::Cow::Borrowed(&$crate::or!($($crate::include_js_files!( $name $( dir $dir_js , )? $( $js , )* ))?, []));
             V
           },
           esm_files: {
-            const V: std::borrow::Cow<'static, [$crate::ExtensionFileSource]> = std::borrow::Cow::Borrowed(&$crate::or!($($crate::include_js_files!( $name $( dir $dir_esm , )? $( $esm $( with_specifier $esm_specifier )? , )* ))?, []));
+            const V: ::std::borrow::Cow<'static, [$crate::ExtensionFileSource]> = ::std::borrow::Cow::Borrowed(&$crate::or!($($crate::include_js_files!( $name $( dir $dir_esm , )? $( $esm $( with_specifier $esm_specifier )? , )* ))?, []));
             V
           },
           lazy_loaded_esm_files: {
-            const V: std::borrow::Cow<'static, [$crate::ExtensionFileSource]> = std::borrow::Cow::Borrowed(&$crate::or!($($crate::include_lazy_loaded_js_files!( $name $( dir $dir_lazy_loaded_esm , )? $( $lazy_loaded_esm $( with_specifier $lazy_loaded_esm_specifier )? , )* ))?, []));
+            const V: ::std::borrow::Cow<'static, [$crate::ExtensionFileSource]> = ::std::borrow::Cow::Borrowed(&$crate::or!($($crate::include_lazy_loaded_js_files!( $name $( dir $dir_lazy_loaded_esm , )? $( $lazy_loaded_esm $( with_specifier $lazy_loaded_esm_specifier )? , )* ))?, []));
             V
           },
           esm_entry_point: {
-            const V: Option<&'static str> = $crate::or!($(Some($esm_entry_point))?, None);
+            const V: ::std::option::Option<&'static ::std::primitive::str> = $crate::or!($(::std::option::Option::Some($esm_entry_point))?, ::std::option::Option::None);
             V
           },
-          ops: std::borrow::Cow::Borrowed(&[$($(
+          ops: ::std::borrow::Cow::Borrowed(&[$($(
             $( #[ $m ] )*
             $( $op )::+ $( :: < $($op_param),* > )? :: DECL
           ),+)?]),
-          external_references: std::borrow::Cow::Borrowed(&[ $( $external_reference ),* ]),
-          global_template_middleware: None,
-          global_object_middleware: None,
+          external_references: ::std::borrow::Cow::Borrowed(&[ $( $external_reference ),* ]),
+          global_template_middleware: ::std::option::Option::None,
+          global_object_middleware: ::std::option::Option::None,
           // Computed at runtime:
-          op_state_fn: None,
-          middleware_fn: None,
+          op_state_fn: ::std::option::Option::None,
+          middleware_fn: ::std::option::Option::None,
           enabled: true,
         }
       }
@@ -376,15 +376,15 @@ macro_rules! extension {
         $crate::extension!(! __config__ ext $( parameters = [ $( $param : $type ),* ] )? $( config = { $( $options_id : $options_type ),* } )? $( state_fn = $state_fn )? );
 
         $(
-          ext.global_template_middleware = Some($global_template_middleware_fn);
+          ext.global_template_middleware = ::std::option::Option::Some($global_template_middleware_fn);
         )?
 
         $(
-          ext.global_object_middleware = Some($global_object_middleware_fn);
+          ext.global_object_middleware = ::std::option::Option::Some($global_object_middleware_fn);
         )?
 
         $(
-          ext.middleware_fn = Some(Box::new($middleware_fn));
+          ext.middleware_fn = ::std::option::Option::Some(::std::boxed::Box::new($middleware_fn));
         )?
       }
 
@@ -444,9 +444,9 @@ macro_rules! extension {
         Self::with_ops_fn $( ::< $( $param ),+ > )?(&mut ext);
         Self::with_state_and_middleware $( ::< $( $param ),+ > )?(&mut ext, $( $( $options_id , )* )? );
         Self::with_customizer(&mut ext);
-        ext.js_files = std::borrow::Cow::Borrowed(&[]);
-        ext.esm_files = std::borrow::Cow::Borrowed(&[]);
-        ext.esm_entry_point = None;
+        ext.js_files = ::std::borrow::Cow::Borrowed(&[]);
+        ext.esm_files = ::std::borrow::Cow::Borrowed(&[]);
+        ext.esm_entry_point = ::std::option::Option::None;
         ext
       }
     }
@@ -466,14 +466,14 @@ macro_rules! extension {
       };
 
       let state_fn: fn(&mut $crate::OpState, Config $( <  $( $param ),+ > )? ) = $(  $state_fn  )?;
-      $ext.op_state_fn = Some(Box::new(move |state: &mut $crate::OpState| {
+      $ext.op_state_fn = ::std::option::Option::Some(::std::boxed::Box::new(move |state: &mut $crate::OpState| {
         state_fn(state, config);
       }));
     }
   };
 
   (! __config__ $ext:ident $( parameters = [ $( $param:ident : $type:ident ),+ ] )? $( state_fn = $state_fn:expr )? ) => {
-    $( $ext.op_state_fn = Some(Box::new($state_fn)); )?
+    $( $ext.op_state_fn = ::std::option::Option::Some(::std::boxed::Box::new($state_fn)); )?
   };
 
   (! __ops__ $ext:ident __eot__) => {

--- a/core/external.rs
+++ b/core/external.rs
@@ -7,7 +7,7 @@ use std::mem::ManuallyDrop;
 macro_rules! external {
   ($type:ty, $name:literal) => {
     impl $crate::Externalizable for $type {
-      fn external_marker() -> usize {
+      fn external_marker() -> ::core::primitive::usize {
         // Use the address of a static mut as a way to get around lack of usize-sized TypeId. Because it is mutable, the
         // compiler cannot collapse multiple definitions into one.
         static mut DEFINITION: $crate::ExternalDefinition =
@@ -15,12 +15,13 @@ macro_rules! external {
         // SAFETY: Wash the pointer through black_box so the compiler cannot see what we're going to do with it and needs
         // to assume it will be used for valid purposes. We are taking the address of a static item, but we avoid taking an
         // intermediate mutable reference to make this safe.
-        let ptr =
-          std::hint::black_box(unsafe { std::ptr::addr_of_mut!(DEFINITION) });
-        ptr as usize
+        let ptr = ::std::hint::black_box(unsafe {
+          ::std::ptr::addr_of_mut!(DEFINITION)
+        });
+        ptr as ::core::primitive::usize
       }
 
-      fn external_name() -> &'static str {
+      fn external_name() -> &'static ::core::primitive::str {
         $name
       }
     }

--- a/core/fast_string.rs
+++ b/core/fast_string.rs
@@ -215,7 +215,7 @@ impl From<Arc<str>> for FastString {
 #[macro_export]
 macro_rules! include_ascii_string {
   ($file:literal) => {
-    $crate::FastString::ensure_static_ascii(include_str!($file))
+    $crate::FastString::ensure_static_ascii(::std::include_str!($file))
   };
 }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -190,11 +190,11 @@ macro_rules! located_script_name {
   () => {
     concat!(
       "[ext:",
-      std::file!(),
+      ::std::file!(),
       ":",
-      std::line!(),
+      ::std::line!(),
       ":",
-      std::column!(),
+      ::std::column!(),
       "]"
     )
   };

--- a/core/resources.rs
+++ b/core/resources.rs
@@ -521,7 +521,10 @@ impl ResourceTable {
 
   /// Retrieves the [`ResourceHandle`] for a given resource, for potential optimization
   /// purposes within ops.
-  pub fn get_handle(&self, rid: ResourceId) -> Result<ResourceHandle, Error> {
+  pub fn get_handle(
+    &self,
+    rid: ResourceId,
+  ) -> ::std::result::Result<ResourceHandle, ::anyhow::Error> {
     let Some(handle) = self.get_any(rid)?.backing_handle() else {
       return Err(bad_resource_id());
     };
@@ -535,25 +538,28 @@ impl ResourceTable {
 #[macro_export]
 macro_rules! impl_readable_byob {
   () => {
-    fn read(self: Rc<Self>, limit: usize) -> AsyncResult<$crate::BufView> {
-      Box::pin(async move {
-        let mut vec = vec![0; limit];
+    fn read(
+      self: ::std::rc::Rc<Self>,
+      limit: ::core::primitive::usize,
+    ) -> AsyncResult<$crate::BufView> {
+      ::std::boxed::Box::pin(async move {
+        let mut vec = ::std::vec![0; limit];
         let nread = self.read(&mut vec).await?;
         if nread != vec.len() {
           vec.truncate(nread);
         }
         let view = $crate::BufView::from(vec);
-        Ok(view)
+        ::std::result::Result::Ok(view)
       })
     }
 
     fn read_byob(
-      self: Rc<Self>,
+      self: ::std::rc::Rc<Self>,
       mut buf: $crate::BufMutView,
-    ) -> AsyncResult<(usize, $crate::BufMutView)> {
-      Box::pin(async move {
+    ) -> AsyncResult<(::core::primitive::usize, $crate::BufMutView)> {
+      ::std::boxed::Box::pin(async move {
         let nread = self.read(buf.as_mut()).await?;
-        Ok((nread, buf))
+        ::std::result::Result::Ok((nread, buf))
       })
     }
   };
@@ -563,20 +569,26 @@ macro_rules! impl_readable_byob {
 macro_rules! impl_writable {
   (__write) => {
     fn write(
-      self: Rc<Self>,
+      self: ::std::rc::Rc<Self>,
       view: $crate::BufView,
-    ) -> AsyncResult<$crate::WriteOutcome> {
-      Box::pin(async move {
+    ) -> $crate::AsyncResult<$crate::WriteOutcome> {
+      ::std::boxed::Box::pin(async move {
         let nwritten = self.write(&view).await?;
-        Ok($crate::WriteOutcome::Partial { nwritten, view })
+        ::std::result::Result::Ok($crate::WriteOutcome::Partial {
+          nwritten,
+          view,
+        })
       })
     }
   };
   (__write_all) => {
-    fn write_all(self: Rc<Self>, view: $crate::BufView) -> AsyncResult<()> {
-      Box::pin(async move {
+    fn write_all(
+      self: ::std::rc::Rc<Self>,
+      view: $crate::BufView,
+    ) -> $crate::AsyncResult<()> {
+      ::std::boxed::Box::pin(async move {
         self.write_all(&view).await?;
-        Ok(())
+        ::std::result::Result::Ok(())
       })
     }
   };


### PR DESCRIPTION
Current macros are not hygienic in path resolution. This causes compile error with codes like below.

```rust
deno_core::extension!(
    ext,
    js = [ "/path/to/ext.js" ]
);

mod std {}
```

error diagnostic:

```
error[E0433]: failed to resolve: could not find `borrow` in `std`
  --> src/lib.rs:14:1
   |
14 | / deno_core::extension!(
15 | |     ext,
16 | |     js = [ "/path/to/ext.js" ],
17 | | );
   | |_^ could not find `borrow` in `std`
   |
   = note: this error originates in the macro `deno_core::extension` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This PR almost resolves this problem, by using unambiguous paths. There are still ambiguous paths remaining, but they won't couse such a issue because they only appear in unexported macros. I'm sorry if I missed something :pray:

references about hygienic macro:

- https://en.wikipedia.org/wiki/Hygienic_macro
- https://doc.rust-lang.org/reference/macros-by-example.html#hygiene
- https://gist.github.com/Kestrer/8c05ebd4e0e9347eb05f265dfb7252e1