### PR TITLE
feat: Infrastructure for op sanitizer in deno_core

### DIFF
--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -44,13 +44,13 @@ impl Hasher for IdentityHasher {
 
 /// We will be experimenting with different driver types in the future. This allows us to
 /// swap the driver out for experimentation.
-#[cfg(feature = "op_driver_joinset")]
+#[cfg(all(
+  feature = "op_driver_joinset",
+  not(feature = "op_driver_futuresunordered")
+))]
 type DefaultOpDriver = super::op_driver::JoinSetDriver;
 
-#[cfg(all(
-  feature = "op_driver_futuresunordered",
-  not(feature = "op_driver_joinset")
-))]
+#[cfg(feature = "op_driver_futuresunordered")]
 type DefaultOpDriver = super::op_driver::FuturesUnorderedDriver;
 
 pub(crate) struct ContextState<OpDriverImpl: OpDriver = DefaultOpDriver> {

--- a/core/runtime/op_driver/erased_future.rs
+++ b/core/runtime/op_driver/erased_future.rs
@@ -4,7 +4,6 @@ use std::marker::PhantomData;
 use std::marker::PhantomPinned;
 use std::mem::MaybeUninit;
 use std::pin::Pin;
-use std::ptr::addr_of_mut;
 use std::ptr::NonNull;
 use std::task::Context;
 use std::task::Poll;
@@ -87,6 +86,7 @@ pub struct ErasedFuture<const MAX_SIZE: usize, Output> {
 }
 
 impl<const MAX_SIZE: usize, Output> ErasedFuture<MAX_SIZE, Output> {
+  #[allow(dead_code)]
   unsafe fn poll<F>(
     pin: Pin<&mut TypeErased<MAX_SIZE>>,
     cx: &mut Context<'_>,
@@ -97,6 +97,7 @@ impl<const MAX_SIZE: usize, Output> ErasedFuture<MAX_SIZE, Output> {
     F::poll(std::mem::transmute(pin), cx)
   }
 
+  #[allow(dead_code)]
   pub fn new<F>(f: F) -> Self
   where
     F: Future<Output = Output>,

--- a/core/runtime/op_driver/future_arena.rs
+++ b/core/runtime/op_driver/future_arena.rs
@@ -1,43 +1,168 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-use super::erased_future::ErasedFuture;
+use super::erased_future::TypeErased;
 use crate::arena::ArenaBox;
 use crate::arena::ArenaUnique;
-use futures::FutureExt;
+use pin_project::pin_project;
 use std::future::Future;
+use std::marker::PhantomData;
+use std::mem::MaybeUninit;
 use std::pin::Pin;
+use std::ptr::NonNull;
 use std::task::Context;
 use std::task::Poll;
 
 const MAX_ARENA_FUTURE_SIZE: usize = 1024;
+
+/// The number of futures we'll allow to live in the Arena.
 const FUTURE_ARENA_COUNT: usize = 256;
 
-pub enum FutureAllocation<R: 'static> {
-  Arena(ArenaBox<ErasedFuture<MAX_ARENA_FUTURE_SIZE, R>>),
-  Box(Pin<Box<dyn Future<Output = R>>>),
+/// The [`FutureArena`] requires context for each submitted future. This mapper provides the context, as well
+/// as finalizes the output of the future to the correct output type for this arena.
+pub trait FutureContextMapper<T, C, R> {
+  fn context(&self) -> C;
+  fn map(&self, r: R) -> T;
 }
 
-impl<R> Unpin for FutureAllocation<R> {}
+struct DynFutureInfoErased<T, C> {
+  ptr: MaybeUninit<NonNull<dyn ContextFuture<T, C>>>,
+  data: TypeErased<MAX_ARENA_FUTURE_SIZE>,
+}
 
-impl<R> Future for FutureAllocation<R> {
-  type Output = R;
+pub trait ContextFuture<T, C>: Future<Output = T> {
+  fn context(&self) -> C;
+}
 
-  #[inline(always)]
+#[pin_project]
+struct DynFutureInfo<
+  T: 'static,
+  C: 'static,
+  M: FutureContextMapper<T, C, F::Output>,
+  F: Future,
+> {
+  /// The future metadata
+  #[pin]
+  context: M,
+
+  /// The underlying [`Future`], [`Pin`]-projectable.
+  #[pin]
+  future: F,
+
+  _phantom: PhantomData<(T, C)>,
+}
+
+impl<T, C, M: FutureContextMapper<T, C, F::Output>, F: Future>
+  ContextFuture<T, C> for DynFutureInfo<T, C, M, F>
+{
+  fn context(&self) -> C {
+    self.context.context()
+  }
+}
+
+impl<T, C, M: FutureContextMapper<T, C, F::Output>, F: Future> Future
+  for DynFutureInfo<T, C, M, F>
+{
+  type Output = T;
+
   fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-    match self.get_mut() {
-      Self::Arena(f) => f.poll_unpin(cx),
-      Self::Box(f) => f.poll_unpin(cx),
+    let this = self.project();
+    match F::poll(this.future, cx) {
+      Poll::Pending => Poll::Pending,
+      Poll::Ready(v) => Poll::Ready(this.context.map(v)),
     }
   }
 }
 
-/// An arena of erased futures. Futures too large for the arena, or futures allocated when the
-/// arena are full, are automatically moved to the heap instead.
-#[repr(transparent)]
-pub struct FutureArena {
-  arena: ArenaUnique<ErasedFuture<MAX_ARENA_FUTURE_SIZE, ()>>,
+#[allow(private_interfaces)]
+pub enum FutureAllocation<T: 'static, C: 'static> {
+  /// The future and metadata are small enough to fit in the arena, so let's put it there
+  Arena(ArenaBox<DynFutureInfoErased<T, C>>),
+  /// If this future doesn't fit in the arena (because the arena is full or the future is too
+  /// large), it is stored in the heap.
+  Box(Pin<Box<dyn ContextFuture<T, C>>>),
 }
 
-impl Default for FutureArena {
+impl<T, C> FutureAllocation<T, C> {
+  pub fn context(&self) -> C {
+    unsafe {
+      match self {
+        Self::Arena(a) => (a.ptr.assume_init().as_ref()).context(),
+        Self::Box(b) => b.context(),
+      }
+    }
+  }
+}
+
+impl<T, C> Unpin for FutureAllocation<T, C> {}
+
+impl<T, C> Future for FutureAllocation<T, C> {
+  type Output = T;
+
+  #[inline(always)]
+  fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    // SAFETY: We know the underlying futures are both pinned by their allocations
+    unsafe {
+      match self.get_mut() {
+        Self::Arena(a) => {
+          Pin::new_unchecked(a.ptr.assume_init().as_mut()).poll(cx)
+        }
+        Self::Box(b) => b.as_mut().poll(cx),
+      }
+    }
+  }
+}
+
+/// A [`FutureAllocation`] that has not been erased yet. This may be polled using its original
+/// type of [`Future`].
+pub struct TypedFutureAllocation<
+  T: 'static,
+  C: 'static,
+  M: FutureContextMapper<T, C, F::Output>,
+  F: Future,
+> {
+  inner: FutureAllocation<T, C>,
+  /// Maintain a pointer to the raw type until we erase it
+  ptr: NonNull<DynFutureInfo<T, C, M, F>>,
+}
+
+impl<T, C, M: FutureContextMapper<T, C, F::Output>, F: Future> Unpin
+  for TypedFutureAllocation<T, C, M, F>
+{
+}
+
+impl<T, C, M: FutureContextMapper<T, C, F::Output>, F: Future>
+  TypedFutureAllocation<T, C, M, F>
+{
+  #[inline(always)]
+  pub fn erase(self) -> FutureAllocation<T, C> {
+    self.inner
+  }
+}
+
+impl<T, C, M: FutureContextMapper<T, C, F::Output>, F: Future> Future
+  for TypedFutureAllocation<T, C, M, F>
+{
+  type Output = F::Output;
+  #[inline(always)]
+  fn poll(
+    mut self: Pin<&mut Self>,
+    cx: &mut Context<'_>,
+  ) -> Poll<Self::Output> {
+    // SAFETY: We know the underlying futures are both pinned by their allocations
+    unsafe { F::poll(Pin::new_unchecked(&mut self.ptr.as_mut().future), cx) }
+  }
+}
+
+/// An arena of erased futures with associated mapping functions. Futures too large for the arena,
+/// or futures allocated when the arena are full, are automatically moved to the heap instead.
+///
+/// Each future is associated with an output type and a context. The context is used to create the
+/// output type.
+#[repr(transparent)]
+pub struct FutureArena<T, C> {
+  arena: ArenaUnique<DynFutureInfoErased<T, C>>,
+}
+
+impl<T, C> Default for FutureArena<T, C> {
   fn default() -> Self {
     FutureArena {
       arena: ArenaUnique::with_capacity(FUTURE_ARENA_COUNT),
@@ -45,67 +170,135 @@ impl Default for FutureArena {
   }
 }
 
-impl FutureArena {
+impl<T, C: Clone> FutureArena<T, C> {
   /// Allocate a future to run in this `FuturesUnordered`. If the future is too large, or the arena
   /// is full, allocated in the heap.
-  pub fn allocate<F, R>(&self, f: F) -> FutureAllocation<R>
+  ///
+  /// The type of the future provided must convert into the type of the arena itself via [`From`].
+  #[inline]
+  #[allow(private_bounds)]
+  pub fn allocate<F, R, M: FutureContextMapper<T, C, R> + 'static>(
+    &self,
+    context: M,
+    future: F,
+  ) -> TypedFutureAllocation<T, C, M, F>
   where
     F: Future<Output = R> + 'static,
+    DynFutureInfo<T, C, M, F>: ContextFuture<T, C>,
   {
-    if std::mem::size_of::<F>() > MAX_ARENA_FUTURE_SIZE {
-      FutureAllocation::Box(f.boxed_local())
-    } else {
+    if std::mem::size_of::<DynFutureInfo<T, C, M, F>>() <= MAX_ARENA_FUTURE_SIZE
+    {
       unsafe {
-        match self.arena.reserve_space() {
-          Some(reservation) => {
-            let alloc = self.arena.complete_reservation(
-              reservation,
-              std::mem::transmute(
-                ErasedFuture::<MAX_ARENA_FUTURE_SIZE, _>::new(f),
-              ),
-            );
-            FutureAllocation::Arena(std::mem::transmute(alloc))
-          }
-          None => FutureAllocation::Box(f.boxed_local()),
+        if let Some(reservation) = self.arena.reserve_space() {
+          let mut alloc = self.arena.complete_reservation(
+            reservation,
+            DynFutureInfoErased {
+              ptr: MaybeUninit::uninit(),
+              data: TypeErased::new(DynFutureInfo {
+                context,
+                future,
+                _phantom: PhantomData,
+              }),
+            },
+          );
+          let ptr = alloc.data.raw_ptr::<DynFutureInfo<T, C, M, F>>();
+          alloc.ptr.write(ptr);
+          return TypedFutureAllocation {
+            inner: FutureAllocation::Arena(alloc),
+            ptr,
+          };
         }
       }
+    }
+
+    let mut future = Box::pin(DynFutureInfo {
+      context,
+      future,
+      _phantom: PhantomData,
+    });
+
+    let ptr = unsafe { NonNull::from(future.as_mut().get_unchecked_mut()) };
+
+    TypedFutureAllocation {
+      inner: FutureAllocation::Box(future),
+      ptr,
     }
   }
 }
 
 #[cfg(test)]
 mod tests {
+  use super::*;
+  use futures::task::noop_waker_ref;
+  use futures::FutureExt;
+  use std::fmt::Display;
   use std::future::ready;
 
-  use super::*;
+  const INFO: usize = 0;
+
+  #[derive(Debug, PartialEq, Eq)]
+  struct Stringish(String);
+
+  impl<R: Display> FutureContextMapper<Stringish, usize, R> for usize {
+    fn context(&self) -> usize {
+      *self
+    }
+
+    fn map(&self, r: R) -> Stringish {
+      Stringish(format!("{r}"))
+    }
+  }
+
+  #[test]
+  fn test_mapping() {
+    let arena = FutureArena::<Stringish, usize>::default();
+
+    // Poll unmapped
+    let mut f = arena.allocate(INFO, async { 1 });
+    let Poll::Ready(v) =
+      f.poll_unpin(&mut Context::from_waker(noop_waker_ref()))
+    else {
+      panic!();
+    };
+    assert_eq!(v, 1);
+
+    // Poll Mapped
+    let mut f = arena.allocate(INFO, async { 1 }).erase();
+    let Poll::Ready(v) =
+      f.poll_unpin(&mut Context::from_waker(noop_waker_ref()))
+    else {
+      panic!();
+    };
+    assert_eq!(v.0, "1".to_owned());
+  }
 
   #[test]
   fn test_double_free() {
-    let arena = FutureArena::default();
-    let f = arena.allocate(async { 1 });
+    let arena = FutureArena::<Stringish, usize>::default();
+    let f = arena.allocate(INFO, async { 1 });
     drop(f);
-    let f = arena.allocate(Box::pin(async { 1 }));
+    let f = arena.allocate(INFO, Box::pin(async { 1 }));
     drop(f);
-    let f = arena.allocate(ready(Box::new(1)));
+    let f = arena.allocate(INFO, ready(Box::new(1_i32)));
     drop(f);
   }
 
   #[test]
   fn test_exceed_arena() {
-    let arena = FutureArena::default();
+    let arena = FutureArena::<Stringish, usize>::default();
     let mut v = vec![];
     for _ in 0..1000 {
-      v.push(arena.allocate(ready(Box::new(1))));
+      v.push(arena.allocate(INFO, ready(Box::new(1_i32))));
     }
     drop(v);
   }
 
   #[test]
-  fn test_drop_after_joinset() {
-    let arena = FutureArena::default();
+  fn test_drop_after_arena() {
+    let arena = FutureArena::<Stringish, usize>::default();
     let mut v = vec![];
     for _ in 0..1000 {
-      v.push(arena.allocate(ready(Box::new(1))));
+      v.push(arena.allocate(INFO, ready(Box::new(1_i32))));
     }
     drop(arena);
     drop(v);

--- a/core/runtime/op_driver/futures_unordered_driver.rs
+++ b/core/runtime/op_driver/futures_unordered_driver.rs
@@ -3,6 +3,7 @@ use super::future_arena::FutureAllocation;
 use super::future_arena::FutureArena;
 use super::op_results::*;
 use super::OpDriver;
+use super::OpInflightStats;
 use crate::OpId;
 use crate::PromiseId;
 use anyhow::Error;
@@ -27,7 +28,7 @@ use std::task::Poll;
 
 async fn poll_task<C: OpMappingContext>(
   mut results: SubmissionQueueResults<
-    FuturesUnordered<FutureAllocation<PendingOp<C>>>,
+    FuturesUnordered<FutureAllocation<PendingOp<C>, PendingOpInfo>>,
   >,
   tx: Rc<RefCell<VecDeque<PendingOp<C>>>>,
   tx_waker: Rc<UnsyncWaker>,
@@ -54,10 +55,12 @@ pub struct FuturesUnorderedDriver<
   len: Cell<usize>,
   task: Cell<MaybeTask>,
   task_set: Cell<bool>,
-  queue: SubmissionQueue<FuturesUnordered<FutureAllocation<PendingOp<C>>>>,
+  queue: SubmissionQueue<
+    FuturesUnordered<FutureAllocation<PendingOp<C>, PendingOpInfo>>,
+  >,
   completed_ops: Rc<RefCell<VecDeque<PendingOp<C>>>>,
   completed_waker: Rc<UnsyncWaker>,
-  arena: FutureArena,
+  arena: FutureArena<PendingOp<C>, PendingOpInfo>,
 }
 
 impl<C: OpMappingContext + 'static> Drop for FuturesUnorderedDriver<C> {
@@ -110,36 +113,12 @@ impl<C: OpMappingContext> FuturesUnorderedDriver<C> {
     self.task_set.set(true);
   }
 
-  /// Spawn an unpolled task, along with a function that can map it to a [`PendingOp`].
-  #[inline(always)]
-  fn spawn_unpolled<R>(
-    &self,
-    task: impl Future<Output = R> + 'static,
-    map: impl FnOnce(R) -> PendingOp<C> + 'static,
-  ) {
-    self.ensure_task();
-    self.len.set(self.len.get() + 1);
-    self.queue.spawn(self.arena.allocate(task.map(map)));
-  }
-
-  /// Spawn a ready task that already has a [`PendingOp`].
-  #[inline(always)]
-  fn spawn_ready(&self, ready_op: PendingOp<C>) {
-    self.ensure_task();
-    self.len.set(self.len.get() + 1);
-    self.queue.spawn(self.arena.allocate(ready(ready_op)));
-  }
-
   /// Spawn a polled task inside a [`FutureAllocation`], along with a function that can map it to a [`PendingOp`].
   #[inline(always)]
-  fn spawn_polled<R>(
-    &self,
-    task: FutureAllocation<R>,
-    map: impl FnOnce(R) -> PendingOp<C> + 'static,
-  ) {
+  fn spawn(&self, task: FutureAllocation<PendingOp<C>, PendingOpInfo>) {
     self.ensure_task();
     self.len.set(self.len.get() + 1);
-    self.queue.spawn(self.arena.allocate(task.map(map)));
+    self.queue.spawn(task);
   }
 }
 
@@ -157,28 +136,31 @@ impl<C: OpMappingContext> OpDriver<C> for FuturesUnorderedDriver<C> {
     rv_map: C::MappingFn<R>,
   ) -> Option<Result<R, E>> {
     {
-      let info = PendingOpInfo(promise_id, op_id);
+      let info = PendingOpMappingInfo::<_, _, true>(
+        PendingOpInfo(promise_id, op_id),
+        rv_map,
+      );
+      let mut pinned = self.arena.allocate(info, op);
 
       if LAZY {
-        self.spawn_unpolled(op, move |r| PendingOp::new(info, rv_map, r));
+        self.spawn(pinned.erase());
         return None;
       }
 
       // We poll every future here because it's much faster to return a result than
       // spin the event loop to get it.
-      let mut pinned = self.arena.allocate(op);
       match pinned.poll_unpin(&mut Context::from_waker(noop_waker_ref())) {
-        Poll::Pending => {
-          self.spawn_polled(pinned, move |r| PendingOp::new(info, rv_map, r))
-        }
+        Poll::Pending => self.spawn(pinned.erase()),
         Poll::Ready(res) => {
           if DEFERRED {
-            self.spawn_ready(PendingOp::new(info, rv_map, res))
+            drop(pinned);
+            self.spawn(self.arena.allocate(info, ready(res)).erase())
           } else {
             return Some(res);
           }
         }
       };
+
       None
     }
   }
@@ -195,22 +177,27 @@ impl<C: OpMappingContext> OpDriver<C> for FuturesUnorderedDriver<C> {
     rv_map: C::MappingFn<R>,
   ) -> Option<R> {
     {
-      let info = PendingOpInfo(promise_id, op_id);
+      let info = PendingOpMappingInfo::<_, _, false>(
+        PendingOpInfo(promise_id, op_id),
+        rv_map,
+      );
+      let mut pinned = self.arena.allocate(info, op);
+
       if LAZY {
-        self.spawn_unpolled(op, move |r| PendingOp::ok(info, rv_map, r));
+        self.spawn(pinned.erase());
         return None;
       }
 
       // We poll every future here because it's much faster to return a result than
       // spin the event loop to get it.
-      let mut pinned = self.arena.allocate(op);
-      match pinned.poll_unpin(&mut Context::from_waker(noop_waker_ref())) {
-        Poll::Pending => {
-          self.spawn_polled(pinned, move |res| PendingOp::ok(info, rv_map, res))
-        }
+      match Pin::new(&mut pinned)
+        .poll(&mut Context::from_waker(noop_waker_ref()))
+      {
+        Poll::Pending => self.spawn(pinned.erase()),
         Poll::Ready(res) => {
           if DEFERRED {
-            self.spawn_ready(PendingOp::ok(info, rv_map, res))
+            drop(pinned);
+            self.spawn(self.arena.allocate(info, ready(res)).erase())
           } else {
             return Some(res);
           }
@@ -240,6 +227,18 @@ impl<C: OpMappingContext> OpDriver<C> for FuturesUnorderedDriver<C> {
   #[inline(always)]
   fn len(&self) -> usize {
     self.len.get()
+  }
+
+  fn stats(&self) -> OpInflightStats {
+    let q = self.queue.queue.queue.borrow();
+    let mut v: Vec<PendingOpInfo> = Vec::with_capacity(self.len.get());
+    for f in q.iter() {
+      v.push(f.context())
+    }
+    OpInflightStats {
+      supported: true,
+      ops: v.into_boxed_slice(),
+    }
   }
 }
 

--- a/core/runtime/op_driver/mod.rs
+++ b/core/runtime/op_driver/mod.rs
@@ -19,8 +19,18 @@ pub use joinset_driver::JoinSetDriver;
 
 pub use self::op_results::OpMappingContext;
 pub use self::op_results::OpResult;
+use self::op_results::PendingOpInfo;
 pub use self::op_results::V8OpMappingContext;
 pub use self::op_results::V8RetValMapper;
+
+#[derive(Default)]
+#[allow(dead_code)] // follow-up PR
+/// Returns a set of stats on inflight ops.
+pub struct OpInflightStats {
+  /// The [`PromiseId`] of any inflight ops by each [`OpId`].
+  ops: Box<[PendingOpInfo]>,
+  supported: bool,
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum OpScheduling {
@@ -118,8 +128,16 @@ pub(crate) trait OpDriver<C: OpMappingContext = V8OpMappingContext>:
     cx: &mut Context,
   ) -> Poll<(PromiseId, OpId, OpResult<C>)>;
 
-  /// Return the number of futures currently being polled.
+  /// Return the number of in-flight ops currently being polled, or waiting for their results to be
+  /// picked up in `poll_ready`.
   fn len(&self) -> usize;
+
+  /// Capture the statistics of in-flight ops, for op sanitizer purposes. Note that this
+  /// may not be a cheap operation and calling it large number of times (for example, in an
+  /// event loop) may cause slowdowns.
+  ///
+  /// A [`PromiseId`] will appear in this list until its results have been picked up in `poll_ready`.
+  fn stats(&self) -> OpInflightStats;
 }
 
 #[cfg(test)]
@@ -166,6 +184,12 @@ mod tests {
     ) -> UnmappedResult<'s, Self> {
       let f: Self::MappingFn<R> = unsafe { std::mem::transmute(f) };
       f(r)
+    }
+
+    fn unerase_mapping_fn_raw<R: 'static>(
+      f: *const fn(),
+    ) -> Self::MappingFn<R> {
+      unsafe { std::mem::transmute(f) }
     }
   }
 


### PR DESCRIPTION
This is the underlying infrastructure we need to get the op sanitizer working in Rust. There are no useful public-facing APIs from this yet, but it implements the op portion of the work.

Step 2 will be adding resources and timers to the API, then we'll be able to implement this in Deno itself.