### PR TITLE
feat: Add `Deno.core.createCancelHandle()`

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -429,6 +429,7 @@
     op_timer_ref,
     op_timer_unref,
     op_unref_op,
+    op_cancel_handle,
 
     op_is_any_array_buffer,
     op_is_arguments_object,
@@ -659,6 +660,7 @@
     propWritableLazyLoaded,
     propNonEnumerableLazyLoaded,
     createLazyLoader,
+    createCancelHandle: () => op_cancel_handle(),
   });
 
   const internals = {};

--- a/core/lib.deno_core.d.ts
+++ b/core/lib.deno_core.d.ts
@@ -322,6 +322,8 @@ declare namespace Deno {
     type LazyLoader<T> = () => T;
     function createLazyLoader<T = unknown>(specifier: string): LazyLoader<T>;
 
+    function createCancelHandle(): number;
+
     const build: {
       target: string;
       arch: string;

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -8,6 +8,7 @@ use crate::io::ResourceId;
 use crate::op2;
 use crate::ops_builtin_types;
 use crate::ops_builtin_v8;
+use crate::CancelHandle;
 use crate::JsBuffer;
 use crate::Op;
 use crate::OpDecl;
@@ -54,6 +55,7 @@ builtin_ops! {
   op_format_file_name,
   op_str_byte_length,
   op_panic,
+  op_cancel_handle,
   ops_builtin_types::op_is_any_array_buffer,
   ops_builtin_types::op_is_arguments_object,
   ops_builtin_types::op_is_array_buffer,
@@ -371,4 +373,11 @@ fn op_str_byte_length(
   } else {
     0
   }
+}
+
+/// Creates a [`CancelHandle`] resource that can be used to cancel invocations of certain ops.
+#[op2(fast)]
+#[smi]
+pub fn op_cancel_handle(state: &mut OpState) -> u32 {
+  state.resource_table.add(CancelHandle::new())
 }


### PR DESCRIPTION
This is a common utility used in `ext/fs` and `ext/net` in `deno` repo.

It's weirdly created in `ext/web` so it can be shared between the two extensions.