### PR TITLE
 refactor(core): clean up include_js_files! macros 

### DIFF
--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -244,7 +244,7 @@ pub(crate) fn initialize_deno_core_namespace<'s>(
 pub(crate) fn initialize_primordials_and_infra(
   scope: &mut v8::HandleScope,
 ) -> Result<(), AnyError> {
-  for file_source in CONTEXT_SETUP_SOURCES {
+  for file_source in &CONTEXT_SETUP_SOURCES {
     let code = file_source.load().unwrap();
     let source_str = code.v8_string(scope).unwrap();
     let name = v8_static_strings::new_from_static_str(

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -271,7 +271,7 @@ const VIRTUAL_OPS_MODULE_NAME: &str = "ext:core/ops";
 
 /// These files are executed just after a new context is created. They provided
 /// the necessary infrastructure to bind ops.
-pub(crate) const CONTEXT_SETUP_SOURCES: [ExtensionFileSource; 2] = include_js_files!(
+pub(crate) static CONTEXT_SETUP_SOURCES: [ExtensionFileSource; 2] = include_js_files!(
   core
   "00_primordials.js",
   "00_infra.js",
@@ -279,14 +279,14 @@ pub(crate) const CONTEXT_SETUP_SOURCES: [ExtensionFileSource; 2] = include_js_fi
 
 /// These files are executed when we start setting up extensions. They rely
 /// on ops being already fully set up.
-pub(crate) const BUILTIN_SOURCES: [ExtensionFileSource; 2] = include_js_files!(
+pub(crate) static BUILTIN_SOURCES: [ExtensionFileSource; 2] = include_js_files!(
   core
   "01_core.js",
   "02_error.js",
 );
 /// Executed after `BUILTIN_SOURCES` are executed. Provides a thin ES module
 /// that exports `core`, `internals` and `primordials` objects.
-pub(crate) const BUILTIN_ES_MODULES: [ExtensionFileSource; 1] =
+pub(crate) static BUILTIN_ES_MODULES: [ExtensionFileSource; 1] =
   include_js_files!(core "mod.js",);
 
 /// We have `ext:core/ops` and `ext:core/mod.js` that are always provided.
@@ -2203,6 +2203,7 @@ fn mark_as_loaded_from_fs_during_snapshot(
   files_loaded: &mut Vec<&'static str>,
   source: &ExtensionFileSourceCode,
 ) {
+  #[allow(deprecated)]
   if let ExtensionFileSourceCode::LoadedFromFsDuringSnapshot(path) = source {
     files_loaded.push(path);
   }

--- a/core/runtime/tests/snapshot.rs
+++ b/core/runtime/tests/snapshot.rs
@@ -256,20 +256,15 @@ fn es_snapshot() {
 #[test]
 pub(crate) fn es_snapshot_without_runtime_module_loader() {
   let startup_data = {
-    let extension = Extension {
-      name: "module_snapshot",
-      esm_files: Cow::Borrowed(&[ExtensionFileSource {
-        specifier: "ext:module_snapshot/test.js",
-        code: ExtensionFileSourceCode::IncludedInBinary(
-          "globalThis.TEST = 'foo'; export const TEST = 'bar';",
-        ),
-      }]),
-      esm_entry_point: Some("ext:module_snapshot/test.js"),
-      ..Default::default()
-    };
+    deno_core::extension!(
+      module_snapshot,
+      esm_entry_point = "ext:module_snapshot/test.js",
+      esm = ["ext:module_snapshot/test.js" =
+        { source = "globalThis.TEST = 'foo'; export const TEST = 'bar';" },]
+    );
 
     let runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
-      extensions: vec![extension],
+      extensions: vec![module_snapshot::init_ops_and_esm()],
       ..Default::default()
     });
 

--- a/testing/checkin/runner/mod.rs
+++ b/testing/checkin/runner/mod.rs
@@ -69,12 +69,12 @@ deno_core::extension!(
     dir "checkin/runtime",
     "__bootstrap.js",
     "__init.js",
-    "async.ts" with_specifier "checkin:async",
-    "console.ts" with_specifier "checkin:console",
-    "error.ts" with_specifier "checkin:error",
-    "testing.ts" with_specifier "checkin:testing",
-    "timers.ts" with_specifier "checkin:timers",
-    "worker.ts" with_specifier "checkin:worker",
+    "checkin:async" = "async.ts",
+    "checkin:console" = "console.ts",
+    "checkin:error" = "error.ts",
+    "checkin:testing" = "testing.ts",
+    "checkin:timers" = "timers.ts",
+    "checkin:worker" = "worker.ts",
   ],
   state = |state| {
     state.put(TestFunctions::default());


### PR DESCRIPTION
This looks pretty big, but it's mostly a cleanup of `include_js_files!` that makes it easier to understand and easier to maintain moving forward.

`include_js_files!` supports four styles of includes:

 - `"file"` <- old
 - `"file" with_specifier "specifier"` <- old, triggers a deprecation warning with a hint
 - `specifier = "file"` <- new
 - `specifier = { source = "source" }` <- new, see below

The `specifier = "file"` syntax will be preferred to replace the current `"file" with_specifier "specifier"` syntax, but won't be removed yet. If we want to add any other possible options to this macro, it's just too hard to expand the old syntax (which is why I introduced this new syntax!).

We now support an inline, embeddable string script for all places where `include_js_files!` is used:

```
    deno_core::extension!(
      module_snapshot,
      esm_entry_point = "mod:test",
      esm = ["mod:test" =
        { source = "globalThis.TEST = 'foo'; export const TEST = 'bar';" },]
    );
```

Changes:
 - `ExtensionFileSource` cannot be constructed using the bare struct syntax anymore (a new field named `_unconstructable_use_new` helps suggest the right course of action)
 - `ExtensionFileSource` has new `const` constructors 
 - `include_js_files!` macro and related macros have been rewritten
