### PR TITLE
fix: Remove 'leak' call when creating `v8::ExternalReferences`

### DIFF
--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -86,10 +86,7 @@ pub(crate) fn external_references(
 
   references.extend_from_slice(additional_references);
 
-  let refs = v8::ExternalReferences::new(&references);
-  // Leak, V8 takes ownership of the references.
-  std::mem::forget(references);
-  refs
+  v8::ExternalReferences::new(&references)
 }
 
 // TODO(nayeemrmn): Move to runtime and/or make `pub(crate)`.


### PR DESCRIPTION
Calling `v8::ExternalReferences::new` does not take ownership of the Vec - it internally copies the values into a new Vec. As a result, the memory owned by the original Vec was never getting freed.