### PR TITLE
feat: Use serde_json and Snapshot*DataStore for managing snapshot sidecar data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +422,7 @@ version = "0.260.0"
 dependencies = [
  "anyhow",
  "bencher",
+ "bincode",
  "bit-set",
  "bit-vec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ deno_core_icudata = "0.0.73"
 
 anyhow = "1"
 bencher = "0.1"
+bincode = "1"
 criterion = "0.5"
 bit-set = "0"
 bit-vec = "0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,7 +18,9 @@ path = "main.rs"
 path = "lib.rs"
 
 [features]
-default = ["include_icu_data", "v8_use_custom_libcxx"]
+default = ["include_icu_data", "v8_use_custom_libcxx", "snapshot_data_json"]
+snapshot_data_json = []
+snapshot_data_bincode = ["bincode"]
 include_icu_data = ["deno_core_icudata"]
 v8_use_custom_libcxx = ["v8/use_custom_libcxx"]
 include_js_files_for_snapshotting = []
@@ -29,6 +31,7 @@ unsafe_use_unprotected_platform = []
 anyhow.workspace = true
 bit-set.workspace = true
 bit-vec.workspace = true
+bincode = { workspace = true, optional = true }
 bytes.workspace = true
 cooked-waker.workspace = true
 deno_core_icudata = { workspace = true, optional = true }

--- a/core/fast_string.rs
+++ b/core/fast_string.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+use serde::Deserializer;
+use serde::Serializer;
 use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -222,6 +224,27 @@ impl From<String> for FastString {
 impl From<Arc<str>> for FastString {
   fn from(value: Arc<str>) -> Self {
     FastString::Arc(value)
+  }
+}
+
+impl serde::Serialize for FastString {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    serializer.serialize_str(self.as_str())
+  }
+}
+
+type DeserializeProxy<'de> = &'de str;
+
+impl<'de> serde::Deserialize<'de> for FastString {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    DeserializeProxy::<'de>::deserialize(deserializer)
+      .map(|v| v.to_owned().into())
   }
 }
 

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -236,10 +236,7 @@ impl ModuleMap {
     data_store: &mut SnapshotStoreDataStore,
   ) -> ModuleMapSnapshotData {
     let data = std::mem::take(&mut *self.data.borrow_mut());
-    self
-      .data
-      .take()
-      .serialize_for_snapshotting(scope, data_store)
+    data.serialize_for_snapshotting(scope, data_store)
   }
 
   #[cfg(test)]

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -232,11 +232,10 @@ impl ModuleMap {
 
   pub(crate) fn serialize_for_snapshotting(
     &self,
-    scope: &mut v8::HandleScope,
     data_store: &mut SnapshotStoreDataStore,
   ) -> ModuleMapSnapshotData {
     let data = std::mem::take(&mut *self.data.borrow_mut());
-    data.serialize_for_snapshotting(scope, data_store)
+    data.serialize_for_snapshotting(data_store)
   }
 
   #[cfg(test)]

--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -510,7 +510,7 @@ pub(crate) struct ModuleRequest {
   pub requested_module_type: RequestedModuleType,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub(crate) struct ModuleInfo {
   #[allow(unused)]
   pub id: ModuleId,

--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -31,7 +31,7 @@ pub use loaders::NoopModuleLoader;
 pub use loaders::StaticModuleLoader;
 pub(crate) use map::synthetic_module_evaluation_steps;
 pub(crate) use map::ModuleMap;
-pub(crate) use module_map_data::ModuleMapSnapshottedData;
+pub(crate) use module_map_data::ModuleMapSnapshotData;
 
 pub type ModuleId = usize;
 pub(crate) type ModuleLoadId = i32;

--- a/core/modules/module_map_data.rs
+++ b/core/modules/module_map_data.rs
@@ -298,8 +298,7 @@ impl ModuleMapData {
   }
 
   pub fn serialize_for_snapshotting(
-    mut self,
-    scope: &mut v8::HandleScope,
+    self,
     data_store: &mut SnapshotStoreDataStore,
   ) -> ModuleMapSnapshotData {
     let mut ser = ModuleMapSnapshotData::default();

--- a/core/modules/module_map_data.rs
+++ b/core/modules/module_map_data.rs
@@ -46,7 +46,6 @@ impl<T> Default for ModuleNameTypeMap<T> {
 }
 
 impl<T> ModuleNameTypeMap<T> {
-  #[cfg(debug_assertions)]
   pub fn len(&self) -> usize {
     self.len
   }

--- a/core/modules/module_map_data.rs
+++ b/core/modules/module_map_data.rs
@@ -307,8 +307,10 @@ impl ModuleMapData {
     ser.next_load_id = self.next_load_id;
     ser.main_module_id = self.main_module_id.map(|x| x as _);
 
-    for (i, info) in self.info.into_iter().enumerate() {
-      let module_handle = data_store.register(self.handles[i]);
+    debug_assert_eq!(self.info.len(), self.handles.len());
+
+    for (info, module) in self.info.into_iter().zip(self.handles) {
+      let module_handle = data_store.register(module);
       ser.modules.push((
         info.id as _,
         info.name.as_str().to_owned(),
@@ -344,8 +346,8 @@ impl ModuleMapData {
     self.main_module_id = data.main_module_id.map(|x| x as _);
 
     for (id, b, requests, module_type, module_handle) in data.modules {
-      let module = data_store.get(module_handle);
-      self.handles_inverted.insert(module, id as _);
+      let module = data_store.get::<v8::Module>(scope, module_handle);
+      self.handles_inverted.insert(module.clone(), id as _);
       self.handles.push(module);
       self.info.push(ModuleInfo {
         id: id as _,

--- a/core/modules/module_map_data.rs
+++ b/core/modules/module_map_data.rs
@@ -150,8 +150,19 @@ pub(crate) struct ModuleMapData {
 pub(crate) struct ModuleMapSnapshotData {
   next_load_id: i32,
   main_module_id: Option<i32>,
-  modules: Vec<(i32, String, Vec<ModuleRequest>, ModuleType, SnapshotDataId)>,
-  by_name: Vec<(String, RequestedModuleType, Option<String>, Option<i32>)>,
+  modules: Vec<(
+    i32,
+    FastString,
+    Vec<ModuleRequest>,
+    ModuleType,
+    SnapshotDataId,
+  )>,
+  by_name: Vec<(
+    FastString,
+    RequestedModuleType,
+    Option<FastString>,
+    Option<i32>,
+  )>,
 }
 
 impl ModuleMapData {
@@ -308,7 +319,7 @@ impl ModuleMapData {
       let module_handle = data_store.register(module);
       ser.modules.push((
         info.id as _,
-        info.name.as_str().to_owned(),
+        info.name,
         info.requests,
         info.module_type.clone(),
         module_handle,
@@ -317,15 +328,10 @@ impl ModuleMapData {
 
     self.by_name.drain(|_, module_type, name, module| {
       let (alias, id) = match module {
-        SymbolicModule::Alias(alias) => (Some(alias.as_str().to_owned()), None),
+        SymbolicModule::Alias(alias) => (Some(alias), None),
         SymbolicModule::Mod(id) => (None, Some(id as i32)),
       };
-      ser.by_name.push((
-        name.as_str().to_owned(),
-        module_type.clone(),
-        alias,
-        id,
-      ));
+      ser.by_name.push((name, module_type.clone(), alias, id));
     });
 
     ser

--- a/core/modules/module_map_data.rs
+++ b/core/modules/module_map_data.rs
@@ -7,7 +7,12 @@ use crate::modules::ModuleLoadId;
 use crate::modules::ModuleName;
 use crate::modules::ModuleRequest;
 use crate::modules::ModuleType;
+use crate::runtime::SnapshotDataId;
+use crate::runtime::SnapshotLoadDataStore;
+use crate::runtime::SnapshotStoreDataStore;
 use crate::ExtensionFileSource;
+use serde::Deserialize;
+use serde::Serialize;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -92,25 +97,20 @@ impl<T> ModuleNameTypeMap<T> {
     }
   }
 
-  /// Rather than providing an iterator, we provide a walk method. This is mainly because Rust
+  /// Rather than providing an iterator, we provide a drain method. This is mainly because Rust
   /// doesn't have generators.
-  pub fn walk(
-    &self,
-    mut f: impl FnMut(usize, &RequestedModuleType, &ModuleName, &T),
+  pub fn drain(
+    mut self,
+    mut f: impl FnMut(usize, &RequestedModuleType, ModuleName, T),
   ) {
     let mut i = 0;
-    for (ty, value) in self.map_index.iter() {
-      for (key, value) in self.submaps.get(*value).unwrap() {
-        f(i, ty, key, value);
+    for (ty, value) in self.map_index.into_iter() {
+      for (key, value) in self.submaps.get_mut(value).unwrap().drain() {
+        f(i, &ty, key, value);
         i += 1;
       }
     }
   }
-}
-
-pub(crate) struct ModuleMapSnapshottedData {
-  pub module_map_data: v8::Global<v8::Array>,
-  pub module_handles: Vec<v8::Global<v8::Module>>,
 }
 
 /// An array of tuples that provide module exports.
@@ -149,6 +149,15 @@ pub(crate) struct ModuleMapData {
   pub(crate) synthetic_module_exports_store: SyntheticModuleExportsStore,
   pub(crate) lazy_esm_sources:
     Rc<RefCell<HashMap<&'static str, ExtensionFileSource>>>,
+}
+
+/// Snapshot-compatible representation of this data.
+#[derive(Default, Serialize, Deserialize)]
+pub(crate) struct ModuleMapSnapshotData {
+  next_load_id: i32,
+  main_module_id: Option<i32>,
+  modules: Vec<(i32, String, Vec<ModuleRequest>, ModuleType, SnapshotDataId)>,
+  by_name: Vec<(String, RequestedModuleType, Option<String>, Option<i32>)>,
 }
 
 impl ModuleMapData {
@@ -289,234 +298,79 @@ impl ModuleMapData {
   }
 
   pub fn serialize_for_snapshotting(
-    &self,
+    mut self,
     scope: &mut v8::HandleScope,
-  ) -> ModuleMapSnapshottedData {
-    let data = self;
-    let array = v8::Array::new(scope, 3);
+    data_store: &mut SnapshotStoreDataStore,
+  ) -> ModuleMapSnapshotData {
+    let mut ser = ModuleMapSnapshotData::default();
 
-    let next_load_id = v8::Integer::new(scope, data.next_load_id);
-    array.set_index(scope, 0, next_load_id.into());
+    ser.next_load_id = self.next_load_id;
+    ser.main_module_id = self.main_module_id.map(|x| x as _);
 
-    if let Some(main_module_id) = data.main_module_id {
-      let main_module_id = v8::Integer::new(scope, main_module_id as i32);
-      array.set_index(scope, 1, main_module_id.into());
+    for (i, info) in self.info.into_iter().enumerate() {
+      let module_handle = data_store.register(self.handles[i]);
+      ser.modules.push((
+        info.id as _,
+        info.name.as_str().to_owned(),
+        info.requests,
+        info.module_type.clone(),
+        module_handle,
+      ));
     }
 
-    let info_arr = v8::Array::new(scope, data.info.len() as i32);
-    for (i, info) in data.info.iter().enumerate() {
-      let module_info_arr = v8::Array::new(scope, 4);
-
-      let id = v8::Integer::new(scope, info.id as i32);
-      module_info_arr.set_index(scope, 0, id.into());
-
-      let name = info.name.v8(scope);
-      module_info_arr.set_index(scope, 1, name.into());
-
-      let array_len = 2 * info.requests.len() as i32;
-      let requests_arr = v8::Array::new(scope, array_len);
-      for (i, request) in info.requests.iter().enumerate() {
-        let specifier = v8::String::new_from_one_byte(
-          scope,
-          request.specifier.as_bytes(),
-          v8::NewStringType::Normal,
-        )
-        .unwrap();
-        requests_arr.set_index(scope, 2 * i as u32, specifier.into());
-        let value = request.requested_module_type.to_v8(scope);
-        requests_arr.set_index(scope, (2 * i) as u32 + 1, value);
-      }
-      module_info_arr.set_index(scope, 2, requests_arr.into());
-
-      let module_type = info.module_type.to_v8(scope);
-      module_info_arr.set_index(scope, 3, module_type);
-
-      info_arr.set_index(scope, i as u32, module_info_arr.into());
-    }
-    array.set_index(scope, 2, info_arr.into());
-
-    let length = self.by_name.len();
-    let by_name_array = v8::Array::new(scope, length.try_into().unwrap());
-    self.by_name.walk(|i, module_type, name, module| {
-      let arr = v8::Array::new(scope, 3);
-
-      let specifier = name.v8(scope);
-      arr.set_index(scope, 0, specifier.into());
-      let value = module_type.to_v8(scope);
-      arr.set_index(scope, 1, value);
-
-      let symbolic_module: v8::Local<v8::Value> = match module {
-        SymbolicModule::Alias(alias) => {
-          let alias = v8::String::new_from_one_byte(
-            scope,
-            alias.as_bytes(),
-            v8::NewStringType::Normal,
-          )
-          .unwrap();
-          alias.into()
-        }
-        SymbolicModule::Mod(id) => {
-          let id = v8::Integer::new(scope, *id as i32);
-          id.into()
-        }
+    self.by_name.drain(|_, module_type, name, module| {
+      let (alias, id) = match module {
+        SymbolicModule::Alias(alias) => (Some(alias.as_str().to_owned()), None),
+        SymbolicModule::Mod(id) => (None, Some(id as i32)),
       };
-      arr.set_index(scope, 2, symbolic_module);
-
-      by_name_array.set_index(scope, i as u32, arr.into());
+      ser.by_name.push((
+        name.as_str().to_owned(),
+        module_type.clone(),
+        alias,
+        id,
+      ));
     });
-    array.set_index(scope, 3, by_name_array.into());
 
-    let array_global = v8::Global::new(scope, array);
-
-    let handles = data.handles.clone();
-    ModuleMapSnapshottedData {
-      module_map_data: array_global,
-      module_handles: handles,
-    }
+    ser
   }
 
   pub fn update_with_snapshotted_data(
     &mut self,
     scope: &mut v8::HandleScope,
-    snapshotted_data: ModuleMapSnapshottedData,
+    data_store: &mut SnapshotLoadDataStore,
+    data: ModuleMapSnapshotData,
   ) {
-    let local_data: v8::Local<v8::Array> =
-      v8::Local::new(scope, snapshotted_data.module_map_data);
+    self.next_load_id = data.next_load_id;
+    self.main_module_id = data.main_module_id.map(|x| x as _);
 
-    {
-      let next_load_id = local_data.get_index(scope, 0).unwrap();
-      assert!(next_load_id.is_int32());
-      let integer = next_load_id.to_integer(scope).unwrap();
-      let val = integer.int32_value(scope).unwrap();
-      self.next_load_id = val;
+    for (id, b, requests, module_type, module_handle) in data.modules {
+      let module = data_store.get(module_handle);
+      self.handles_inverted.insert(module, id as _);
+      self.handles.push(module);
+      self.info.push(ModuleInfo {
+        id: id as _,
+        main: Some(id as usize) == self.main_module_id,
+        module_type,
+        name: FastString::from(b),
+        requests,
+      });
     }
 
-    {
-      let main_module_id = local_data.get_index(scope, 1).unwrap();
-      if !main_module_id.is_undefined() {
-        let integer = main_module_id
-          .to_integer(scope)
-          .map(|v| v.int32_value(scope).unwrap() as usize);
-        self.main_module_id = integer;
-      }
+    for (name, module_type, c, d) in data.by_name {
+      match (c, d) {
+        (Some(id), None) => self.by_name.insert(
+          &module_type,
+          FastString::from(name),
+          SymbolicModule::Alias(id.into()),
+        ),
+        (None, Some(id)) => self.by_name.insert(
+          &module_type,
+          FastString::from(name),
+          SymbolicModule::Mod(id as _),
+        ),
+        _ => unreachable!(),
+      };
     }
-
-    {
-      let info_val = local_data.get_index(scope, 2).unwrap();
-
-      let info_arr: v8::Local<v8::Array> = info_val.try_into().unwrap();
-      let len = info_arr.length() as usize;
-      // Over allocate so executing a few scripts doesn't have to resize this vec.
-      let mut info = Vec::with_capacity(len + 16);
-
-      for i in 0..len {
-        let module_info_arr: v8::Local<v8::Array> = info_arr
-          .get_index(scope, i as u32)
-          .unwrap()
-          .try_into()
-          .unwrap();
-        let id = module_info_arr
-          .get_index(scope, 0)
-          .unwrap()
-          .to_integer(scope)
-          .unwrap()
-          .value() as ModuleId;
-
-        let name = module_info_arr
-          .get_index(scope, 1)
-          .unwrap()
-          .to_rust_string_lossy(scope)
-          .into();
-
-        let requests_arr: v8::Local<v8::Array> = module_info_arr
-          .get_index(scope, 2)
-          .unwrap()
-          .try_into()
-          .unwrap();
-        let len = (requests_arr.length() as usize) / 2;
-        let mut requests = Vec::with_capacity(len);
-        for i in 0..len {
-          let specifier = requests_arr
-            .get_index(scope, (2 * i) as u32)
-            .unwrap()
-            .to_rust_string_lossy(scope);
-          let value =
-            requests_arr.get_index(scope, (2 * i + 1) as u32).unwrap();
-          let requested_module_type =
-            RequestedModuleType::try_from_v8(scope, value).unwrap();
-          requests.push(ModuleRequest {
-            specifier,
-            requested_module_type,
-          });
-        }
-
-        let value = module_info_arr.get_index(scope, 3).unwrap();
-        let module_type = ModuleType::try_from_v8(scope, value).unwrap();
-
-        let main = self.main_module_id == Some(id);
-        let module_info = ModuleInfo {
-          id,
-          main,
-          name,
-          requests,
-          module_type,
-        };
-        info.push(module_info);
-      }
-      self.info = info;
-    }
-
-    self.by_name.clear();
-
-    {
-      let by_name_arr: v8::Local<v8::Array> =
-        local_data.get_index(scope, 3).unwrap().try_into().unwrap();
-      let len = by_name_arr.length() as usize;
-
-      for i in 0..len {
-        let arr: v8::Local<v8::Array> = by_name_arr
-          .get_index(scope, i as u32)
-          .unwrap()
-          .try_into()
-          .unwrap();
-
-        let specifier =
-          arr.get_index(scope, 0).unwrap().to_rust_string_lossy(scope);
-        let requested_module_type = match arr
-          .get_index(scope, 1)
-          .unwrap()
-          .to_integer(scope)
-          .unwrap()
-          .value()
-        {
-          0 => RequestedModuleType::None,
-          1 => RequestedModuleType::Json,
-          _ => unreachable!(),
-        };
-
-        let symbolic_module_val = arr.get_index(scope, 2).unwrap();
-        let val = if symbolic_module_val.is_number() {
-          SymbolicModule::Mod(
-            symbolic_module_val
-              .to_integer(scope)
-              .unwrap()
-              .value()
-              .try_into()
-              .unwrap(),
-          )
-        } else {
-          SymbolicModule::Alias(
-            symbolic_module_val.to_rust_string_lossy(scope).into(),
-          )
-        };
-
-        self
-          .by_name
-          .insert(&requested_module_type, specifier.into(), val);
-      }
-    }
-
-    self.handles = snapshotted_data.module_handles;
   }
 
   // TODO(mmastrac): this is better than giving the entire crate access to the internals.

--- a/core/modules/module_map_data.rs
+++ b/core/modules/module_map_data.rs
@@ -46,6 +46,7 @@ impl<T> Default for ModuleNameTypeMap<T> {
 }
 
 impl<T> ModuleNameTypeMap<T> {
+  #[cfg(debug_assertions)]
   pub fn len(&self) -> usize {
     self.len
   }
@@ -62,12 +63,6 @@ impl<T> ModuleNameTypeMap<T> {
     let index = self.map_index(ty)?;
     let map = self.submaps.get(index)?;
     map.get(name)
-  }
-
-  pub fn clear(&mut self) {
-    self.len = 0;
-    self.map_index.clear();
-    self.submaps.clear();
   }
 
   pub fn insert(
@@ -301,11 +296,13 @@ impl ModuleMapData {
     self,
     data_store: &mut SnapshotStoreDataStore,
   ) -> ModuleMapSnapshotData {
-    let mut ser = ModuleMapSnapshotData::default();
+    let mut ser = ModuleMapSnapshotData {
+      next_load_id: self.next_load_id,
+      main_module_id: self.main_module_id.map(|x| x as _),
+      ..Default::default()
+    };
 
-    ser.next_load_id = self.next_load_id;
-    ser.main_module_id = self.main_module_id.map(|x| x as _);
-
+    debug_assert_eq!(self.by_name.len(), self.handles.len());
     debug_assert_eq!(self.info.len(), self.handles.len());
 
     for (info, module) in self.info.into_iter().zip(self.handles) {

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -762,7 +762,7 @@ impl JsRuntime {
       import_meta_resolve_cb,
     ));
 
-    if let Some((snapshotted_data, data_store)) = snapshotted_data {
+    if let Some((snapshotted_data, mut data_store)) = snapshotted_data {
       *exception_state.js_handled_promise_rejection_cb.borrow_mut() =
         snapshotted_data.js_handled_promise_rejection_cb;
       module_map.update_with_snapshotted_data(

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1828,10 +1828,7 @@ impl JsRuntimeForSnapshot {
       let mut data_store = SnapshotStoreDataStore::default();
       let module_map_data = {
         let module_map = realm.0.module_map();
-        module_map.serialize_for_snapshotting(
-          &mut realm.handle_scope(self.v8_isolate()),
-          &mut data_store,
-        )
+        module_map.serialize_for_snapshotting(&mut data_store)
       };
       let maybe_js_handled_promise_rejection_cb = {
         let context_state = &realm.0.context_state;

--- a/core/runtime/mod.rs
+++ b/core/runtime/mod.rs
@@ -38,6 +38,9 @@ pub use snapshot_util::get_js_files;
 pub use snapshot_util::CreateSnapshotOptions;
 pub use snapshot_util::CreateSnapshotOutput;
 pub use snapshot_util::FilterFn;
+pub(crate) use snapshot_util::SnapshotDataId;
+pub(crate) use snapshot_util::SnapshotLoadDataStore;
+pub(crate) use snapshot_util::SnapshotStoreDataStore;
 pub(crate) use snapshot_util::SnapshottedData;
 
 pub use bindings::script_origin;

--- a/core/runtime/mod.rs
+++ b/core/runtime/mod.rs
@@ -11,7 +11,7 @@ mod setup;
 mod snapshot_util;
 pub mod stats;
 
-#[cfg(all(test, not(miri)))]
+#[cfg(all(test))]
 mod tests;
 
 pub const V8_WRAPPER_TYPE_INDEX: i32 = 0;

--- a/core/runtime/mod.rs
+++ b/core/runtime/mod.rs
@@ -11,7 +11,7 @@ mod setup;
 mod snapshot_util;
 pub mod stats;
 
-#[cfg(all(test))]
+#[cfg(all(test, not(miri)))]
 mod tests;
 
 pub const V8_WRAPPER_TYPE_INDEX: i32 = 0;

--- a/core/runtime/snapshot_util.rs
+++ b/core/runtime/snapshot_util.rs
@@ -4,6 +4,10 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::time::Instant;
 
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::modules::ModuleMapSnapshotData;
 use crate::Extension;
 use crate::JsRuntimeForSnapshot;
 use crate::RuntimeOptions;
@@ -11,6 +15,44 @@ use crate::Snapshot;
 
 pub type CompressionCb = dyn Fn(&mut Vec<u8>, &[u8]);
 pub type WithRuntimeCb = dyn Fn(&mut JsRuntimeForSnapshot);
+
+pub type SnapshotDataId = u32;
+
+#[derive(Default)]
+pub struct SnapshotLoadDataStore {
+  data: Vec<Option<v8::Global<v8::Data>>>,
+}
+
+impl SnapshotLoadDataStore {
+  pub fn get<T>(&mut self, id: SnapshotDataId) -> v8::Global<T>
+  where
+    v8::Global<T>: From<v8::Global<v8::Data>>,
+  {
+    let Some(data) = self.data.get_mut(id as usize) else {
+      panic!("Attempted to read snapshot data out of range: {id}");
+    };
+    let Some(data) = data.take() else {
+      panic!("Attempted to read the snapshot data at index {id} twice");
+    };
+    data.try_into().unwrap_or_else(|_| {
+      panic!(
+        "Invalid data type at index {id}, expected '{}'",
+        std::any::type_name::<T>()
+      )
+    })
+  }
+}
+
+#[derive(Default)]
+pub struct SnapshotStoreDataStore {
+  data: Vec<v8::Global<v8::Data>>,
+}
+
+impl SnapshotStoreDataStore {
+  pub fn register<T>(&mut self, global: v8::Global<T>) -> SnapshotDataId {
+    unimplemented!()
+  }
+}
 
 pub struct CreateSnapshotOptions {
   pub cargo_manifest_dir: &'static str,
@@ -144,99 +186,80 @@ fn data_error_to_panic(err: v8::DataError) -> ! {
 }
 
 pub(crate) struct SnapshottedData {
-  pub module_map_data: v8::Global<v8::Array>,
-  pub module_handles: Vec<v8::Global<v8::Module>>,
+  pub module_map_data: ModuleMapSnapshotData,
   pub js_handled_promise_rejection_cb: Option<v8::Global<v8::Function>>,
 }
 
-static MODULE_MAP_CONTEXT_DATA_INDEX: usize = 0;
-static JS_HANDLED_PROMISE_REJECTION_CB_DATA_INDEX: usize = 1;
+#[derive(Serialize, Deserialize)]
+struct RawSnapshottedData<'s> {
+  data_count: u32,
+  module_map_data: ModuleMapSnapshotData,
+  js_handled_promise_rejection_cb: Option<serde_v8::Value<'s>>,
+}
+
+static RAW_SNAPSHOTTED_DATA_INDEX: usize = 0;
 
 pub(crate) fn get_snapshotted_data(
   scope: &mut v8::HandleScope<()>,
   context: v8::Local<v8::Context>,
-) -> SnapshottedData {
+) -> (SnapshottedData, SnapshotLoadDataStore) {
   let mut scope = v8::ContextScope::new(scope, context);
 
-  // The 0th element is the module map itself, followed by X number of module
-  // handles. We need to deserialize the "next_module_id" field from the
-  // map to see how many module handles we expect.
-  let result = scope.get_context_data_from_snapshot_once::<v8::Array>(
-    MODULE_MAP_CONTEXT_DATA_INDEX,
+  let result = scope.get_context_data_from_snapshot_once::<v8::Value>(
+    RAW_SNAPSHOTTED_DATA_INDEX,
   );
-
   let val = match result {
     Ok(v) => v,
     Err(err) => data_error_to_panic(err),
   };
 
-  let next_module_id = {
-    let info_data: v8::Local<v8::Array> =
-      val.get_index(&mut scope, 2).unwrap().try_into().unwrap();
-    info_data.length()
-  };
-
-  let js_handled_promise_rejection_cb = match scope
-    .get_context_data_from_snapshot_once::<v8::Value>(
-      JS_HANDLED_PROMISE_REJECTION_CB_DATA_INDEX,
-    ) {
-    Ok(val) => {
-      if val.is_undefined() {
-        None
-      } else {
-        let fn_: v8::Local<v8::Function> = val.try_into().unwrap();
-        Some(v8::Global::new(&mut scope, fn_))
-      }
-    }
-    Err(err) => data_error_to_panic(err),
-  };
-
-  // Over allocate so executing a few scripts doesn't have to resize this vec.
-  let mut module_handles = Vec::with_capacity(next_module_id as usize + 16);
-  for i in 2..=next_module_id + 1 {
-    match scope.get_context_data_from_snapshot_once::<v8::Module>(i as usize) {
-      Ok(val) => {
-        let module_global = v8::Global::new(&mut scope, val);
-        module_handles.push(module_global);
-      }
-      Err(err) => data_error_to_panic(err),
-    }
+  let raw_data: RawSnapshottedData =
+    serde_v8::from_v8(scope, val).expect("Failed to deserialize snapshot data");
+  let mut data = SnapshotLoadDataStore::default();
+  for i in 0..raw_data.data_count {
+    let item = scope
+      .get_context_data_from_snapshot_once::<v8::Data>(i as _ + 1)
+      .unwrap();
+    let item = v8::Global::new(&mut scope, item);
+    data.data.push(Some(item));
   }
 
-  SnapshottedData {
-    module_map_data: v8::Global::new(&mut scope, val),
-    module_handles,
-    js_handled_promise_rejection_cb,
-  }
+  (
+    SnapshottedData {
+      module_map_data: raw_data.module_map_data,
+      js_handled_promise_rejection_cb: raw_data
+        .js_handled_promise_rejection_cb
+        .map(|x| {
+          v8::Global::new(&mut scope, x.v8_value.try_into().unwrap()).into()
+        }),
+    },
+    data,
+  )
 }
 
 pub(crate) fn set_snapshotted_data(
   scope: &mut v8::HandleScope<()>,
   context: v8::Global<v8::Context>,
   snapshotted_data: SnapshottedData,
+  data_store: SnapshotStoreDataStore,
 ) {
   let local_context = v8::Local::new(scope, context);
-  let local_data = v8::Local::new(scope, snapshotted_data.module_map_data);
+
+  let raw_snapshot_data = RawSnapshottedData {
+    data_count: data_store.data.len() as _,
+    module_map_data: snapshotted_data.module_map_data,
+    js_handled_promise_rejection_cb: snapshotted_data
+      .js_handled_promise_rejection_cb
+      .map(|v| v8::Local::new(scope, v).into()),
+  };
+
+  let local_data = serde_v8::to_v8(scope, raw_snapshot_data).unwrap();
   let offset = scope.add_context_data(local_context, local_data);
-  assert_eq!(offset, MODULE_MAP_CONTEXT_DATA_INDEX);
+  assert_eq!(offset, RAW_SNAPSHOTTED_DATA_INDEX);
 
-  let local_handled_promise_rejection_cb: v8::Local<v8::Value> =
-    if let Some(handled_promise_rejection_cb) =
-      snapshotted_data.js_handled_promise_rejection_cb
-    {
-      v8::Local::new(scope, handled_promise_rejection_cb).into()
-    } else {
-      v8::undefined(scope).into()
-    };
-  let offset =
-    scope.add_context_data(local_context, local_handled_promise_rejection_cb);
-  assert_eq!(offset, JS_HANDLED_PROMISE_REJECTION_CB_DATA_INDEX);
-
-  for (index, handle) in snapshotted_data.module_handles.into_iter().enumerate()
-  {
-    let module_handle = v8::Local::new(scope, handle);
-    let offset = scope.add_context_data(local_context, module_handle);
-    assert_eq!(offset, index + 2);
+  for data in data_store.data.drain(..) {
+    let data = v8::Local::new(scope, data);
+    scope.add_context_data(local_context, data);
   }
 }
 

--- a/serde_v8/magic/value.rs
+++ b/serde_v8/magic/value.rs
@@ -145,6 +145,7 @@ mod tests {
   fn test_conversions_compile() {
     // SAFETY: We don't run this test -- it's just to make sure this code compiles
     #[allow(invalid_value)]
+    #[allow(clippy::unnecessary_fallible_conversions)]
     unsafe {
       let value: v8::Local<v8::Function> = std::mem::zeroed();
 

--- a/serde_v8/magic/value.rs
+++ b/serde_v8/magic/value.rs
@@ -1,5 +1,4 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-
 use crate::magic::transl8::impl_magic;
 use crate::magic::transl8::FromV8;
 use crate::magic::transl8::ToV8;
@@ -15,6 +14,33 @@ pub struct Value<'s> {
 }
 impl_magic!(Value<'_>);
 
+impl<'s> Value<'s> {
+  /// Converts this to a [`v8::Global`] infallibly, if this `v8` type can be converted infallibly
+  /// to [`v8::Global<T>`] (eg: [`v8::Data`] or [`v8::Value`]).
+  pub fn as_global<T>(&self, scope: &mut v8::HandleScope<'s>) -> v8::Global<T>
+  where
+    v8::Local<'s, T>: From<v8::Local<'s, v8::Value>>,
+  {
+    let local = v8::Local::<T>::from(self.v8_value);
+    v8::Global::new(scope, local)
+  }
+
+  /// Converts this to a [`v8::Global`] fallibly.
+  pub fn try_as_global<T>(
+    &self,
+    scope: &mut v8::HandleScope<'s>,
+  ) -> Result<
+    v8::Global<T>,
+    <v8::Local<'s, T> as TryFrom<v8::Local<'s, v8::Value>>>::Error,
+  >
+  where
+    v8::Local<'s, T>: TryFrom<v8::Local<'s, v8::Value>>,
+  {
+    let local = v8::Local::<T>::try_from(self.v8_value)?;
+    Ok(v8::Global::new(scope, local))
+  }
+}
+
 impl<'s, T> From<v8::Local<'s, T>> for Value<'s>
 where
   v8::Local<'s, T>: Into<v8::Local<'s, v8::Value>>,
@@ -25,8 +51,8 @@ where
 }
 
 impl<'s> From<Value<'s>> for v8::Local<'s, v8::Value> {
-  fn from(v: Value<'s>) -> Self {
-    v.v8_value
+  fn from(value: Value<'s>) -> Self {
+    value.v8_value
   }
 }
 
@@ -47,5 +73,93 @@ impl FromV8 for Value<'_> {
   ) -> Result<Self, crate::Error> {
     // SAFETY: not fully safe, since lifetimes are detached from original scope
     Ok(unsafe { transmute::<Value, Value>(value.into()) })
+  }
+}
+
+macro_rules! impl_try_from {
+  ($($type:ident),+) => {$(
+    /// Implements `TryFrom` for the given `v8` type. If the type is not compatible,
+    /// returns `Err(v8::DataError)`.
+    impl<'s> TryFrom<Value<'s>> for v8::Local<'s, v8::$type> {
+      type Error = v8::DataError;
+      fn try_from(value: Value<'s>) -> Result<Self, Self::Error> {
+        value.try_into()
+      }
+    }
+  )+};
+}
+
+impl_try_from!(
+  External,
+  Object,
+  Array,
+  ArrayBuffer,
+  ArrayBufferView,
+  DataView,
+  TypedArray,
+  BigInt64Array,
+  BigUint64Array,
+  Float32Array,
+  Float64Array,
+  Int16Array,
+  Int32Array,
+  Int8Array,
+  Uint16Array,
+  Uint32Array,
+  Uint8Array,
+  Uint8ClampedArray,
+  BigIntObject,
+  BooleanObject,
+  Date,
+  Function,
+  Map,
+  NumberObject,
+  Promise,
+  PromiseResolver,
+  Proxy,
+  RegExp,
+  Set,
+  SharedArrayBuffer,
+  StringObject,
+  SymbolObject,
+  WasmMemoryObject,
+  WasmModuleObject,
+  Primitive,
+  BigInt,
+  Boolean,
+  Name,
+  String,
+  Symbol,
+  Number,
+  Integer,
+  Int32,
+  Uint32
+);
+
+#[cfg(test)]
+mod tests {
+  use std::convert::Infallible;
+
+  #[test]
+  #[ignore]
+  fn test_conversions_compile() {
+    // SAFETY: We don't run this test -- it's just to make sure this code compiles
+    #[allow(invalid_value)]
+    unsafe {
+      let value: v8::Local<v8::Function> = std::mem::zeroed();
+
+      // TryInto compiles for non-value
+      let serde_value: super::Value = value.into();
+      let _: Result<v8::Local<v8::Function>, v8::DataError> =
+        serde_value.try_into();
+
+      // TryInto compiles for value
+      let serde_value: super::Value = value.into();
+      let _: Result<v8::Local<v8::Value>, Infallible> = serde_value.try_into();
+
+      // Into compiles for value
+      let serde_value: super::Value = value.into();
+      let _: v8::Local<v8::Value> = serde_value.into();
+    }
   }
 }

--- a/serde_v8/magic/value.rs
+++ b/serde_v8/magic/value.rs
@@ -15,9 +15,12 @@ pub struct Value<'s> {
 }
 impl_magic!(Value<'_>);
 
-impl<'s> From<v8::Local<'s, v8::Value>> for Value<'s> {
-  fn from(v8_value: v8::Local<'s, v8::Value>) -> Self {
-    Self { v8_value }
+impl<'s, T> From<v8::Local<'s, T>> for Value<'s>
+where
+  v8::Local<'s, T>: Into<v8::Local<'s, v8::Value>>,
+{
+  fn from(v: v8::Local<'s, T>) -> Self {
+    Self { v8_value: v.into() }
   }
 }
 


### PR DESCRIPTION
This code will be used for the future opcall tracing work, as we need to get a reference to a number of primordials on the Rust side and persist those references in the snapshot.

This drastically simplifies our management of snapshot sidecar data. 

As a positive side-effect, the management of module map data becomes trivially easy. In the future, we may decide to serialize that serde_v8 data using a more efficient protocol, but that's left as a future task.

The sidecar data is serialized in the snapshot by using a single, nested serde_v8 struct and a collection of `v8::Data` objects that are referenced by ID. Because we cannot use serde_v8 for `v8::Data` objects like `v8::Module`, these are simply aggregated and stored in successive indexes of the snapshot per-context data.

It's a shame we don't have the ability to create a `v8::FixedArray` because that would be ideal for this.

`cargo benchmark --bench snapshot` shows that the snapshot load time difference is within the noise margin.