### PR TITLE
refactor(core): Add tests to opcall tracing so we can make changes

### DIFF
--- a/core/00_infra.js
+++ b/core/00_infra.js
@@ -112,6 +112,10 @@
   let opCallTracingEnabled = false;
   const opCallTraces = new SafeMap();
 
+  function getAllOpCallTraces() {
+    return new Map(opCallTraces);
+  }
+
   function setOpCallTracingEnabled(enabled) {
     opCallTracingEnabled = enabled;
   }
@@ -470,7 +474,7 @@
     registerErrorClass,
     setOpCallTracingEnabled,
     isOpCallTracingEnabled,
-    opCallTraces,
+    getAllOpCallTraces,
     getOpCallTraceForPromise,
     handleOpCallTracing,
     setUpAsyncStub,

--- a/core/00_infra.js
+++ b/core/00_infra.js
@@ -112,12 +112,20 @@
   let opCallTracingEnabled = false;
   const opCallTraces = new SafeMap();
 
-  function enableOpCallTracing() {
-    opCallTracingEnabled = true;
+  function setOpCallTracingEnabled(enabled) {
+    opCallTracingEnabled = enabled;
   }
 
   function isOpCallTracingEnabled() {
     return opCallTracingEnabled;
+  }
+
+  function getOpCallTraceForPromise(promise) {
+    const trace = MapPrototypeGet(opCallTraces, promise[promiseIdSymbol]);
+    if (trace) {
+      return trace.stack;
+    }
+    return null;
   }
 
   function handleOpCallTracing(opName, promiseId, p) {
@@ -460,9 +468,10 @@
     registerErrorBuilder,
     buildCustomError,
     registerErrorClass,
-    enableOpCallTracing,
+    setOpCallTracingEnabled,
     isOpCallTracingEnabled,
     opCallTraces,
+    getOpCallTraceForPromise,
     handleOpCallTracing,
     setUpAsyncStub,
     getPromise,

--- a/core/lib.deno_core.d.ts
+++ b/core/lib.deno_core.d.ts
@@ -18,7 +18,7 @@ declare namespace Deno {
      * if there are only "unref" promises left. */
     function unrefOpPromise<T>(promise: Promise<T>): void;
 
-    function setOpCallTracingEnabled(boolean);
+    function setOpCallTracingEnabled(enabled: boolean);
     function isOpCallTracingEnabled(): boolean;
     function getOpCallTraceForPromise<T>(promise: Promise<T>): string | null;
     function getAllOpCallTraces(): Map<number, string>;

--- a/core/lib.deno_core.d.ts
+++ b/core/lib.deno_core.d.ts
@@ -21,7 +21,8 @@ declare namespace Deno {
     function setOpCallTracingEnabled(boolean);
     function isOpCallTracingEnabled(): boolean;
     function getOpCallTraceForPromise<T>(promise: Promise<T>): string | null;
-
+    function getAllOpCallTraces(): Map<number, string>;
+    
     /**
      * List of all registered ops, in the form of a map that maps op
      * name to function.

--- a/core/lib.deno_core.d.ts
+++ b/core/lib.deno_core.d.ts
@@ -22,7 +22,7 @@ declare namespace Deno {
     function isOpCallTracingEnabled(): boolean;
     function getOpCallTraceForPromise<T>(promise: Promise<T>): string | null;
     function getAllOpCallTraces(): Map<number, string>;
-    
+
     /**
      * List of all registered ops, in the form of a map that maps op
      * name to function.

--- a/core/lib.deno_core.d.ts
+++ b/core/lib.deno_core.d.ts
@@ -18,9 +18,28 @@ declare namespace Deno {
      * if there are only "unref" promises left. */
     function unrefOpPromise<T>(promise: Promise<T>): void;
 
+    /**
+     * Enables collection of stack traces of all async ops. This allows for
+     * debugging of where a given async op was started. Deno CLI uses this for
+     * improving error message in op sanitizer errors for `deno test`.
+     *
+     * **NOTE:** enabling tracing has a significant negative performance impact.
+     */
     function setOpCallTracingEnabled(enabled: boolean);
+
     function isOpCallTracingEnabled(): boolean;
+
+    /**
+     * Returns the origin stack trace of the given async op promise. The promise
+     * must be ongoing.
+     */
     function getOpCallTraceForPromise<T>(promise: Promise<T>): string | null;
+
+    /**
+     * Returns a map containing traces for all ongoing async ops. The key is the promise id.
+     * Tracing only occurs when `Deno.core.setOpCallTracingEnabled()` was previously
+     * enabled.
+     */
     function getAllOpCallTraces(): Map<number, string>;
 
     /**
@@ -212,29 +231,6 @@ declare namespace Deno {
     ): Uint8Array;
 
     function deserialize(buffer: Uint8Array, options?: any): any;
-
-    /**
-     * Enables collection of stack traces of all async ops. This allows for
-     * debugging of where a given async op was started. Deno CLI uses this for
-     * improving error message in op sanitizer errors for `deno test`.
-     *
-     * **NOTE:** enabling tracing has a significant negative performance impact.
-     * To get high level metrics on async ops with no added performance cost,
-     * use `Deno.core.metrics()`.
-     */
-    function enableOpCallTracing(): void;
-
-    export interface OpCallTrace {
-      opName: string;
-      stack: string;
-    }
-
-    /**
-     * A map containing traces for all ongoing async ops. The key is the op id.
-     * Tracing only occurs when `Deno.core.enableOpCallTracing()` was previously
-     * enabled.
-     */
-    const opCallTraces: Map<number, OpCallTrace>;
 
     /**
      * Adds a callback for the given Promise event. If this function is called

--- a/core/lib.deno_core.d.ts
+++ b/core/lib.deno_core.d.ts
@@ -18,6 +18,10 @@ declare namespace Deno {
      * if there are only "unref" promises left. */
     function unrefOpPromise<T>(promise: Promise<T>): void;
 
+    function setOpCallTracingEnabled(boolean);
+    function isOpCallTracingEnabled(): boolean;
+    function getOpCallTraceForPromise<T>(promise: Promise<T>): string | null;
+
     /**
      * List of all registered ops, in the form of a map that maps op
      * name to function.

--- a/testing/checkin/runtime/async.ts
+++ b/testing/checkin/runtime/async.ts
@@ -16,8 +16,8 @@ export function barrierCreate(name: string, count: number) {
   op_async_barrier_create(name, count);
 }
 
-export async function barrierAwait(name: string) {
-  await op_async_barrier_await(name);
+export function barrierAwait(name: string) {
+  return op_async_barrier_await(name);
 }
 
 export async function asyncYield() {

--- a/testing/unit/ops_async_test.ts
+++ b/testing/unit/ops_async_test.ts
@@ -3,33 +3,49 @@ import { assertEquals, test } from "checkin:testing";
 import { asyncYield, barrierAwait, barrierCreate } from "checkin:async";
 import { asyncThrow } from "checkin:error";
 
+function assertStackTraceEquals(stack1: string, stack2: string) {
+  function normalize(s: string) {
+    return s.replace(/[ ]+/g, " ")
+      .replace(/^ /g, "")
+      .replace(/\d+:\d+/g, "line:col")
+      .trim();
+  }
+
+  assertEquals(normalize(stack1), normalize(stack2));
+}
+
 // Test that stack traces from async ops are all sane
 test(async function testAsyncThrow() {
   try {
     await asyncThrow("eager");
   } catch (e) {
-    const stack = e.stack.replace(/\d+:\d+/g, "line:col");
-    assertEquals(
-      stack,
-      "TypeError: Error\n    at asyncThrow (checkin:error:line:col)\n    at testAsyncThrow (test:///unit/ops_async_test.ts:line:col)",
+    assertStackTraceEquals(
+      e.stack,
+      `TypeError: Error
+        at asyncThrow (checkin:error:line:col)
+        at testAsyncThrow (test:///unit/ops_async_test.ts:line:col)
+      `,
     );
   }
   try {
     await asyncThrow("lazy");
   } catch (e) {
-    const stack = e.stack.replace(/\d+:\d+/g, "line:col");
-    assertEquals(
-      stack,
-      "TypeError: Error\n    at async asyncThrow (checkin:error:line:col)\n    at async testAsyncThrow (test:///unit/ops_async_test.ts:line:col)",
+    assertStackTraceEquals(
+      e.stack,
+      `TypeError: Error
+        at async asyncThrow (checkin:error:line:col)
+        at async testAsyncThrow (test:///unit/ops_async_test.ts:line:col)
+      `,
     );
   }
   try {
     await asyncThrow("deferred");
   } catch (e) {
-    const stack = e.stack.replace(/\d+:\d+/g, "line:col");
-    assertEquals(
-      stack,
-      "TypeError: Error\n    at async asyncThrow (checkin:error:line:col)\n    at async testAsyncThrow (test:///unit/ops_async_test.ts:line:col)",
+    assertStackTraceEquals(
+      e.stack,
+      `TypeError: Error
+        at async asyncThrow (checkin:error:line:col)
+        at async testAsyncThrow (test:///unit/ops_async_test.ts:line:col)`,
     );
   }
 });
@@ -48,4 +64,26 @@ test(async function testAsyncBarrier() {
     promises.push(barrierAwait("barrier"));
   }
   await Promise.all(promises);
+});
+
+test(async function testAsyncOpCallTrace() {
+  const oldTracingState = Deno.core.isOpCallTracingEnabled();
+  Deno.core.setOpCallTracingEnabled(true);
+  barrierCreate("barrier", 2);
+  try {
+    let p1 = barrierAwait("barrier");
+    assertStackTraceEquals(
+      Deno.core.getOpCallTraceForPromise(p1),
+      `
+      at handleOpCallTracing (ext:core/00_infra.js:line:col)
+      at op_async_barrier_await (ext:core/00_infra.js:line:col)
+      at barrierAwait (checkin:async:line:col)
+      at testAsyncOpCallTrace (test:///unit/ops_async_test.ts:line:col)
+    `,
+    );
+    let p2 = barrierAwait("barrier");
+    await Promise.all([p1, p2]);
+  } finally {
+    Deno.core.setOpCallTracingEnabled(oldTracingState);
+  }
 });

--- a/testing/unit/ops_async_test.ts
+++ b/testing/unit/ops_async_test.ts
@@ -72,7 +72,7 @@ test(async function testAsyncOpCallTrace() {
   barrierCreate("barrier", 2);
   try {
     const tracesBefore = Deno.core.getAllOpCallTraces();
-    let p1 = barrierAwait("barrier");
+    const p1 = barrierAwait("barrier");
     const tracesAfter = Deno.core.getAllOpCallTraces();
     assertEquals(tracesAfter.size, tracesBefore.size + 1);
     assertStackTraceEquals(
@@ -84,7 +84,7 @@ test(async function testAsyncOpCallTrace() {
       at testAsyncOpCallTrace (test:///unit/ops_async_test.ts:line:col)
     `,
     );
-    let p2 = barrierAwait("barrier");
+    const p2 = barrierAwait("barrier");
     await Promise.all([p1, p2]);
   } finally {
     Deno.core.setOpCallTracingEnabled(oldTracingState);

--- a/testing/unit/ops_async_test.ts
+++ b/testing/unit/ops_async_test.ts
@@ -71,7 +71,10 @@ test(async function testAsyncOpCallTrace() {
   Deno.core.setOpCallTracingEnabled(true);
   barrierCreate("barrier", 2);
   try {
+    const tracesBefore = Deno.core.getAllOpCallTraces();
     let p1 = barrierAwait("barrier");
+    const tracesAfter = Deno.core.getAllOpCallTraces();
+    assertEquals(tracesAfter.size, tracesBefore.size + 1);
     assertStackTraceEquals(
       Deno.core.getOpCallTraceForPromise(p1),
       `


### PR DESCRIPTION
This tweaks the opcall tracing interface to make it compatible with a Rust implementation in the future, as well as adding some basic testing for it.