### PR TITLE
refactor: Prepare for Wasm imports support

### DIFF
--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -213,6 +213,13 @@ impl ModuleMap {
     self.data.borrow().get_name_by_id(id)
   }
 
+  pub(crate) fn get_type_by_module(
+    &self,
+    global: &v8::Global<v8::Module>,
+  ) -> Option<ModuleType> {
+    self.data.borrow().get_type_by_module(global)
+  }
+
   pub(crate) fn get_handle(
     &self,
     id: ModuleId,
@@ -305,6 +312,11 @@ impl ModuleMap {
           code,
           dynamic,
         )?
+      }
+      ModuleType::Wasm => {
+        return Err(ModuleError::Other(generic_error(
+          "Importing Wasm modules is currently not supported.",
+        )));
       }
       ModuleType::Json => {
         let code =

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -916,7 +916,7 @@ export const foo = bytes;
           "foobar-synth".into()
         )
       }],
-      module_type: RequestedModuleType::Other("foobar".into()),
+      module_type: ModuleType::Other("foobar".into()),
     }
   );
   let info = data.info.get(mod_id - 1).unwrap();
@@ -927,7 +927,7 @@ export const foo = bytes;
       main: false,
       name: ascii_str!("file:///b.png"),
       requests: vec![],
-      module_type: RequestedModuleType::Other("foobar-synth".into()),
+      module_type: ModuleType::Other("foobar-synth".into()),
     }
   );
 }

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -23,6 +23,7 @@ use crate::runtime::InitMode;
 use crate::runtime::JsRealm;
 use crate::FastString;
 use crate::JsRuntime;
+use crate::ModuleType;
 
 pub(crate) fn create_external_references(
   ops: &[OpCtx],
@@ -171,6 +172,10 @@ pub mod v8_static_strings {
   pub static DIRNAME: v8::OneByteConst = onebyte_const!("dirname");
   pub static SET_UP_ASYNC_STUB: v8::OneByteConst =
     onebyte_const!("setUpAsyncStub");
+  pub static WEBASSEMBLY: v8::OneByteConst = onebyte_const!("WebAssembly");
+  pub static INSTANTIATE: v8::OneByteConst = onebyte_const!("instantiate");
+  pub static WASM_INSTANTIATE: v8::OneByteConst =
+    onebyte_const!("wasmInstantiate");
 }
 
 /// Create an object on the `globalThis` that looks like this:
@@ -452,10 +457,14 @@ pub extern "C" fn host_initialize_import_meta_object_callback(
   // SAFETY: `CallbackScope` can be safely constructed from `Local<Context>`
   let scope = &mut unsafe { v8::CallbackScope::new(context) };
   let module_map = JsRealm::module_map_from(scope);
+  let state = JsRealm::state_from_scope(scope);
 
   let module_global = v8::Global::new(scope, module);
   let name = module_map
     .get_name_by_module(&module_global)
+    .expect("Module not found");
+  let module_type = module_map
+    .get_type_by_module(&module_global)
     .expect("Module not found");
 
   let url_key = v8_static_strings::new(scope, &v8_static_strings::URL);
@@ -466,6 +475,19 @@ pub extern "C" fn host_initialize_import_meta_object_callback(
   let main = module_map.is_main_module(&module_global);
   let main_val = v8::Boolean::new(scope, main);
   meta.create_data_property(scope, main_key.into(), main_val.into());
+
+  // Add special method that allows WASM module to instantiate themselves.
+  if module_type == ModuleType::Wasm {
+    let wasm_instantiate_key =
+      v8_static_strings::new(scope, &v8_static_strings::WASM_INSTANTIATE);
+    let f = state.wasm_instantiate_fn.borrow().as_ref().unwrap().clone();
+    let wasm_instantiate_val = v8::Local::new(scope, &*f);
+    meta.create_data_property(
+      scope,
+      wasm_instantiate_key.into(),
+      wasm_instantiate_val.into(),
+    );
+  }
 
   let builder =
     v8::FunctionBuilder::new(import_meta_resolve).data(url_val.into());

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -53,6 +53,7 @@ pub(crate) struct ContextState {
     RefCell<Option<Rc<v8::Global<v8::Function>>>>,
   pub(crate) js_wasm_streaming_cb:
     RefCell<Option<Rc<v8::Global<v8::Function>>>>,
+  pub(crate) wasm_instantiate_fn: RefCell<Option<Rc<v8::Global<v8::Function>>>>,
   pub(crate) unrefed_ops:
     RefCell<HashSet<i32, BuildHasherDefault<IdentityHasher>>>,
   pub(crate) pending_ops: Rc<OpDriverImpl>,
@@ -79,6 +80,7 @@ impl ContextState {
       has_next_tick_scheduled: Default::default(),
       js_event_loop_tick_cb: Default::default(),
       js_wasm_streaming_cb: Default::default(),
+      wasm_instantiate_fn: Default::default(),
       op_ctxs,
       pending_ops: op_driver,
       task_spawner_factory: Default::default(),

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -837,7 +837,7 @@ impl JsRuntime {
         )?;
       }
 
-      js_runtime.store_js_callbacks(&realm);
+      js_runtime.store_js_callbacks(&realm, will_snapshot);
 
       js_runtime.init_extension_js(
         &realm,
@@ -1114,8 +1114,8 @@ impl JsRuntime {
 
   /// Grab and store JavaScript bindings to callbacks necessary for the
   /// JsRuntime to operate properly.
-  fn store_js_callbacks(&mut self, realm: &JsRealm) {
-    let (event_loop_tick_cb, build_custom_error_cb) = {
+  fn store_js_callbacks(&mut self, realm: &JsRealm, will_snapshot: bool) {
+    let (event_loop_tick_cb, build_custom_error_cb, wasm_instantiate_fn) = {
       let scope = &mut realm.handle_scope(self.v8_isolate());
       let context = realm.context();
       let context_local = v8::Local::new(scope, context);
@@ -1140,9 +1140,26 @@ impl JsRuntime {
         "Deno.core.buildCustomError",
       );
 
+      let mut wasm_instantiate_fn = None;
+      if !will_snapshot {
+        let web_assembly_object: v8::Local<v8::Object> = bindings::get(
+          scope,
+          global,
+          &v8_static_strings::WEBASSEMBLY,
+          "WebAssembly",
+        );
+        wasm_instantiate_fn = Some(bindings::get::<v8::Local<v8::Function>>(
+          scope,
+          web_assembly_object,
+          &v8_static_strings::INSTANTIATE,
+          "WebAssembly.instantiate",
+        ));
+      }
+
       (
         v8::Global::new(scope, event_loop_tick_cb),
         v8::Global::new(scope, build_custom_error_cb),
+        wasm_instantiate_fn.map(|f| v8::Global::new(scope, f)),
       )
     };
 
@@ -1157,6 +1174,12 @@ impl JsRuntime {
       .js_build_custom_error_cb
       .borrow_mut()
       .replace(Rc::new(build_custom_error_cb));
+    if let Some(wasm_instantiate_fn) = wasm_instantiate_fn {
+      state_rc
+        .wasm_instantiate_fn
+        .borrow_mut()
+        .replace(Rc::new(wasm_instantiate_fn));
+    }
   }
 
   /// Returns the runtime's op state, which can be used to maintain ops

--- a/core/runtime/tests/snapshot.rs
+++ b/core/runtime/tests/snapshot.rs
@@ -160,7 +160,7 @@ fn es_snapshot() {
         specifier: format!("file:///{prev}.js"),
         requested_module_type: RequestedModuleType::None,
       }],
-      module_type: RequestedModuleType::None,
+      module_type: ModuleType::JavaScript,
     }
   }
 
@@ -198,7 +198,7 @@ fn es_snapshot() {
     main: false,
     name: specifier.into(),
     requests: vec![],
-    module_type: RequestedModuleType::None,
+    module_type: ModuleType::JavaScript,
   });
 
   modules.extend((1..200).map(|i| create_module(&mut runtime, i, false)));


### PR DESCRIPTION
This commit prepares for support of WASM modules.

A new variant of "ModuleType::Wasm" was added.

Actually trying to load a WASM module will throw an error.