### PR TITLE
chore: improve publish dry-run

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,0 @@
-[registries]
-# Specify the registry as "upstream" so we can dry-run publish to a test server
-upstream = { index = "sparse+https://index.crates.io/" }

--- a/.github/workflows/ci-job.yml
+++ b/.github/workflows/ci-job.yml
@@ -11,6 +11,12 @@ on:
       job:
         required: true
         type: string
+      is_main:
+        required: true
+        type: boolean
+      is_tag:
+        required: true
+        type: boolean
 
 jobs:
   job:
@@ -33,11 +39,16 @@ jobs:
         with:
           prefix-key: "v0-rust"
           shared-key: "${{ inputs.label }}-${{ inputs.job }}"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ inputs.is_main }}
 
       - name: Clean
-        if: github.ref == 'refs/heads/main'
+        if: inputs.is_main
         run: cargo clean
+
+      - name: No-op
+        id: nop
+        if: inputs.job == 'nop'
+        uses: ./.github/workflows/ci-nop
 
       - name: Lint
         id: lint
@@ -63,6 +74,11 @@ jobs:
         id: test-miri
         if: inputs.job == 'test-miri'
         uses: ./.github/workflows/ci-test-miri
+
+      - name: Publish (dry-run)
+        id: test-publish
+        if: inputs.job == 'test-publish'
+        uses: ./.github/workflows/ci-test-publish
 
       - name: Publish
         id: publish

--- a/.github/workflows/ci-nop/action.yml
+++ b/.github/workflows/ci-nop/action.yml
@@ -1,0 +1,7 @@
+name: No-op
+runs:
+  using: "composite"
+  steps:
+    - name: No-op
+      shell: bash
+      run: echo 'Doing nothing (intentionally)!'

--- a/.github/workflows/ci-publish/action.yml
+++ b/.github/workflows/ci-publish/action.yml
@@ -2,25 +2,8 @@ name: Publish workflow
 runs:
   using: "composite"
   steps:
-    - name: Cargo publish (dry-run)
-      shell: bash
-      if: contains(github.event.pull_request.labels.*.name, 'cargo-publish-dry-run')
-      env:
-        CARGO_REGISTRIES_UPSTREAM_INDEX: sparse+http://localhost:8000/api/v1/crates/
-        CARGO_REGISTRIES_UPSTREAM_TOKEN: Zy9HhJ02RJmg0GCrgLfaCVfU6IwDfhXD
-        # This should match our bumped-up crates.io limits
-        KELLNR_REGISTRY__MAX_CRATE_SIZE: 10
-      run: |
-        curl -L --output kellnr-latest.zip "https://github.com/kellnr/kellnr/releases/download/v5.1.1/kellnr-x86_64-unknown-linux-gnu.zip"
-        unzip kellnr-latest.zip -d ./kellnr
-        (cd ./kellnr && ./kellnr) &
-        sleep 1
-        for package in serde_v8 deno_ops deno_core; do
-          cargo publish -p $package --registry upstream --allow-dirty
-        done
     - name: Cargo publish
       shell: bash
-      if: "!contains(github.event.pull_request.labels.*.name, 'cargo-publish-dry-run')"
       run: |
         for package in serde_v8 deno_ops deno_core; do
           cargo publish -p $package

--- a/.github/workflows/ci-test-publish/action.yml
+++ b/.github/workflows/ci-test-publish/action.yml
@@ -1,0 +1,17 @@
+name: Test publish
+runs:
+  using: "composite"
+  steps:
+    - name: Cargo publish (dry-run)
+      shell: bash
+      env:
+        CARGO_REGISTRIES_UPSTREAM_INDEX: sparse+http://localhost:8000/api/v1/crates/
+        CARGO_REGISTRIES_UPSTREAM_TOKEN: Zy9HhJ02RJmg0GCrgLfaCVfU6IwDfhXD
+        # This should match our bumped-up crates.io limits
+        KELLNR_REGISTRY__MAX_CRATE_SIZE: 10
+      run: |
+        curl -L --output kellnr-latest.zip "https://github.com/kellnr/kellnr/releases/download/v5.1.1/kellnr-x86_64-unknown-linux-gnu.zip"
+        unzip kellnr-latest.zip -d ./kellnr
+        (cd ./kellnr && ./kellnr) &
+        sleep 1
+        tools/publish_dry_run.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,29 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  # Run on any push to main or any tag
+  push:
+    branches:
+      - main
+    tags:
+      - \*
+  # Run on any pull request
+  pull_request:
+    branches:
+      - main
 
 jobs:
-  success:
-    needs: top
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print success
-        run: echo Success ✅
-
   compute-jobs:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.read-jobs.outputs.matrix }}
+      # If we're not running in the denoland repo, or we're building on a tag, use the 'nop' matrix
+      # that runs a single, no-op job
+      matrix: |
+        ${{ (github.repository == 'denoland/deno_core' && !startsWith(github.ref, 'refs/tags/')) 
+          && steps.read-jobs.outputs.matrix 
+          || '[{ "label": "linux", "os": "ubuntu-latest", "job": "nop" }]' }}
+      is_tag: ${{ github.repository == 'denoland/deno_core' && startsWith(github.ref, 'refs/tags/') }}
+      is_main: ${{ github.repository == 'denoland/deno_core' && github.ref == 'refs/heads/main' }}
     steps:
       # https://github.com/marketplace/actions/query-yaml-config-as-outputs
       - name: Read job configuration
@@ -27,7 +37,7 @@ jobs:
           config: |-
             linux:
               os: ubuntu-latest
-              jobs: [lint, lint-deps, test, test-miri, test-ops]
+              jobs: [lint, lint-deps, test, test-miri, test-ops, test-publish]
             macos:
               os: macOS-latest
               jobs: [lint, test]
@@ -38,23 +48,35 @@ jobs:
   top:
     name: build-${{ matrix.label }}
     needs: compute-jobs
-    if: github.repository == 'denoland/deno_core'
     uses: ./.github/workflows/ci-job.yml
     with:
       label: ${{ matrix.label }}
       os: ${{ matrix.os }}
       job: ${{ matrix.job }}
+      is_main: ${{ needs.compute-jobs.outputs.is_main == true }}
+      is_tag: ${{ needs.compute-jobs.outputs.is_tag == true }}
     strategy:
       matrix:
         include: ${{ fromJSON(needs.compute-jobs.outputs.matrix) }}
 
+  success:
+    needs: top
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print success
+        run: echo Success ✅
+
   publish:
     name: publish
-    needs: top
-    if: (github.repository == 'denoland/deno_core' && startsWith(github.ref, 'refs/tags/')) || contains(github.event.pull_request.labels.*.name, 'cargo-publish-dry-run')
+    needs:
+      - top
+      - compute-jobs
+    if: needs.compute-jobs.outputs.is_tag
     uses: ./.github/workflows/ci-job.yml
     secrets: inherit
     with:
       label: linux
       os: ubuntu-latest
       job: publish
+      is_main: ${{ needs.compute-jobs.outputs.is_main }}
+      is_tag: ${{ needs.compute-jobs.outputs.is_tag }}

--- a/serde_v8/utilities/Cargo.toml
+++ b/serde_v8/utilities/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "serde_v8_utilities"
 version = "0.3.0"
+publish = false
 
 [lib]
 path = "lib.rs"

--- a/tools/deno_core_workspace.ts
+++ b/tools/deno_core_workspace.ts
@@ -27,6 +27,10 @@ export class DenoWorkspace {
     return this.#repo;
   }
 
+  static get manifest() {
+    return $.path.join(this.rootDirPath, "Cargo.toml");
+  }
+
   get crates() {
     return this.#repo.crates;
   }
@@ -34,7 +38,7 @@ export class DenoWorkspace {
   /** Gets the deno_core dependency crates that should be published. */
   getDenoCoreDependencyCrates() {
     return this.getDenoCoreCrate()
-      .descendantDependenciesInRepo();
+      .immediateDependenciesInRepo().map(c => c.crate);
   }
 
   getDenoCoreCrate() {

--- a/tools/publish_dry_run.ts
+++ b/tools/publish_dry_run.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env -S deno run -A --lock=tools/deno.lock.json
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import { DenoWorkspace } from "./deno_core_workspace.ts";
+
+const workspace = await DenoWorkspace.load();
+const repo = workspace.repo;
+const denoCoreCrate = workspace.getDenoCoreCrate();
+
+const allCrates = {};
+allCrates[denoCoreCrate.name] = denoCoreCrate;
+
+for (const crate of workspace.getDenoCoreDependencyCrates()) {
+  allCrates[crate.name] = crate;
+}
+
+// We have the crates in the correct publish order here
+const cratesInOrder = repo.getCratesPublishOrder().map(c => allCrates[c.name]).filter(c => !!c);
+
+for (const crate of cratesInOrder) {
+  await crate.increment("minor");
+}
+
+const originalManifest = Deno.readTextFileSync(DenoWorkspace.manifest);
+let manifest = originalManifest;
+for (const crate of cratesInOrder) {
+  const re = new RegExp(`^(\\b${crate.name}\\b\\s=.*)}$`, "gm");
+  manifest = manifest.replace(re, '$1, registry = "upstream" }');
+}
+
+Deno.writeTextFileSync(DenoWorkspace.manifest, manifest);
+
+for (const crate of cratesInOrder) {
+  await crate.publish(
+    "-p", crate.name,
+    "--allow-dirty", 
+    "--registry", "upstream",
+    "--token", "Zy9HhJ02RJmg0GCrgLfaCVfU6IwDfhXD", 
+    "--config", 'registries.upstream.index="sparse+http://localhost:8000/api/v1/crates/"'
+  );
+}


### PR DESCRIPTION
Changes to publishing/build workflows:

 - No longer build twice when running a version bump. The only branch that will trigger a build will be `main`.
 - Tag builds run an empty matrix, since they are being built from a main commit that should succeed, and the publish workflow runs a test compile on top of everything.
   - Even if the tag build failed with an error, we still just went ahead and published that tag!
 - All PRs run a `cargo publish` dry-run against a test server
