### PR TITLE
feat: Add `dcore` bin target

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,10 @@ readme = "README.md"
 repository.workspace = true
 description = "A modern JavaScript/TypeScript runtime built with V8, Rust, and Tokio"
 
+[[bin]]
+name = "deno_core"
+path = "main.rs"
+
 [lib]
 path = "lib.rs"
 
@@ -32,9 +36,9 @@ bit-set.workspace = true
 bit-vec.workspace = true
 bytes.workspace = true
 cooked-waker.workspace = true
+deno_core_icudata = { workspace = true, optional = true }
 deno_ops.workspace = true
 deno_unsync.workspace = true
-deno_core_icudata = { workspace = true, optional = true }
 futures.workspace = true
 libc.workspace = true
 log.workspace = true
@@ -52,11 +56,11 @@ url.workspace = true
 v8.workspace = true
 
 [dev-dependencies]
-deno_ast.workspace = true
 bencher.workspace = true
+deno_ast.workspace = true
+fastrand.workspace = true
 pretty_assertions.workspace = true
 rstest.workspace = true
-fastrand.workspace = true
 unicycle = "0"
 
 [[bench]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 description = "A modern JavaScript/TypeScript runtime built with V8, Rust, and Tokio"
 
 [[bin]]
-name = "deno_core"
+name = "dcore"
 path = "main.rs"
 
 [lib]

--- a/core/main.rs
+++ b/core/main.rs
@@ -72,8 +72,11 @@ fn text_module(
 
 fn main() -> Result<(), Error> {
   let args: Vec<String> = std::env::args().collect();
+  eprintln!(
+    "🛑 deno_core binary is meant for development and testing purposes."
+  );
   if args.len() < 2 {
-    println!("Usage: target/examples/debug/fs_module_loader <path_to_module>");
+    println!("Usage: cargo run -- <path_to_module>");
     std::process::exit(1);
   }
   let main_url = &args[1];


### PR DESCRIPTION
This commit adds minimal binary target to "deno_core" crate.

It is now possible to "cargo run ./path/to/file.ts" to execute a file.
This feature is being added for development and testing purposes only
and is not meant for end-users. The API is minimal and the binary can't
do anything interesting.

"fs_module_loader" example has been removed in favor of binary target.

Closes https://github.com/denoland/deno_core/issues/412
Once #415 lands we can extend functionality further.