### PR TITLE
feat(ops): add `#[cppgc]` argument attribute

### DIFF
--- a/core/cppgc.rs
+++ b/core/cppgc.rs
@@ -41,9 +41,13 @@ pub fn make_cppgc_object<'a, T: 'static>(
   obj
 }
 
-pub fn unwrap_cppgc_object<'sc, T: 'static>(
-  obj: v8::Local<v8::Object>,
+pub fn try_unwrap_cppgc_object<'sc, T: 'static>(
+  val: v8::Local<v8::Value>,
 ) -> Option<&'sc T> {
+  let Ok(obj): Result<v8::Local<v8::Object>, _> = val.try_into() else {
+    return None;
+  };
+
   if obj.internal_field_count() != FIELD_COUNT {
     return None;
   }

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -1865,10 +1865,9 @@ mod tests {
     Ok(())
   }
 
-  struct TestResource {
+  pub struct TestResource {
     pub value: u32,
   }
-  impl crate::Resource for TestResource {}
 
   #[op2]
   pub fn op_test_make_cppgc_resource<'s>(
@@ -1879,9 +1878,7 @@ mod tests {
 
   #[op2(fast)]
   #[smi]
-  pub fn op_test_get_cppgc_resource(resource: v8::Local<v8::Object>) -> u32 {
-    let resource =
-      crate::cppgc::unwrap_cppgc_object::<TestResource>(resource).unwrap();
+  pub fn op_test_get_cppgc_resource(#[cppgc] resource: &TestResource) -> u32 {
     resource.value
   }
 

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -713,7 +713,10 @@ fn map_v8_fastcall_arg_to_arg(
       )?;
       quote!(let #arg_ident = #fast_api_callback_options.wasm_memory as _; #convert; let #arg_ident = Some(#arg_ident);)
     }
-    Arg::Special(Special::CppGcResource(ty)) => {
+    Arg::CppGcResource(ty) => {
+      let ty =
+        syn::parse_str::<syn::Path>(ty).expect("Failed to reparse state type");
+
       *needs_fast_api_callback_options = true;
       quote! {
         let #arg_ident = #arg_ident.try_into().unwrap();
@@ -831,7 +834,7 @@ fn map_arg_to_v8_fastcall_type(
     // Cow byte strings can be fast and don't require copying
     Arg::String(Strings::CowByte) => V8FastCallType::SeqOneByteString,
     Arg::External(..) => V8FastCallType::Pointer,
-    Arg::Special(Special::CppGcResource(_)) => V8FastCallType::V8Value,
+    Arg::CppGcResource(..) => V8FastCallType::V8Value,
     _ => return Err("a fast argument"),
   };
   Ok(Some(rv))

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -719,8 +719,7 @@ fn map_v8_fastcall_arg_to_arg(
 
       *needs_fast_api_callback_options = true;
       quote! {
-        let #arg_ident = #arg_ident.try_into().unwrap();
-        let Some(#arg_ident) = deno_core::cppgc::unwrap_cppgc_object::<#ty>(#arg_ident) else {
+        let Some(#arg_ident) = deno_core::cppgc::try_unwrap_cppgc_object::<#ty>(#arg_ident) else {
             #fast_api_callback_options.fallback = true;
             // SAFETY: All fast return types have zero as a valid value
             return unsafe { std::mem::zeroed() };

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -506,6 +506,12 @@ pub fn from_arg(
         };
       }
     }
+    Arg::Special(Special::CppGcResource(ty)) => {
+      quote! {
+          let #arg_ident = #arg_ident.try_into().unwrap();
+          let #arg_ident = deno_core::cppgc::unwrap_cppgc_object::<#ty>(#arg_ident).unwrap();
+      }
+    }
     _ => return Err("a slow argument"),
   };
   Ok(res)

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -24,7 +24,6 @@ use super::signature::Strings;
 use super::signature::WasmMemorySource;
 use super::V8MappingError;
 use super::V8SignatureMappingError;
-use crate::op2::signature::stringify_token;
 use proc_macro2::Ident;
 use proc_macro2::TokenStream;
 use quote::format_ident;
@@ -507,12 +506,11 @@ pub fn from_arg(
         };
       }
     }
-    Arg::Special(Special::CppGcResource(ty)) => {
-      let throw_exception = throw_type_error(
-        generator_state,
-        format!("expected {}", stringify_token(ty)),
-      )?;
-
+    Arg::CppGcResource(ty) => {
+      let throw_exception =
+        throw_type_error(generator_state, format!("expected {}", &ty))?;
+      let ty =
+        syn::parse_str::<syn::Path>(ty).expect("Failed to reparse state type");
       quote! {
         let #arg_ident = #arg_ident.try_into().unwrap();
         let Some(#arg_ident) = deno_core::cppgc::unwrap_cppgc_object::<#ty>(#arg_ident) else {

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -512,8 +512,7 @@ pub fn from_arg(
       let ty =
         syn::parse_str::<syn::Path>(ty).expect("Failed to reparse state type");
       quote! {
-        let #arg_ident = #arg_ident.try_into().unwrap();
-        let Some(#arg_ident) = deno_core::cppgc::unwrap_cppgc_object::<#ty>(#arg_ident) else {
+        let Some(#arg_ident) = deno_core::cppgc::try_unwrap_cppgc_object::<#ty>(#arg_ident) else {
           #throw_exception;
         };
       }

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -865,7 +865,7 @@ pub enum ArgError {
   InvalidDenoCorePrefix(String, String, String),
   #[error("Expected a reference. Use '#[cppgc] &{0}' instead.")]
   ExpectedCppGcReference(String),
-  #[error("Invalid cppgc type '{0}'")]
+  #[error("Invalid #[cppgc] type '{0}'")]
   InvalidCppGcType(String),
 }
 

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -863,7 +863,7 @@ pub enum ArgError {
   NotAllowedInThisPosition(String),
   #[error("Invalid deno_core:: prefix for type '{0}'. Try adding `use deno_core::{1}` at the top of the file and specifying `{2}` in this position.")]
   InvalidDenoCorePrefix(String, String, String),
-  #[error("Expected reference. Try changing to `&{0}`.")]
+  #[error("Expected a reference. Use '#[cppgc] &{0}' instead.")]
   ExpectedCppGcReference(String),
   #[error("Invalid cppgc type '{0}'")]
   InvalidCppGcType(String),

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -1378,12 +1378,10 @@ fn parse_type_state(ty: &Type) -> Result<Arg, ArgError> {
 fn parse_cppgc(ty: &Type) -> Result<Arg, ArgError> {
   match ty {
     Type::Reference(of) if of.mutability.is_none() => match &*of.elem {
-      Type::Path(of) => {
-        return Ok(Arg::CppGcResource(stringify_token(&of.path)));
-      }
-      _ => return Err(ArgError::InvalidCppGcType(stringify_token(ty))),
+      Type::Path(of) => Ok(Arg::CppGcResource(stringify_token(&of.path))),
+      _ => Err(ArgError::InvalidCppGcType(stringify_token(ty))),
     },
-    _ => return Err(ArgError::ExpectedCppGcReference(stringify_token(ty))),
+    _ => Err(ArgError::ExpectedCppGcReference(stringify_token(ty))),
   }
 }
 

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -15,7 +15,7 @@ impl deno_core::_ops::Op for op_file {
             use deno_core::v8::fast_api::Type;
             use deno_core::v8::fast_api::CType;
             deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::V8Value],
+                &[Type::V8Value, Type::V8Value, Type::CallbackOptions],
                 CType::Void,
                 Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
             )
@@ -56,7 +56,7 @@ impl op_file {
             &opctx,
             deno_core::_ops::OpMetricsEvent::Dispatched,
         );
-        let res = Self::v8_fn_ptr_fast(this, arg0);
+        let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
         deno_core::_ops::dispatch_metrics_fast(
             &opctx,
             deno_core::_ops::OpMetricsEvent::Completed,
@@ -67,15 +67,20 @@ impl op_file {
     fn v8_fn_ptr_fast(
         _: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: deno_core::v8::Local<deno_core::v8::Value>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         #[cfg(debug_assertions)]
         let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
             &<Self as deno_core::_ops::Op>::DECL,
         );
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let result = {
             let arg0 = arg0.try_into().unwrap();
-            let arg0 = deno_core::cppgc::unwrap_cppgc_object::<std::fs::File>(arg0)
-                .unwrap();
+            let Some(arg0) = deno_core::cppgc::unwrap_cppgc_object::<std::fs::File>(arg0)
+            else {
+                fast_api_callback_options.fallback = true;
+                return unsafe { std::mem::zeroed() };
+            };
             Self::call(arg0)
         };
         result as _
@@ -95,8 +100,19 @@ impl op_file {
         let result = {
             let arg0 = args.get(0usize as i32);
             let arg0 = arg0.try_into().unwrap();
-            let arg0 = deno_core::cppgc::unwrap_cppgc_object::<std::fs::File>(arg0)
-                .unwrap();
+            let Some(arg0) = deno_core::cppgc::unwrap_cppgc_object::<std::fs::File>(arg0)
+            else {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let msg = deno_core::v8::String::new_from_one_byte(
+                        &mut scope,
+                        "expected std::fs::File".as_bytes(),
+                        deno_core::v8::NewStringType::Normal,
+                    )
+                    .unwrap();
+                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                scope.throw_exception(exc);
+                return 1;
+            };
             Self::call(arg0)
         };
         deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -147,5 +147,5 @@ impl op_file {
         }
     }
     #[inline(always)]
-    fn call(file: &std::fs::File) {}
+    fn call(_file: &std::fs::File) {}
 }

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -75,9 +75,9 @@ impl op_file {
         );
         let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
         let result = {
-            let arg0 = arg0.try_into().unwrap();
-            let Some(arg0) = deno_core::cppgc::unwrap_cppgc_object::<std::fs::File>(arg0)
-            else {
+            let Some(arg0) = deno_core::cppgc::try_unwrap_cppgc_object::<
+                std::fs::File,
+            >(arg0) else {
                 fast_api_callback_options.fallback = true;
                 return unsafe { std::mem::zeroed() };
             };
@@ -99,9 +99,9 @@ impl op_file {
         });
         let result = {
             let arg0 = args.get(0usize as i32);
-            let arg0 = arg0.try_into().unwrap();
-            let Some(arg0) = deno_core::cppgc::unwrap_cppgc_object::<std::fs::File>(arg0)
-            else {
+            let Some(arg0) = deno_core::cppgc::try_unwrap_cppgc_object::<
+                std::fs::File,
+            >(arg0) else {
                 let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                 let msg = deno_core::v8::String::new_from_one_byte(
                         &mut scope,

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -1,0 +1,135 @@
+#[allow(non_camel_case_types)]
+struct op_file {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
+impl deno_core::_ops::Op for op_file {
+    const NAME: &'static str = stringify!(op_file);
+    const DECL: deno_core::_ops::OpDecl = deno_core::_ops::OpDecl::new_internal_op2(
+        stringify!(op_file),
+        false,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::V8Value],
+                CType::Void,
+                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+            )
+        }),
+        Some({
+            use deno_core::v8::fast_api::Type;
+            use deno_core::v8::fast_api::CType;
+            deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                &[Type::V8Value, Type::V8Value, Type::CallbackOptions],
+                CType::Void,
+                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+            )
+        }),
+    );
+}
+impl op_file {
+    pub const fn name() -> &'static str {
+        stringify!(op_file)
+    }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast_metrics(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: deno_core::v8::Local<deno_core::v8::Value>,
+        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+    ) -> () {
+        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<
+                deno_core::v8::External,
+            >::cast(unsafe { fast_api_callback_options.data.data })
+                .value() as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
+        );
+        let res = Self::v8_fn_ptr_fast(this, arg0);
+        deno_core::_ops::dispatch_metrics_fast(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Completed,
+        );
+        res
+    }
+    #[allow(clippy::too_many_arguments)]
+    fn v8_fn_ptr_fast(
+        _: deno_core::v8::Local<deno_core::v8::Object>,
+        arg0: deno_core::v8::Local<deno_core::v8::Value>,
+    ) -> () {
+        #[cfg(debug_assertions)]
+        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+            &<Self as deno_core::_ops::Op>::DECL,
+        );
+        let result = {
+            let arg0 = arg0.try_into().unwrap();
+            let arg0 = deno_core::cppgc::unwrap_cppgc_object::<std::fs::File>(arg0)
+                .unwrap();
+            Self::call(arg0)
+        };
+        result as _
+    }
+    #[inline(always)]
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        #[cfg(debug_assertions)]
+        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+            &<Self as deno_core::_ops::Op>::DECL,
+        );
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+            &*info
+        });
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let result = {
+            let arg0 = args.get(0usize as i32);
+            let arg0 = arg0.try_into().unwrap();
+            let arg0 = deno_core::cppgc::unwrap_cppgc_object::<std::fs::File>(arg0)
+                .unwrap();
+            Self::call(arg0)
+        };
+        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+        return 0;
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::slow_function_impl(info);
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_slow(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
+        );
+        let res = Self::slow_function_impl(info);
+        if res == 0 {
+            deno_core::_ops::dispatch_metrics_slow(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Completed,
+            );
+        } else {
+            deno_core::_ops::dispatch_metrics_slow(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Error,
+            );
+        }
+    }
+    #[inline(always)]
+    fn call(file: &std::fs::File) {}
+}

--- a/ops/op2/test_cases/sync/cppgc_resource.rs
+++ b/ops/op2/test_cases/sync/cppgc_resource.rs
@@ -3,4 +3,4 @@
 deno_ops_compile_test_runner::prelude!();
 
 #[op2(fast)]
-fn op_file(#[cppgc] file: &std::fs::File) {}
+fn op_file(#[cppgc] _file: &std::fs::File) {}

--- a/ops/op2/test_cases/sync/cppgc_resource.rs
+++ b/ops/op2/test_cases/sync/cppgc_resource.rs
@@ -1,0 +1,7 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+#![deny(warnings)]
+deno_ops_compile_test_runner::prelude!();
+
+#[op2(fast)]
+fn op_file(#[cppgc] file: &std::fs::File) {
+}

--- a/ops/op2/test_cases/sync/cppgc_resource.rs
+++ b/ops/op2/test_cases/sync/cppgc_resource.rs
@@ -3,5 +3,4 @@
 deno_ops_compile_test_runner::prelude!();
 
 #[op2(fast)]
-fn op_file(#[cppgc] file: &std::fs::File) {
-}
+fn op_file(#[cppgc] file: &std::fs::File) {}


### PR DESCRIPTION
Builtin support for getting a reference to a `CppGcObject<T>`.

```rust
#[op2(fast)]
fn op_file(#[cppgc] file: &std::fs::File) {}
```