### PR TITLE
feat: Add bindings to analyse WASM modules

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -98,6 +98,7 @@ pub use crate::module_specifier::resolve_url;
 pub use crate::module_specifier::resolve_url_or_path;
 pub use crate::module_specifier::ModuleResolutionError;
 pub use crate::module_specifier::ModuleSpecifier;
+pub use crate::modules::CustomModuleEvaluationCtx;
 pub use crate::modules::CustomModuleEvaluationKind;
 pub use crate::modules::ExtModuleLoaderCb;
 pub use crate::modules::FsModuleLoader;

--- a/core/main.rs
+++ b/core/main.rs
@@ -4,6 +4,7 @@ use anyhow::anyhow;
 use anyhow::Context;
 use deno_core::anyhow::Error;
 use deno_core::v8;
+use deno_core::CustomModuleEvaluationCtx;
 use deno_core::CustomModuleEvaluationKind;
 use deno_core::FastString;
 use deno_core::FsModuleLoader;
@@ -15,6 +16,7 @@ use std::rc::Rc;
 
 fn custom_module_evaluation_cb(
   scope: &mut v8::HandleScope,
+  _ctx: CustomModuleEvaluationCtx,
   module_type: Cow<'_, str>,
   module_name: &FastString,
   code: ModuleSourceCode,

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -324,12 +324,16 @@ impl ModuleMap {
           ))));
         };
 
+        let ctx = JsRealm::get_custom_module_evaluation_ctx(scope);
+
         // TODO(bartlomieju): creating a global just to create a local from it
         // seems superfluous. However, changing `CustomModuleEvaluationCb` to have
         // a lifetime will have a viral effect and required `JsRuntimeOptions`
         // to have a callback as well as `JsRuntime`.
+
         let module_evaluation_kind = custom_evaluation_cb(
           scope,
+          ctx,
           module_type.clone(),
           &module_url_found,
           code,

--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -11,6 +11,7 @@ use serde::Serialize;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::future::Future;
+use std::rc::Rc;
 use std::sync::Arc;
 
 mod loaders;
@@ -124,11 +125,75 @@ pub(crate) fn default_import_meta_resolve_cb(
 pub type ValidateImportAttributesCb =
   Box<dyn Fn(&mut v8::HandleScope, &HashMap<String, String>)>;
 
+pub struct CustomModuleEvaluationCtx {
+  pub(crate) web_assembly_module_imports_fn: Rc<v8::Global<v8::Function>>,
+  pub(crate) web_assembly_module_exports_fn: Rc<v8::Global<v8::Function>>,
+}
+
+#[derive(Debug)]
+pub struct WasmModuleAnalysis {
+  pub imports: Vec<WebAssemblyImportDescriptor>,
+  pub exports: Vec<WebAssemblyExportDescriptor>,
+}
+#[derive(Debug, Deserialize)]
+pub struct WebAssemblyImportDescriptor {
+  pub module: String,
+  pub name: String,
+  pub kind: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WebAssemblyExportDescriptor {
+  pub name: String,
+  pub kind: String,
+}
+
+impl CustomModuleEvaluationCtx {
+  pub fn analyze_wasm_module(
+    &self,
+    scope: &mut v8::HandleScope,
+    value: v8::Local<v8::Value>,
+  ) -> Result<WasmModuleAnalysis, Error> {
+    let web_assembly_module_imports_fn: v8::Local<v8::Function> =
+      v8::Local::new(scope, self.web_assembly_module_imports_fn.as_ref());
+    let web_assembly_module_exports_fn: v8::Local<v8::Function> =
+      v8::Local::new(scope, self.web_assembly_module_exports_fn.as_ref());
+    let receiver = v8::undefined(scope);
+
+    let tc_scope = &mut v8::TryCatch::new(scope);
+
+    let import_result =
+      web_assembly_module_imports_fn.call(tc_scope, receiver.into(), &[value]);
+
+    if tc_scope.has_caught() {
+      let exception = tc_scope.exception().unwrap();
+      return exception_to_err_result(tc_scope, exception, false, false);
+    }
+
+    let imports: Vec<WebAssemblyImportDescriptor> =
+      serde_v8::from_v8(tc_scope, import_result.unwrap()).unwrap();
+
+    let export_result =
+      web_assembly_module_exports_fn.call(tc_scope, receiver.into(), &[value]);
+
+    if tc_scope.has_caught() {
+      let exception = tc_scope.exception().unwrap();
+      return exception_to_err_result(tc_scope, exception, false, false);
+    }
+
+    let exports: Vec<WebAssemblyExportDescriptor> =
+      serde_v8::from_v8(tc_scope, export_result.unwrap()).unwrap();
+
+    Ok(WasmModuleAnalysis { imports, exports })
+  }
+}
+
 /// Callback to validate import attributes. If the validation fails and exception
 /// should be thrown using `scope.throw_exception()`.
 pub type CustomModuleEvaluationCb = Box<
   dyn Fn(
     &mut v8::HandleScope,
+    CustomModuleEvaluationCtx,
     Cow<'_, str>,
     &FastString,
     ModuleSourceCode,

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -5,6 +5,7 @@ use crate::error::generic_error;
 use crate::modules::loaders::ModuleLoadEventCounts;
 use crate::modules::loaders::TestingModuleLoader;
 use crate::modules::loaders::*;
+use crate::modules::CustomModuleEvaluationCtx;
 use crate::modules::CustomModuleEvaluationKind;
 use crate::modules::ModuleCodeBytes;
 use crate::modules::ModuleError;
@@ -754,6 +755,7 @@ fn test_custom_module_type_default() {
 fn test_custom_module_type_callback_synthetic() {
   fn custom_eval_cb(
     scope: &mut v8::HandleScope,
+    _ctx: CustomModuleEvaluationCtx,
     module_type: Cow<'_, str>,
     _module_name: &FastString,
     module_code: ModuleSourceCode,
@@ -836,6 +838,7 @@ fn test_custom_module_type_callback_synthetic() {
 fn test_custom_module_type_callback_computed() {
   fn custom_eval_cb(
     scope: &mut v8::HandleScope,
+    _ctx: CustomModuleEvaluationCtx,
     module_type: Cow<'_, str>,
     module_name: &FastString,
     module_code: ModuleSourceCode,

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -153,6 +153,7 @@ pub mod v8_static_strings {
   pub static CALL_CONSOLE: &[u8] = b"callConsole";
   pub static FILENAME: &[u8] = b"filename";
   pub static DIRNAME: &[u8] = b"dirname";
+  pub static SET_UP_ASYNC_STUB: &[u8] = b"setUpAsyncStub";
 }
 
 /// Create an object on the `globalThis` that looks like this:
@@ -208,7 +209,7 @@ pub(crate) fn initialize_deno_core_namespace<'s>(
     let console_obj: v8::Local<v8::Object> = get(
       scope,
       extra_binding_obj,
-      b"console",
+      v8_static_strings::CONSOLE,
       "ExtrasBindingObject.console",
     );
     let console_key = v8_static_strings::new(scope, v8_static_strings::CONSOLE);
@@ -250,14 +251,19 @@ pub(crate) fn initialize_deno_core_ops_bindings<'s>(
   // Set up JavaScript bindings for the defined op - this will insert proper
   // `v8::Function` into `Deno.core.ops` object. For async ops, there a bit
   // more machinery involved, see comment below.
-  let deno_obj = get(scope, global, b"Deno", "Deno");
-  let deno_core_obj = get(scope, deno_obj, b"core", "Deno.core");
-  let deno_core_ops_obj: v8::Local<v8::Object> =
-    get(scope, deno_core_obj, b"ops", "Deno.core.ops");
+  let deno_obj = get(scope, global, v8_static_strings::DENO, "Deno");
+  let deno_core_obj =
+    get(scope, deno_obj, v8_static_strings::CORE, "Deno.core");
+  let deno_core_ops_obj: v8::Local<v8::Object> = get(
+    scope,
+    deno_core_obj,
+    v8_static_strings::OPS,
+    "Deno.core.ops",
+  );
   let set_up_async_stub_fn: v8::Local<v8::Function> = get(
     scope,
     deno_core_obj,
-    b"setUpAsyncStub",
+    v8_static_strings::SET_UP_ASYNC_STUB,
     "Deno.core.setUpAsyncStub",
   );
 
@@ -728,12 +734,13 @@ pub fn create_exports_for_ops_virtual_module<'s>(
 ) -> Vec<(FastString, v8::Local<'s, v8::Value>)> {
   let mut exports = Vec::with_capacity(op_ctxs.len());
 
-  let deno_obj = get(scope, global, b"Deno", "Deno");
-  let deno_core_obj = get(scope, deno_obj, b"core", "Deno.core");
+  let deno_obj = get(scope, global, v8_static_strings::DENO, "Deno");
+  let deno_core_obj =
+    get(scope, deno_obj, v8_static_strings::CORE, "Deno.core");
   let set_up_async_stub_fn: v8::Local<v8::Function> = get(
     scope,
     deno_core_obj,
-    b"setUpAsyncStub",
+    v8_static_strings::SET_UP_ASYNC_STUB,
     "Deno.core.setUpAsyncStub",
   );
 

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -113,7 +113,7 @@ pub fn script_origin<'a>(
   )
 }
 
-fn get<'s, T>(
+pub(crate) fn get<'s, T>(
   scope: &mut v8::HandleScope<'s>,
   from: v8::Local<v8::Object>,
   key: &'static [u8],

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -154,6 +154,10 @@ pub mod v8_static_strings {
   pub static FILENAME: &[u8] = b"filename";
   pub static DIRNAME: &[u8] = b"dirname";
   pub static SET_UP_ASYNC_STUB: &[u8] = b"setUpAsyncStub";
+  pub static WEBASSEMBLY: &[u8] = b"WebAssembly";
+  pub static MODULE: &[u8] = b"Module";
+  pub static IMPORTS: &[u8] = b"imports";
+  pub static EXPORTS: &[u8] = b"exports";
 }
 
 /// Create an object on the `globalThis` that looks like this:

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -122,7 +122,7 @@ fn get<'s, T>(
 where
   v8::Local<'s, v8::Value>: TryInto<T>,
 {
-  let key = v8::String::new_external_onebyte_static(scope, key).unwrap();
+  let key = v8_static_strings::new(scope, key);
   from
     .get(scope, key.into())
     .unwrap_or_else(|| panic!("{path} exists"))
@@ -131,6 +131,13 @@ where
 }
 
 pub mod v8_static_strings {
+  pub fn new<'s>(
+    scope: &mut v8::HandleScope<'s>,
+    str_: &'static [u8],
+  ) -> v8::Local<'s, v8::String> {
+    v8::String::new_external_onebyte_static(scope, str_).unwrap()
+  }
+
   pub static DENO: &[u8] = b"Deno";
   pub static CORE: &[u8] = b"core";
   pub static OPS: &[u8] = b"ops";
@@ -144,6 +151,8 @@ pub mod v8_static_strings {
   pub static BUILD_CUSTOM_ERROR: &[u8] = b"buildCustomError";
   pub static CONSOLE: &[u8] = b"console";
   pub static CALL_CONSOLE: &[u8] = b"callConsole";
+  pub static FILENAME: &[u8] = b"filename";
+  pub static DIRNAME: &[u8] = b"dirname";
 }
 
 /// Create an object on the `globalThis` that looks like this:
@@ -164,9 +173,7 @@ pub(crate) fn initialize_deno_core_namespace<'s>(
   init_mode: InitMode,
 ) {
   let global = context.global(scope);
-  let deno_str =
-    v8::String::new_external_onebyte_static(scope, v8_static_strings::DENO)
-      .unwrap();
+  let deno_str = v8_static_strings::new(scope, v8_static_strings::DENO);
 
   let maybe_deno_obj_val = global.get(scope, deno_str.into());
 
@@ -178,14 +185,10 @@ pub(crate) fn initialize_deno_core_namespace<'s>(
   }
 
   let deno_obj = v8::Object::new(scope);
-  let deno_core_key =
-    v8::String::new_external_onebyte_static(scope, v8_static_strings::CORE)
-      .unwrap();
+  let deno_core_key = v8_static_strings::new(scope, v8_static_strings::CORE);
   // Set up `Deno.core.ops` object
   let deno_core_ops_obj = v8::Object::new(scope);
-  let deno_core_ops_key =
-    v8::String::new_external_onebyte_static(scope, v8_static_strings::OPS)
-      .unwrap();
+  let deno_core_ops_key = v8_static_strings::new(scope, v8_static_strings::OPS);
 
   let deno_core_obj = v8::Object::new(scope);
   deno_core_obj
@@ -196,11 +199,8 @@ pub(crate) fn initialize_deno_core_namespace<'s>(
   if init_mode == InitMode::New {
     // Bind `call_console` to Deno.core.callConsole
     let call_console_fn = v8::Function::new(scope, call_console).unwrap();
-    let call_console_key = v8::String::new_external_onebyte_static(
-      scope,
-      v8_static_strings::CALL_CONSOLE,
-    )
-    .unwrap();
+    let call_console_key =
+      v8_static_strings::new(scope, v8_static_strings::CALL_CONSOLE);
     deno_core_obj.set(scope, call_console_key.into(), call_console_fn.into());
 
     // Bind v8 console object to Deno.core.console
@@ -211,11 +211,7 @@ pub(crate) fn initialize_deno_core_namespace<'s>(
       b"console",
       "ExtrasBindingObject.console",
     );
-    let console_key = v8::String::new_external_onebyte_static(
-      scope,
-      v8_static_strings::CONSOLE,
-    )
-    .unwrap();
+    let console_key = v8_static_strings::new(scope, v8_static_strings::CONSOLE);
     deno_core_obj.set(scope, console_key.into(), console_obj.into());
   }
 
@@ -231,11 +227,7 @@ pub(crate) fn initialize_primordials_and_infra(
   for file_source in CONTEXT_SETUP_SOURCES {
     let code = file_source.load().unwrap();
     let source_str = code.v8_string(scope).unwrap();
-    let name = v8::String::new_external_onebyte_static(
-      scope,
-      file_source.specifier.as_bytes(),
-    )
-    .unwrap();
+    let name = v8_static_strings::new(scope, file_source.specifier.as_bytes());
     let origin = script_origin(scope, name);
     // TODO(bartlomieju): these two calls will panic if there's any problem in the JS code
     let script = v8::Script::compile(scope, source_str, Some(&origin))
@@ -272,11 +264,7 @@ pub(crate) fn initialize_deno_core_ops_bindings<'s>(
   let undefined = v8::undefined(scope);
   for op_ctx in op_ctxs {
     let mut op_fn = op_ctx_function(scope, op_ctx);
-    let key = v8::String::new_external_onebyte_static(
-      scope,
-      op_ctx.decl.name.as_bytes(),
-    )
-    .unwrap();
+    let key = v8_static_strings::new(scope, op_ctx.decl.name.as_bytes());
 
     // For async ops we need to set them up, by calling `Deno.core.setUpAsyncStub` -
     // this call will generate an optimized function that binds to the provided
@@ -298,9 +286,7 @@ fn op_ctx_function<'s>(
 ) -> v8::Local<'s, v8::Function> {
   let op_ctx_ptr = op_ctx as *const OpCtx as *const c_void;
   let external = v8::External::new(scope, op_ctx_ptr as *mut c_void);
-  let v8name =
-    v8::String::new_external_onebyte_static(scope, op_ctx.decl.name.as_bytes())
-      .unwrap();
+  let v8name = v8_static_strings::new(scope, op_ctx.decl.name.as_bytes());
 
   let (slow_fn, fast_fn) = if op_ctx.metrics_enabled() {
     (
@@ -440,15 +426,11 @@ pub extern "C" fn host_initialize_import_meta_object_callback(
     .get_name_by_module(&module_global)
     .expect("Module not found");
 
-  let url_key =
-    v8::String::new_external_onebyte_static(scope, v8_static_strings::URL)
-      .unwrap();
+  let url_key = v8_static_strings::new(scope, v8_static_strings::URL);
   let url_val = v8::String::new(scope, &name).unwrap();
   meta.create_data_property(scope, url_key.into(), url_val.into());
 
-  let main_key =
-    v8::String::new_external_onebyte_static(scope, v8_static_strings::MAIN)
-      .unwrap();
+  let main_key = v8_static_strings::new(scope, v8_static_strings::MAIN);
   let main = module_map.is_main_module(&module_global);
   let main_val = v8::Boolean::new(scope, main);
   meta.create_data_property(scope, main_key.into(), main_val.into());
@@ -456,9 +438,7 @@ pub extern "C" fn host_initialize_import_meta_object_callback(
   let builder =
     v8::FunctionBuilder::new(import_meta_resolve).data(url_val.into());
   let val = v8::FunctionBuilder::<v8::Function>::build(builder, scope).unwrap();
-  let resolve_key =
-    v8::String::new_external_onebyte_static(scope, v8_static_strings::RESOLVE)
-      .unwrap();
+  let resolve_key = v8_static_strings::new(scope, v8_static_strings::RESOLVE);
   meta.set(scope, resolve_key.into(), val.into());
 
   maybe_add_import_meta_filename_dirname(scope, meta, &name);
@@ -490,8 +470,7 @@ fn maybe_add_import_meta_filename_dirname(
   let Some(filename_val) = v8::String::new(scope, &escaped_filename) else {
     return;
   };
-  let filename_key =
-    v8::String::new_external_onebyte_static(scope, b"filename").unwrap();
+  let filename_key = v8_static_strings::new(scope, v8_static_strings::FILENAME);
   meta.create_data_property(scope, filename_key.into(), filename_val.into());
 
   let dir_path = file_path
@@ -502,8 +481,7 @@ fn maybe_add_import_meta_filename_dirname(
   let Some(dirname_val) = v8::String::new(scope, &escaped_dirname) else {
     return;
   };
-  let dirname_key =
-    v8::String::new_external_onebyte_static(scope, b"dirname").unwrap();
+  let dirname_key = v8_static_strings::new(scope, v8_static_strings::DIRNAME);
   meta.create_data_property(scope, dirname_key.into(), dirname_val.into());
 }
 
@@ -584,11 +562,8 @@ fn catch_dynamic_import_promise_error(
     if !has_call_site(scope, arg) {
       let msg = v8::Exception::create_message(scope, arg);
       let arg: v8::Local<v8::Object> = arg.try_into().unwrap();
-      let message_key = v8::String::new_external_onebyte_static(
-        scope,
-        v8_static_strings::MESSAGE,
-      )
-      .unwrap();
+      let message_key =
+        v8_static_strings::new(scope, v8_static_strings::MESSAGE);
       let message = arg.get(scope, message_key.into()).unwrap();
       let mut message: v8::Local<v8::String> = message.try_into().unwrap();
       if let Some(stack_frame) = JsStackFrame::from_v8_message(scope, msg) {
@@ -605,14 +580,9 @@ fn catch_dynamic_import_promise_error(
         "ReferenceError" => v8::Exception::reference_error(scope, message),
         _ => v8::Exception::error(scope, message),
       };
-      let code_key =
-        v8::String::new_external_onebyte_static(scope, v8_static_strings::CODE)
-          .unwrap();
-      let code_value = v8::String::new_external_onebyte_static(
-        scope,
-        v8_static_strings::ERR_MODULE_NOT_FOUND,
-      )
-      .unwrap();
+      let code_key = v8_static_strings::new(scope, v8_static_strings::CODE);
+      let code_value =
+        v8_static_strings::new(scope, v8_static_strings::ERR_MODULE_NOT_FOUND);
       let exception_obj = exception.to_object(scope).unwrap();
       exception_obj.set(scope, code_key.into(), code_value.into());
       scope.throw_exception(exception);
@@ -770,11 +740,7 @@ pub fn create_exports_for_ops_virtual_module<'s>(
   let undefined = v8::undefined(scope);
 
   for op_ctx in op_ctxs {
-    let name = v8::String::new_external_onebyte_static(
-      scope,
-      op_ctx.decl.name.as_bytes(),
-    )
-    .unwrap();
+    let name = v8_static_strings::new(scope, op_ctx.decl.name.as_bytes());
     let mut op_fn = op_ctx_function(scope, op_ctx);
 
     // For async ops we need to set them up, by calling `Deno.core.setUpAsyncStub` -

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -5,6 +5,7 @@ use super::exception_state::ExceptionState;
 use super::op_driver::OpDriver;
 use crate::error::exception_to_err_result;
 use crate::module_specifier::ModuleSpecifier;
+use crate::modules::CustomModuleEvaluationCtx;
 use crate::modules::ModuleCodeString;
 use crate::modules::ModuleId;
 use crate::modules::ModuleMap;
@@ -366,6 +367,26 @@ impl JsRealm {
   pub(crate) fn increment_modules_idle(&self) {
     let count = &self.0.module_map.dyn_module_evaluate_idle_counter;
     count.set(count.get() + 1)
+  }
+
+  pub(crate) fn get_custom_module_evaluation_ctx(
+    scope: &mut v8::HandleScope,
+  ) -> CustomModuleEvaluationCtx {
+    let state = Self::state_from_scope(scope);
+    let web_assembly_module_imports_fn = state
+      .web_assembly_module_imports_fn
+      .borrow()
+      .clone()
+      .unwrap();
+    let web_assembly_module_exports_fn = state
+      .web_assembly_module_exports_fn
+      .borrow()
+      .clone()
+      .unwrap();
+    CustomModuleEvaluationCtx {
+      web_assembly_module_imports_fn,
+      web_assembly_module_exports_fn,
+    }
   }
 
   /// Asynchronously load specified module and all of its dependencies.

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -61,6 +61,10 @@ pub(crate) struct ContextState {
     RefCell<Option<Rc<v8::Global<v8::Function>>>>,
   pub(crate) js_wasm_streaming_cb:
     RefCell<Option<Rc<v8::Global<v8::Function>>>>,
+  pub(crate) web_assembly_module_imports_fn:
+    RefCell<Option<Rc<v8::Global<v8::Function>>>>,
+  pub(crate) web_assembly_module_exports_fn:
+    RefCell<Option<Rc<v8::Global<v8::Function>>>>,
   pub(crate) unrefed_ops:
     RefCell<HashSet<i32, BuildHasherDefault<IdentityHasher>>>,
   pub(crate) pending_ops: Rc<OpDriverImpl>,
@@ -87,6 +91,8 @@ impl ContextState {
       has_next_tick_scheduled: Default::default(),
       js_event_loop_tick_cb: Default::default(),
       js_wasm_streaming_cb: Default::default(),
+      web_assembly_module_imports_fn: Default::default(),
+      web_assembly_module_exports_fn: Default::default(),
       op_ctxs,
       pending_ops: op_driver,
       task_spawner_factory: Default::default(),

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1122,22 +1122,12 @@ impl JsRuntime {
       let global = context_local.global(scope);
       // TODO(bartlomieju): these probably could be captured from main realm so we don't have to
       // look up them again?
-      let deno_str =
-        v8::String::new_external_onebyte_static(scope, v8_static_strings::DENO)
-          .unwrap();
-      let core_str =
-        v8::String::new_external_onebyte_static(scope, v8_static_strings::CORE)
-          .unwrap();
-      let event_loop_tick_str = v8::String::new_external_onebyte_static(
-        scope,
-        v8_static_strings::EVENT_LOOP_TICK,
-      )
-      .unwrap();
-      let build_custom_error_str = v8::String::new_external_onebyte_static(
-        scope,
-        v8_static_strings::BUILD_CUSTOM_ERROR,
-      )
-      .unwrap();
+      let deno_str = v8_static_strings::new(scope, v8_static_strings::DENO);
+      let core_str = v8_static_strings::new(scope, v8_static_strings::CORE);
+      let event_loop_tick_str =
+        v8_static_strings::new(scope, v8_static_strings::EVENT_LOOP_TICK);
+      let build_custom_error_str =
+        v8_static_strings::new(scope, v8_static_strings::BUILD_CUSTOM_ERROR);
 
       let deno_obj: v8::Local<v8::Object> = global
         .get(scope, deno_str.into())

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1122,34 +1122,24 @@ impl JsRuntime {
       let global = context_local.global(scope);
       // TODO(bartlomieju): these probably could be captured from main realm so we don't have to
       // look up them again?
-      let deno_str = v8_static_strings::new(scope, v8_static_strings::DENO);
-      let core_str = v8_static_strings::new(scope, v8_static_strings::CORE);
-      let event_loop_tick_str =
-        v8_static_strings::new(scope, v8_static_strings::EVENT_LOOP_TICK);
-      let build_custom_error_str =
-        v8_static_strings::new(scope, v8_static_strings::BUILD_CUSTOM_ERROR);
+      let deno_obj: v8::Local<v8::Object> =
+        bindings::get(scope, global, v8_static_strings::DENO, "Deno");
+      let core_obj: v8::Local<v8::Object> =
+        bindings::get(scope, deno_obj, v8_static_strings::CORE, "Deno.core");
 
-      let deno_obj: v8::Local<v8::Object> = global
-        .get(scope, deno_str.into())
-        .unwrap()
-        .try_into()
-        .unwrap();
-      let core_obj: v8::Local<v8::Object> = deno_obj
-        .get(scope, core_str.into())
-        .unwrap()
-        .try_into()
-        .unwrap();
+      let event_loop_tick_cb: v8::Local<v8::Function> = bindings::get(
+        scope,
+        core_obj,
+        v8_static_strings::EVENT_LOOP_TICK,
+        "Deno.core.eventLoopTick",
+      );
+      let build_custom_error_cb: v8::Local<v8::Function> = bindings::get(
+        scope,
+        core_obj,
+        v8_static_strings::BUILD_CUSTOM_ERROR,
+        "Deno.core.buildCustomError",
+      );
 
-      let event_loop_tick_cb: v8::Local<v8::Function> = core_obj
-        .get(scope, event_loop_tick_str.into())
-        .unwrap()
-        .try_into()
-        .unwrap();
-      let build_custom_error_cb: v8::Local<v8::Function> = core_obj
-        .get(scope, build_custom_error_str.into())
-        .unwrap()
-        .try_into()
-        .unwrap();
       (
         v8::Global::new(scope, event_loop_tick_cb),
         v8::Global::new(scope, build_custom_error_cb),

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -836,7 +836,7 @@ impl JsRuntime {
         )?;
       }
 
-      js_runtime.store_js_callbacks(&realm);
+      js_runtime.store_js_callbacks(&realm, will_snapshot);
 
       js_runtime.init_extension_js(
         &realm,
@@ -1114,7 +1114,7 @@ impl JsRuntime {
 
   /// Grab and store JavaScript bindings to callbacks necessary for the
   /// JsRuntime to operate properly.
-  fn store_js_callbacks(&mut self, realm: &JsRealm) {
+  fn store_js_callbacks(&mut self, realm: &JsRealm, will_snapshot: bool) {
     let (
       event_loop_tick_cb,
       build_custom_error_cb,
@@ -1145,37 +1145,43 @@ impl JsRuntime {
         "Deno.core.buildCustomError",
       );
 
-      let web_assembly_object: v8::Local<v8::Object> = bindings::get(
-        scope,
-        global,
-        v8_static_strings::WEBASSEMBLY,
-        "WebAssembly",
-      );
-      let web_assembly_module_object: v8::Local<v8::Object> = bindings::get(
-        scope,
-        web_assembly_object,
-        v8_static_strings::MODULE,
-        "WebAssembly.Module",
-      );
-      let web_assembly_module_imports_fn: v8::Local<v8::Function> =
-        bindings::get(
+      let mut web_assembly_module_imports_fn = None;
+      let mut web_assembly_module_exports_fn = None;
+
+      if !will_snapshot {
+        let web_assembly_object: v8::Local<v8::Object> = bindings::get(
           scope,
-          web_assembly_module_object,
-          v8_static_strings::IMPORTS,
-          "WebAssembly.Module.imports",
+          global,
+          v8_static_strings::WEBASSEMBLY,
+          "WebAssembly",
         );
-      let web_assembly_module_exports_fn: v8::Local<v8::Function> =
-        bindings::get(
+        let web_assembly_module_object: v8::Local<v8::Object> = bindings::get(
           scope,
-          web_assembly_module_object,
-          v8_static_strings::EXPORTS,
-          "WebAssembly.Module.exports",
+          web_assembly_object,
+          v8_static_strings::MODULE,
+          "WebAssembly.Module",
         );
+        web_assembly_module_imports_fn =
+          Some(bindings::get::<v8::Local<v8::Function>>(
+            scope,
+            web_assembly_module_object,
+            v8_static_strings::IMPORTS,
+            "WebAssembly.Module.imports",
+          ));
+        web_assembly_module_exports_fn =
+          Some(bindings::get::<v8::Local<v8::Function>>(
+            scope,
+            web_assembly_module_object,
+            v8_static_strings::EXPORTS,
+            "WebAssembly.Module.exports",
+          ));
+      }
+
       (
         v8::Global::new(scope, event_loop_tick_cb),
         v8::Global::new(scope, build_custom_error_cb),
-        v8::Global::new(scope, web_assembly_module_imports_fn),
-        v8::Global::new(scope, web_assembly_module_exports_fn),
+        web_assembly_module_imports_fn.map(|f| v8::Global::new(scope, f)),
+        web_assembly_module_exports_fn.map(|f| v8::Global::new(scope, f)),
       )
     };
 
@@ -1190,14 +1196,20 @@ impl JsRuntime {
       .js_build_custom_error_cb
       .borrow_mut()
       .replace(Rc::new(build_custom_error_cb));
-    state_rc
-      .web_assembly_module_imports_fn
-      .borrow_mut()
-      .replace(Rc::new(web_assembly_module_imports_fn));
-    state_rc
-      .web_assembly_module_exports_fn
-      .borrow_mut()
-      .replace(Rc::new(web_assembly_module_exports_fn));
+    if let Some(web_assembly_module_imports_fn) = web_assembly_module_imports_fn
+    {
+      state_rc
+        .web_assembly_module_imports_fn
+        .borrow_mut()
+        .replace(Rc::new(web_assembly_module_imports_fn));
+    }
+    if let Some(web_assembly_module_exports_fn) = web_assembly_module_exports_fn
+    {
+      state_rc
+        .web_assembly_module_exports_fn
+        .borrow_mut()
+        .replace(Rc::new(web_assembly_module_exports_fn));
+    }
   }
 
   /// Returns the runtime's op state, which can be used to maintain ops


### PR DESCRIPTION
This commit adds "CustomModuleEvaluationCtx" struct that is passed to
"CustomModuleEvaluationCb" and allows to analyze contents of WASM modules.

Specifically we add the ability to analyze imports and exports of WASM modules
that can be used to build up support for WASM imports.