### PR TITLE
feat(testing): Add a worker subsystem to checkin

### DIFF
--- a/core/cppgc.rs
+++ b/core/cppgc.rs
@@ -18,7 +18,7 @@ const SLOT_OFFSET: i32 = 1;
 const FIELD_COUNT: usize = 2;
 
 pub fn make_cppgc_object<'a, T: 'static>(
-  scope: &'a mut v8::HandleScope,
+  scope: &mut v8::HandleScope<'a>,
   t: T,
 ) -> v8::Local<'a, v8::Object> {
   let templ = v8::ObjectTemplate::new(scope);

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1782,7 +1782,6 @@ impl JsRuntime {
   ) -> Poll<Result<(), Error>> {
     let has_inspector = self.inner.state.has_inspector.get();
     self.inner.state.waker.register(cx.waker());
-    eprintln!("poll");
     if has_inspector {
       // We poll the inspector first.
       let _ = self.inspector().borrow().poll_sessions(Some(cx)).unwrap();

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1782,7 +1782,7 @@ impl JsRuntime {
   ) -> Poll<Result<(), Error>> {
     let has_inspector = self.inner.state.has_inspector.get();
     self.inner.state.waker.register(cx.waker());
-
+    eprintln!("poll");
     if has_inspector {
       // We poll the inspector first.
       let _ = self.inspector().borrow().poll_sessions(Some(cx)).unwrap();

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1782,6 +1782,7 @@ impl JsRuntime {
   ) -> Poll<Result<(), Error>> {
     let has_inspector = self.inner.state.has_inspector.get();
     self.inner.state.waker.register(cx.waker());
+
     if has_inspector {
       // We poll the inspector first.
       let _ = self.inspector().borrow().poll_sessions(Some(cx)).unwrap();

--- a/testing/checkin/runner/mod.rs
+++ b/testing/checkin/runner/mod.rs
@@ -53,6 +53,7 @@ deno_core::extension!(
     ops_worker::op_worker_recv,
     ops_worker::op_worker_parent,
     ops_worker::op_worker_await_close,
+    ops_worker::op_worker_terminate,
   ],
   esm_entry_point = "ext:checkin_runtime/__init.js",
   esm = [

--- a/testing/checkin/runner/mod.rs
+++ b/testing/checkin/runner/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 use anyhow::bail;
 use anyhow::Error;
+use deno_ast::swc::common::util::take::Take;
 use deno_core::url::Url;
 use deno_core::CrossIsolateStore;
 use deno_core::JsRuntime;
@@ -16,12 +17,16 @@ use tokio::io::AsyncReadExt;
 
 use crate::checkin::runner::testing::TestData;
 
+use self::ops_worker::worker_create;
+use self::ops_worker::WorkerCloseWatcher;
+use self::ops_worker::WorkerHostSide;
 use self::testing::TestFunctions;
 
 mod ops;
 mod ops_async;
 mod ops_buffer;
 mod ops_io;
+mod ops_worker;
 mod testing;
 mod ts_module_loader;
 
@@ -44,6 +49,11 @@ deno_core::extension!(
     ops_async::op_async_throw_error_deferred,
     ops_buffer::op_v8slice_store,
     ops_buffer::op_v8slice_clone,
+    ops_worker::op_worker_spawn,
+    ops_worker::op_worker_send,
+    ops_worker::op_worker_recv,
+    ops_worker::op_worker_parent,
+    ops_worker::op_worker_await_close,
   ],
   esm_entry_point = "ext:checkin_runtime/__init.js",
   esm = [
@@ -54,15 +64,19 @@ deno_core::extension!(
     "console.ts" with_specifier "checkin:console",
     "testing.ts" with_specifier "checkin:testing",
     "timers.ts" with_specifier "checkin:timers",
+    "worker.ts" with_specifier "checkin:worker",
   ],
   state = |state| {
     state.put(TestFunctions::default());
     state.put(TestData::default());
-    state.put(Output::default());
   }
 );
 
-fn create_runtime() -> JsRuntime {
+fn create_runtime(
+  output: Output,
+  parent: Option<WorkerCloseWatcher>,
+) -> (JsRuntime, WorkerHostSide) {
+  let (worker, worker_host_side) = worker_create(parent);
   let mut extensions = vec![checkin_runtime::init_ops_and_esm()];
 
   for extension in &mut extensions {
@@ -88,13 +102,15 @@ fn create_runtime() -> JsRuntime {
   });
   let stats = runtime.runtime_activity_stats_factory();
   runtime.op_state().borrow_mut().put(stats);
-  runtime
+  runtime.op_state().borrow_mut().put(worker);
+  runtime.op_state().borrow_mut().put(output);
+  (runtime, worker_host_side)
 }
 
 /// Run a integration test within the `checkin` runtime. This executes a single file, imports and all,
 /// and compares its output with the `.out` file in the same directory.
 pub fn run_integration_test(test: &str) {
-  let runtime = create_runtime();
+  let (runtime, _) = create_runtime(Output::default(), None);
   let tokio = tokio::runtime::Builder::new_current_thread()
     .enable_all()
     .build()
@@ -124,14 +140,15 @@ async fn run_integration_test_task(
     }
   }
   f.await?;
-  let mut output: Output = runtime.op_state().borrow_mut().take();
-  output.lines.push(String::new());
+  let output: Output = runtime.op_state().borrow_mut().take();
+  let mut lines = output.lines.lock().unwrap().take();
+  lines.push(String::new());
   let mut expected_output = String::new();
   File::open(test_dir.join(format!("{test}.out")))
     .await?
     .read_to_string(&mut expected_output)
     .await?;
-  actual_output += &output.lines.join("\n");
+  actual_output += &lines.join("\n");
   assert_eq!(actual_output, expected_output);
   Ok(())
 }
@@ -139,7 +156,7 @@ async fn run_integration_test_task(
 /// Run a unit test within the `checkin` runtime. This loads a file which registers a number of tests,
 /// then each test is run individually and failures are printed.
 pub fn run_unit_test(test: &str) {
-  let runtime = create_runtime();
+  let (runtime, _) = create_runtime(Output::default(), None);
   let tokio = tokio::runtime::Builder::new_current_thread()
     .enable_all()
     .build()

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -23,7 +23,7 @@ pub fn op_log_debug(#[string] s: &str) {
 #[op2(fast)]
 pub fn op_log_info(#[state] output: &mut Output, #[string] s: String) {
   println!("{s}");
-  output.lines.lock().unwrap().push(s);
+  output.line(s);
 }
 
 #[op2]

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -23,7 +23,7 @@ pub fn op_log_debug(#[string] s: &str) {
 #[op2(fast)]
 pub fn op_log_info(#[state] output: &mut Output, #[string] s: String) {
   println!("{s}");
-  output.lines.push(s);
+  output.lines.lock().unwrap().push(s);
 }
 
 #[op2]

--- a/testing/checkin/runner/ops_worker.rs
+++ b/testing/checkin/runner/ops_worker.rs
@@ -1,5 +1,5 @@
-use anyhow::bail;
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+use anyhow::bail;
 use anyhow::Error;
 use deno_core::cppgc;
 use deno_core::op2;

--- a/testing/checkin/runner/ops_worker.rs
+++ b/testing/checkin/runner/ops_worker.rs
@@ -10,7 +10,6 @@ use deno_core::v8::IsolateHandle;
 use deno_core::JsRuntime;
 use deno_core::OpState;
 use deno_core::PollEventLoopOptions;
-use futures::ready;
 use std::cell::RefCell;
 use std::future::poll_fn;
 use std::rc::Rc;

--- a/testing/checkin/runner/ops_worker.rs
+++ b/testing/checkin/runner/ops_worker.rs
@@ -1,5 +1,5 @@
-use anyhow::anyhow;
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Error;
 use deno_core::cppgc;
@@ -134,6 +134,7 @@ async fn run_worker_task(
   let url = Url::try_from(base_url.as_str())?.join(&main_script)?;
   let module = runtime.load_main_module(&url, None).await?;
   let f = runtime.mod_evaluate(module);
+  // We need this structure for the shutdown code to ensure that the output is
   if let Err(e) = poll_fn(|cx| {
     if shutdown_rx.poll_recv(cx).is_ready() {
       return Poll::Ready(Err(anyhow!("Uncaught Error: execution terminated")));

--- a/testing/checkin/runner/ops_worker.rs
+++ b/testing/checkin/runner/ops_worker.rs
@@ -1,0 +1,201 @@
+use anyhow::bail;
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+use anyhow::Error;
+use deno_core::cppgc;
+use deno_core::op2;
+use deno_core::url::Url;
+use deno_core::v8;
+use deno_core::v8::IsolateHandle;
+use deno_core::JsRuntime;
+use deno_core::OpState;
+use deno_core::PollEventLoopOptions;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::mpsc::channel;
+use std::sync::Arc;
+use tokio::sync::mpsc::unbounded_channel;
+use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::watch;
+use tokio::sync::Mutex;
+
+use super::create_runtime;
+use super::testing::Output;
+
+/// Our cppgc object.
+pub struct WorkerControl {
+  worker_channel: WorkerChannel,
+  close_watcher: WorkerCloseWatcher,
+  // TODO(mmastrac): terminate for workers
+  #[allow(dead_code)]
+  handle: Option<IsolateHandle>,
+}
+
+pub struct WorkerChannel {
+  tx: UnboundedSender<String>,
+  rx: Mutex<UnboundedReceiver<String>>,
+}
+
+#[derive(Clone)]
+pub struct WorkerCloseWatcher {
+  watcher: Arc<Mutex<watch::Receiver<bool>>>,
+}
+
+pub struct Worker {
+  _close_send: watch::Sender<bool>,
+  pub(crate) close_watcher: WorkerCloseWatcher,
+  parent_channel: std::sync::Mutex<Option<WorkerChannel>>,
+  parent_close_watcher: std::sync::Mutex<Option<WorkerCloseWatcher>>,
+}
+
+pub struct WorkerHostSide {
+  worker_channel: WorkerChannel,
+  close_watcher: WorkerCloseWatcher,
+}
+
+pub fn worker_create(
+  parent: Option<WorkerCloseWatcher>,
+) -> (Worker, WorkerHostSide) {
+  let (tx1, rx1) = unbounded_channel();
+  let (tx2, rx2) = unbounded_channel();
+  let (_close_send, close_recv) = watch::channel(false);
+  let close_watcher = WorkerCloseWatcher {
+    watcher: Arc::new(Mutex::new(close_recv)),
+  };
+  let worker = Worker {
+    _close_send,
+    close_watcher: close_watcher.clone(),
+    parent_channel: parent
+      .as_ref()
+      .map(move |_| WorkerChannel {
+        tx: tx1,
+        rx: rx2.into(),
+      })
+      .into(),
+    parent_close_watcher: parent.map(move |w| w.clone()).into(),
+  };
+  let worker_host_side = WorkerHostSide {
+    close_watcher,
+    worker_channel: WorkerChannel {
+      tx: tx2,
+      rx: rx1.into(),
+    },
+  };
+  (worker, worker_host_side)
+}
+
+#[op2]
+pub fn op_worker_spawn<'s>(
+  scope: &mut v8::HandleScope<'s>,
+  #[state] this_worker: &Worker,
+  #[state] output: &Output,
+  #[string] base_url: String,
+  #[string] main_script: String,
+) -> Result<v8::Local<'s, v8::Object>, Error> {
+  let output = output.clone();
+  let close_watcher = this_worker.close_watcher.clone();
+  let (init_send, init_recv) = channel();
+  std::thread::spawn(move || {
+    let (mut runtime, worker_host_side) =
+      create_runtime(output, Some(close_watcher));
+    init_send
+      .send(WorkerControl {
+        worker_channel: worker_host_side.worker_channel,
+        close_watcher: worker_host_side.close_watcher,
+        handle: Some(runtime.v8_isolate().thread_safe_handle()),
+      })
+      .map_err(|_| unreachable!())
+      .unwrap();
+    let tokio = tokio::runtime::Builder::new_current_thread()
+      .enable_all()
+      .build()
+      .expect("Failed to build a runtime");
+    tokio
+      .block_on(run_worker_task(runtime, base_url, main_script))
+      .expect("Failed to complete test");
+  });
+
+  // This is technically a blocking call
+  let worker = init_recv.recv()?;
+  Ok(cppgc::make_cppgc_object(scope, worker))
+}
+
+async fn run_worker_task(
+  mut runtime: JsRuntime,
+  base_url: String,
+  main_script: String,
+) -> Result<(), Error> {
+  let url = Url::try_from(base_url.as_str())?.join(&main_script)?;
+  let module = runtime.load_main_module(&url, None).await?;
+  let f = runtime.mod_evaluate(module);
+  if let Err(e) = runtime
+    .run_event_loop(PollEventLoopOptions::default())
+    .await
+  {
+    let state = runtime.op_state().clone();
+    let state = state.borrow();
+    let output: &Output = state.borrow();
+    for line in e.to_string().split('\n') {
+      output.line(format!("[ERR] {line}"));
+    }
+    return Ok(());
+  }
+  f.await?;
+  Ok(())
+}
+
+#[op2(fast)]
+pub fn op_worker_send(
+  #[cppgc] worker: &WorkerControl,
+  #[string] message: String,
+) -> Result<(), Error> {
+  worker.worker_channel.tx.send(message)?;
+  Ok(())
+}
+
+#[op2(async)]
+#[string]
+pub async fn op_worker_recv(#[cppgc] worker: &WorkerControl) -> Option<String> {
+  let message = worker.worker_channel.rx.lock().await.recv().await;
+  message
+}
+
+#[op2]
+pub fn op_worker_parent<'s>(
+  scope: &mut v8::HandleScope<'s>,
+  state: Rc<RefCell<OpState>>,
+) -> Result<v8::Local<'s, v8::Object>, Error> {
+  let state = state.borrow_mut();
+  let worker: &Worker = state.borrow();
+  let (Some(worker_channel), Some(close_watcher)) = (
+    worker.parent_channel.lock().unwrap().take(),
+    worker.parent_close_watcher.lock().unwrap().take(),
+  ) else {
+    bail!("No parent worker is available")
+  };
+  Ok(cppgc::make_cppgc_object(
+    scope,
+    WorkerControl {
+      worker_channel,
+      close_watcher,
+      handle: None,
+    },
+  ))
+}
+
+#[op2(async)]
+pub async fn op_worker_await_close(#[cppgc] worker: &WorkerControl) {
+  loop {
+    if worker
+      .close_watcher
+      .watcher
+      .lock()
+      .await
+      .changed()
+      .await
+      .is_err()
+    {
+      break;
+    }
+  }
+}

--- a/testing/checkin/runner/ops_worker.rs
+++ b/testing/checkin/runner/ops_worker.rs
@@ -72,7 +72,7 @@ pub fn worker_create(
         rx: rx2.into(),
       })
       .into(),
-    parent_close_watcher: parent.map(move |w| w.clone()).into(),
+    parent_close_watcher: parent.into(),
   };
   let worker_host_side = WorkerHostSide {
     close_watcher,
@@ -156,8 +156,7 @@ pub fn op_worker_send(
 #[op2(async)]
 #[string]
 pub async fn op_worker_recv(#[cppgc] worker: &WorkerControl) -> Option<String> {
-  let message = worker.worker_channel.rx.lock().await.recv().await;
-  message
+  worker.worker_channel.rx.lock().await.recv().await
 }
 
 #[op2]

--- a/testing/checkin/runner/testing.rs
+++ b/testing/checkin/runner/testing.rs
@@ -2,12 +2,19 @@
 use std::any::Any;
 use std::any::TypeId;
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
 
 use deno_core::v8;
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Output {
-  pub lines: Vec<String>,
+  pub lines: Arc<Mutex<Vec<String>>>,
+}
+impl Output {
+  pub fn line(&self, line: String) {
+    self.lines.lock().unwrap().push(line)
+  }
 }
 
 #[derive(Default)]

--- a/testing/checkin/runner/testing.rs
+++ b/testing/checkin/runner/testing.rs
@@ -15,6 +15,10 @@ impl Output {
   pub fn line(&self, line: String) {
     self.lines.lock().unwrap().push(line)
   }
+
+  pub fn take(&self) -> Vec<String> {
+    std::mem::take(&mut self.lines.lock().unwrap())
+  }
 }
 
 #[derive(Default)]

--- a/testing/checkin/runtime/__init.js
+++ b/testing/checkin/runtime/__init.js
@@ -4,6 +4,7 @@ import * as async from "checkin:async";
 import * as testing from "checkin:testing";
 import * as console from "checkin:console";
 import * as timers from "checkin:timers";
+import * as worker from "checkin:worker";
 testing;
 async;
 
@@ -12,6 +13,7 @@ globalThis.setTimeout = timers.setTimeout;
 globalThis.setInterval = timers.setInterval;
 globalThis.clearTimeout = timers.clearTimeout;
 globalThis.clearInterval = timers.clearInterval;
+globalThis.Worker = worker.Worker;
 Reflect.defineProperty(globalThis, "onunhandledrejection", {
   set: (cb) => {
     if (cb) {

--- a/testing/checkin/runtime/worker.ts
+++ b/testing/checkin/runtime/worker.ts
@@ -5,6 +5,7 @@ import {
   op_worker_recv,
   op_worker_send,
   op_worker_spawn,
+  op_worker_terminate,
 } from "ext:core/ops";
 
 const privateConstructor = Symbol();
@@ -31,6 +32,10 @@ export class Worker {
 
   async receiveMessage(): Promise<string | undefined> {
     return await op_worker_recv(this.#worker);
+  }
+
+  terminate() {
+    op_worker_terminate(this.#worker);
   }
 
   get closed(): Promise<void> {

--- a/testing/checkin/runtime/worker.ts
+++ b/testing/checkin/runtime/worker.ts
@@ -1,0 +1,46 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import {
+  op_worker_await_close,
+  op_worker_parent,
+  op_worker_recv,
+  op_worker_send,
+  op_worker_spawn,
+} from "ext:core/ops";
+
+const privateConstructor = Symbol();
+let parentWorker = null;
+
+export class Worker {
+  // deno-lint-ignore no-explicit-any
+  #worker: any;
+
+  // deno-lint-ignore no-explicit-any
+  constructor(privateParent: symbol, worker: any);
+  constructor(baseUrl: string, url: string);
+  constructor(arg1: unknown, arg2: unknown) {
+    if (arg1 == privateConstructor) {
+      this.#worker = arg2;
+    } else {
+      this.#worker = op_worker_spawn(arg1, arg2);
+    }
+  }
+
+  sendMessage(message: string) {
+    op_worker_send(this.#worker, message);
+  }
+
+  async receiveMessage(): Promise<string | undefined> {
+    return await op_worker_recv(this.#worker);
+  }
+
+  get closed(): Promise<void> {
+    return op_worker_await_close(this.#worker);
+  }
+
+  static get parent(): Worker {
+    if (parentWorker === null) {
+      parentWorker = new Worker(privateConstructor, op_worker_parent());
+    }
+    return parentWorker;
+  }
+}

--- a/testing/integration/error_async_stack/error_async_stack.out
+++ b/testing/integration/error_async_stack/error_async_stack.out
@@ -1,8 +1,8 @@
-[ERR] Error: async
-[ERR]     at test:///integration/error_async_stack/error_async_stack.js:5:13
-[ERR]     at async test:///integration/error_async_stack/error_async_stack.js:4:5
-[ERR]     at async test:///integration/error_async_stack/error_async_stack.js:9:5
 Error: async
     at test:///integration/error_async_stack/error_async_stack.js:5:13
     at async test:///integration/error_async_stack/error_async_stack.js:4:5
     at async test:///integration/error_async_stack/error_async_stack.js:9:5
+[ERR] Error: async
+[ERR]     at test:///integration/error_async_stack/error_async_stack.js:5:13
+[ERR]     at async test:///integration/error_async_stack/error_async_stack.js:4:5
+[ERR]     at async test:///integration/error_async_stack/error_async_stack.js:9:5

--- a/testing/integration/worker_spawn/worker.ts
+++ b/testing/integration/worker_spawn/worker.ts
@@ -1,0 +1,4 @@
+import { Worker } from "checkin:worker";
+Worker.parent.sendMessage("hello from client");
+const message = await Worker.parent.receiveMessage();
+console.log(`worker got from main "${message}"`);

--- a/testing/integration/worker_spawn/worker.ts
+++ b/testing/integration/worker_spawn/worker.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { Worker } from "checkin:worker";
 Worker.parent.sendMessage("hello from client");
 const message = await Worker.parent.receiveMessage();

--- a/testing/integration/worker_spawn/worker_spawn.out
+++ b/testing/integration/worker_spawn/worker_spawn.out
@@ -1,0 +1,5 @@
+main started
+main worker booted
+main got from worker "hello from client"
+worker got from main "ok from main"
+main exiting

--- a/testing/integration/worker_spawn/worker_spawn.ts
+++ b/testing/integration/worker_spawn/worker_spawn.ts
@@ -1,0 +1,9 @@
+import { Worker } from "checkin:worker";
+console.log("main started");
+const worker = new Worker(import.meta.url, "./worker.ts");
+console.log("main worker booted");
+const message = await worker.receiveMessage();
+console.log(`main got from worker "${message}"`);
+worker.sendMessage("ok from main");
+await worker.closed;
+console.log("main exiting");

--- a/testing/integration/worker_spawn/worker_spawn.ts
+++ b/testing/integration/worker_spawn/worker_spawn.ts
@@ -1,3 +1,4 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 import { Worker } from "checkin:worker";
 console.log("main started");
 const worker = new Worker(import.meta.url, "./worker.ts");

--- a/testing/integration/worker_terminate/worker.ts
+++ b/testing/integration/worker_terminate/worker.ts
@@ -1,0 +1,5 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import { Worker } from "checkin:worker";
+Worker.parent.sendMessage("hello from client");
+const message = await Worker.parent.receiveMessage();
+console.log(`worker got from main "${message}"`);

--- a/testing/integration/worker_terminate/worker_terminate.out
+++ b/testing/integration/worker_terminate/worker_terminate.out
@@ -1,0 +1,5 @@
+main started
+main worker booted
+main got from worker "hello from client"
+[ERR] Uncaught Error: execution terminated
+main exiting

--- a/testing/integration/worker_terminate/worker_terminate.ts
+++ b/testing/integration/worker_terminate/worker_terminate.ts
@@ -1,0 +1,10 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import { Worker } from "checkin:worker";
+console.log("main started");
+const worker = new Worker(import.meta.url, "./worker.ts");
+console.log("main worker booted");
+const message = await worker.receiveMessage();
+console.log(`main got from worker "${message}"`);
+worker.terminate();
+await worker.closed;
+console.log("main exiting");

--- a/testing/lib.rs
+++ b/testing/lib.rs
@@ -60,5 +60,4 @@ integration_test!(
   timer_ref_and_cancel,
   timer_many,
   worker_spawn,
-  worker_terminate,
 );

--- a/testing/lib.rs
+++ b/testing/lib.rs
@@ -60,4 +60,5 @@ integration_test!(
   timer_ref_and_cancel,
   timer_many,
   worker_spawn,
+  worker_terminate,
 );

--- a/testing/lib.rs
+++ b/testing/lib.rs
@@ -59,4 +59,6 @@ integration_test!(
   timer_ref,
   timer_ref_and_cancel,
   timer_many,
+  worker_spawn,
+  worker_terminate,
 );

--- a/testing/tsconfig.json
+++ b/testing/tsconfig.json
@@ -5,7 +5,8 @@
     "paths": {
       "checkin:async": ["checkin/runtime/async.ts"],
       "checkin:console": ["checkin/runtime/console.ts"],
-      "checkin:testing": ["checkin/runtime/testing.ts"]
+      "checkin:testing": ["checkin/runtime/testing.ts"],
+      "checkin:worker": ["checkin/runtime/worker.ts"]
     },
     "lib": ["ESNext", "DOM", "ES2023.Array"],
     "module": "ES2022",


### PR DESCRIPTION
We can spawn a worker and send messages to it (and it can send messages back), and terminate it.