### PR TITLE
Add Deno.core.internalRidSymbol

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -456,6 +456,7 @@
 
   // Extra Deno.core.* exports
   const core = ObjectAssign(globalThis.Deno.core, {
+    internalRidSymbol: SymbolFor("Deno.internal.rid"),
     ensureFastOps,
     resources,
     metrics,

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -14,6 +14,7 @@
     ObjectHasOwn,
     Proxy,
     setQueueMicrotask,
+    Symbol,
     SymbolFor,
     TypedArrayPrototypeGetLength,
     TypedArrayPrototypeJoin,
@@ -456,7 +457,7 @@
 
   // Extra Deno.core.* exports
   const core = ObjectAssign(globalThis.Deno.core, {
-    internalRidSymbol: SymbolFor("Deno.internal.rid"),
+    internalRidSymbol: Symbol("Deno.internal.rid"),
     ensureFastOps,
     resources,
     metrics,


### PR DESCRIPTION
I need this to cleanup deprecated `rid` properties in Deno.