### PR TITLE
feat: Add property definition utilities to Deno.core

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -1,4 +1,4 @@
-\// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 "use strict";
 
 ((window) => {
@@ -463,7 +463,7 @@
       configurable: true,
     };
   }
-  
+
   function propNonEnumerable(value) {
     return {
       value,
@@ -472,7 +472,7 @@
       configurable: true,
     };
   }
-  
+
   function propReadOnly(value) {
     return {
       value,
@@ -481,7 +481,7 @@
       configurable: true,
     };
   }
-  
+
   function propGetterOnly(getter) {
     return {
       get: getter,
@@ -491,10 +491,10 @@
     };
   }
 
-  function propNonEnumerableLazyLoaded(getter, loadFn){
+  function propNonEnumerableLazyLoaded(getter, loadFn) {
     let valueIsSet = false;
     let value;
-  
+
     return {
       get() {
         loadFn();

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -546,7 +546,7 @@
         value = op_lazy_load_esm(specifier);
       }
       return value;
-    }
+    };
   }
 
   // Extra Deno.core.* exports

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+\// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 "use strict";
 
 ((window) => {
@@ -455,6 +455,65 @@
     op_is_weak_set,
   } = ensureFastOps();
 
+  function propWritable(value) {
+    return {
+      value,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    };
+  }
+  
+  function propNonEnumerable(value) {
+    return {
+      value,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    };
+  }
+  
+  function propReadOnly(value) {
+    return {
+      value,
+      enumerable: true,
+      writable: false,
+      configurable: true,
+    };
+  }
+  
+  function propGetterOnly(getter) {
+    return {
+      get: getter,
+      set() {},
+      enumerable: true,
+      configurable: true,
+    };
+  }
+
+  function propNonEnumerableLazyLoaded(getter, loadFn){
+    let valueIsSet = false;
+    let value;
+  
+    return {
+      get() {
+        loadFn();
+        if (valueIsSet) {
+          return value;
+        } else {
+          return getter();
+        }
+      },
+      set(v) {
+        loadFn();
+        valueIsSet = true;
+        value = v;
+      },
+      enumerable: false,
+      configurable: true,
+    };
+  }
+
   // Extra Deno.core.* exports
   const core = ObjectAssign(globalThis.Deno.core, {
     internalRidSymbol: Symbol("Deno.internal.rid"),
@@ -554,6 +613,11 @@
     currentUserCallSite,
     wrapConsole,
     v8Console,
+    propReadOnly,
+    propWritable,
+    propNonEnumerable,
+    propGetterOnly,
+    propNonEnumerableLazyLoaded,
   });
 
   const internals = {};

--- a/core/lib.deno_core.d.ts
+++ b/core/lib.deno_core.d.ts
@@ -304,8 +304,14 @@ declare namespace Deno {
     function propReadOnly(value: unknown): PropertyDescriptor;
     function propGetterOnly(value: unknown): PropertyDescriptor;
 
-    function propWritableLazyLoaded<T>(getter: (loadedValue: T) => unknown, loadFn: LazyLoader<T>): PropertyDescriptor;
-    function propNonEnumerableLazyLoaded<T>(getter: (loadedValue: T) => unknown, loadFn: LazyLoader<T>): PropertyDescriptor;
+    function propWritableLazyLoaded<T>(
+      getter: (loadedValue: T) => unknown,
+      loadFn: LazyLoader<T>,
+    ): PropertyDescriptor;
+    function propNonEnumerableLazyLoaded<T>(
+      getter: (loadedValue: T) => unknown,
+      loadFn: LazyLoader<T>,
+    ): PropertyDescriptor;
 
     type LazyLoader<T> = () => T;
     function createLazyLoader<T = unknown>(specifier: string): LazyLoader<T>;

--- a/core/lib.deno_core.d.ts
+++ b/core/lib.deno_core.d.ts
@@ -299,6 +299,17 @@ declare namespace Deno {
     function isWeakMap(value: unknown): value is WeakMap<WeakKey, unknown>;
     function isWeakSet(value: unknown): value is WeakSet<WeakKey>;
 
+    function propWritable(value: unknown): PropertyDescriptor;
+    function propNonEnumerable(value: unknown): PropertyDescriptor;
+    function propReadOnly(value: unknown): PropertyDescriptor;
+    function propGetterOnly(value: unknown): PropertyDescriptor;
+
+    function propWritableLazyLoaded<T>(getter: (loadedValue: T) => unknown, loadFn: LazyLoader<T>): PropertyDescriptor;
+    function propNonEnumerableLazyLoaded<T>(getter: (loadedValue: T) => unknown, loadFn: LazyLoader<T>): PropertyDescriptor;
+
+    type LazyLoader<T> = () => T;
+    function createLazyLoader<T = unknown>(specifier: string): LazyLoader<T>;
+
     const build: {
       target: string;
       arch: string;

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -431,10 +431,10 @@ fn test_lazy_loaded_esm() {
       "setup.js",
       r#"
       Deno.core.print("1\n");
-      const module = Deno.core.ops.op_lazy_load_esm("ext:test_ext/lazy_loaded.js");
+      const module = Deno.core.createLazyLoader("ext:test_ext/lazy_loaded.js")();
       module.blah("hello\n");
       Deno.core.print(`${JSON.stringify(module)}\n`);
-      const module1 = Deno.core.ops.op_lazy_load_esm("ext:test_ext/lazy_loaded.js");
+      const module1 = Deno.core.createLazyLoader("ext:test_ext/lazy_loaded.js")();
       if (module !== module1) throw new Error("should return the same error");
       "#,
     )


### PR DESCRIPTION
These are common utilities that are duplicated several times in `deno` and Deploy.