### PR TITLE
refactor(core): opcall tracing in Rust

### DIFF
--- a/core/00_infra.js
+++ b/core/00_infra.js
@@ -123,7 +123,7 @@
     const promise = new Promise((resolve) => {
       promiseRing[idx] = resolve;
     });
-    let wrappedPromise = PromisePrototypeThen(
+    const wrappedPromise = PromisePrototypeThen(
       promise,
       unwrapOpError(),
     );
@@ -180,7 +180,7 @@
       if (res.code) {
         err.code = res.code;
       }
-      // Strip unwrapOpResult() and errorBuilder() calls from stack trace
+      // Strip eventLoopTick() calls from stack trace
       ErrorCaptureStackTrace(err, eventLoopTick);
       throw err;
     };

--- a/core/00_infra.js
+++ b/core/00_infra.js
@@ -21,23 +21,12 @@
     RangeError,
     ReferenceError,
     SafeMap,
-    SafePromisePrototypeFinally,
-    StringPrototypeSlice,
     StringPrototypeSplit,
     SymbolFor,
     SyntaxError,
     TypeError,
     URIError,
   } = window.__bootstrap.primordials;
-  // TODO(bartlomieju): not ideal - effectively we have circular dependency between
-  // 00_infra.js and 01_core.js. Figure out how to fix it.
-  // We have two proposals:
-  //  1. Move `eventLoopTick` function to this file and add `setUpEventLoopTick`
-  //     that would be called by `01_core.js` and forward `op_run_microtasks`
-  //     and `op_dispatch_exception` so we can save references to them.
-  //  2. Add `captureStackTrace` function that will perform stack trace capturing
-  //     and can define which function should the trace hide.
-  const core_ = window.Deno.core;
 
   let nextPromiseId = 0;
   const promiseMap = new SafeMap();
@@ -47,6 +36,19 @@
   // TODO(bartlomieju): it future use `v8::Private` so it's not visible
   // to users. Currently missing bindings.
   const promiseIdSymbol = SymbolFor("Deno.core.internalPromiseId");
+
+  let isOpCallTracingEnabled = false;
+  let submitOpCallTrace;
+  let eventLoopTick;
+
+  function __setOpCallTracingEnabled(enabled) {
+    isOpCallTracingEnabled = enabled;
+  }
+
+  function __initializeCoreMethods(eventLoopTick_, submitOpCallTrace_) {
+    eventLoopTick = eventLoopTick_;
+    submitOpCallTrace = submitOpCallTrace_;
+  }
 
   const build = {
     target: "unknown",
@@ -109,42 +111,6 @@
     errorMap[className] = errorBuilder;
   }
 
-  let opCallTracingEnabled = false;
-  const opCallTraces = new SafeMap();
-
-  function getAllOpCallTraces() {
-    return new Map(opCallTraces);
-  }
-
-  function setOpCallTracingEnabled(enabled) {
-    opCallTracingEnabled = enabled;
-  }
-
-  function isOpCallTracingEnabled() {
-    return opCallTracingEnabled;
-  }
-
-  function getOpCallTraceForPromise(promise) {
-    const trace = MapPrototypeGet(opCallTraces, promise[promiseIdSymbol]);
-    if (trace) {
-      return trace.stack;
-    }
-    return null;
-  }
-
-  function handleOpCallTracing(opName, promiseId, p) {
-    if (opCallTracingEnabled) {
-      const stack = StringPrototypeSlice(new Error().stack, 6);
-      MapPrototypeSet(opCallTraces, promiseId, { opName, stack });
-      return SafePromisePrototypeFinally(
-        p,
-        () => MapPrototypeDelete(opCallTraces, promiseId),
-      );
-    } else {
-      return p;
-    }
-  }
-
   function setPromise(promiseId) {
     const idx = promiseId % RING_SIZE;
     // Move old promise from ring to map
@@ -153,11 +119,19 @@
       const oldPromiseId = promiseId - RING_SIZE;
       MapPrototypeSet(promiseMap, oldPromiseId, oldPromise);
     }
-    // Set new promise
-    return promiseRing[idx] = newPromise();
+
+    const promise = new Promise((resolve) => {
+      promiseRing[idx] = resolve;
+    });
+    let wrappedPromise = PromisePrototypeThen(
+      promise,
+      unwrapOpError(),
+    );
+    wrappedPromise[promiseIdSymbol] = promiseId;
+    return wrappedPromise;
   }
 
-  function getPromise(promiseId) {
+  function __resolvePromise(promiseId, res) {
     // Check if out of ring bounds, fallback to map
     const outOfBounds = promiseId < nextPromiseId - RING_SIZE;
     if (outOfBounds) {
@@ -166,27 +140,17 @@
         throw "Missing promise in map @ " + promiseId;
       }
       MapPrototypeDelete(promiseMap, promiseId);
-      return promise;
+      promise(res);
+    } else {
+      // Otherwise take from ring
+      const idx = promiseId % RING_SIZE;
+      const promise = promiseRing[idx];
+      if (!promise) {
+        throw "Missing promise in ring @ " + promiseId;
+      }
+      promiseRing[idx] = NO_PROMISE;
+      promise(res);
     }
-    // Otherwise take from ring
-    const idx = promiseId % RING_SIZE;
-    const promise = promiseRing[idx];
-    if (!promise) {
-      throw "Missing promise in ring @ " + promiseId;
-    }
-    promiseRing[idx] = NO_PROMISE;
-    return promise;
-  }
-
-  function newPromise() {
-    let resolve, reject;
-    const promise = new Promise((resolve_, reject_) => {
-      resolve = resolve_;
-      reject = reject_;
-    });
-    promise.resolve = resolve;
-    promise.reject = reject;
-    return promise;
   }
 
   function hasPromise(promiseId) {
@@ -200,7 +164,7 @@
     return promiseRing[idx] != NO_PROMISE;
   }
 
-  function unwrapOpError(hideFunction) {
+  function unwrapOpError() {
     return (res) => {
       // .$err_class_name is a special key that should only exist on errors
       const className = res?.$err_class_name;
@@ -217,7 +181,7 @@
         err.code = res.code;
       }
       // Strip unwrapOpResult() and errorBuilder() calls from stack trace
-      ErrorCaptureStackTrace(err, hideFunction);
+      ErrorCaptureStackTrace(err, eventLoopTick);
       throw err;
     };
   }
@@ -240,14 +204,11 @@
             ErrorCaptureStackTrace(err, async_op_0);
             return PromiseReject(err);
           }
+          if (isOpCallTracingEnabled) {
+            submitOpCallTrace(id);
+          }
           nextPromiseId = (id + 1) & 0xffffffff;
-          let promise = PromisePrototypeThen(
-            setPromise(id),
-            unwrapOpError(core_.eventLoopTick),
-          );
-          promise = handleOpCallTracing(opName, id, promise);
-          promise[promiseIdSymbol] = id;
-          return promise;
+          return setPromise(id);
         };
         break;
       case 1:
@@ -262,14 +223,11 @@
             ErrorCaptureStackTrace(err, async_op_1);
             return PromiseReject(err);
           }
+          if (isOpCallTracingEnabled) {
+            submitOpCallTrace(id);
+          }
           nextPromiseId = (id + 1) & 0xffffffff;
-          let promise = PromisePrototypeThen(
-            setPromise(id),
-            unwrapOpError(core_.eventLoopTick),
-          );
-          promise = handleOpCallTracing(opName, id, promise);
-          promise[promiseIdSymbol] = id;
-          return promise;
+          return setPromise(id);
         };
         break;
       case 2:
@@ -284,14 +242,11 @@
             ErrorCaptureStackTrace(err, async_op_2);
             return PromiseReject(err);
           }
+          if (isOpCallTracingEnabled) {
+            submitOpCallTrace(id);
+          }
           nextPromiseId = (id + 1) & 0xffffffff;
-          let promise = PromisePrototypeThen(
-            setPromise(id),
-            unwrapOpError(core_.eventLoopTick),
-          );
-          promise = handleOpCallTracing(opName, id, promise);
-          promise[promiseIdSymbol] = id;
-          return promise;
+          return setPromise(id);
         };
         break;
       case 3:
@@ -306,14 +261,11 @@
             ErrorCaptureStackTrace(err, async_op_3);
             return PromiseReject(err);
           }
+          if (isOpCallTracingEnabled) {
+            submitOpCallTrace(id);
+          }
           nextPromiseId = (id + 1) & 0xffffffff;
-          let promise = PromisePrototypeThen(
-            setPromise(id),
-            unwrapOpError(core_.eventLoopTick),
-          );
-          promise = handleOpCallTracing(opName, id, promise);
-          promise[promiseIdSymbol] = id;
-          return promise;
+          return setPromise(id);
         };
         break;
       case 4:
@@ -328,14 +280,11 @@
             ErrorCaptureStackTrace(err, async_op_4);
             return PromiseReject(err);
           }
+          if (isOpCallTracingEnabled) {
+            submitOpCallTrace(id);
+          }
           nextPromiseId = (id + 1) & 0xffffffff;
-          let promise = PromisePrototypeThen(
-            setPromise(id),
-            unwrapOpError(core_.eventLoopTick),
-          );
-          promise = handleOpCallTracing(opName, id, promise);
-          promise[promiseIdSymbol] = id;
-          return promise;
+          return setPromise(id);
         };
         break;
       case 5:
@@ -350,14 +299,11 @@
             ErrorCaptureStackTrace(err, async_op_5);
             return PromiseReject(err);
           }
+          if (isOpCallTracingEnabled) {
+            submitOpCallTrace(id);
+          }
           nextPromiseId = (id + 1) & 0xffffffff;
-          let promise = PromisePrototypeThen(
-            setPromise(id),
-            unwrapOpError(core_.eventLoopTick),
-          );
-          promise = handleOpCallTracing(opName, id, promise);
-          promise[promiseIdSymbol] = id;
-          return promise;
+          return setPromise(id);
         };
         break;
       case 6:
@@ -372,14 +318,11 @@
             ErrorCaptureStackTrace(err, async_op_6);
             return PromiseReject(err);
           }
+          if (isOpCallTracingEnabled) {
+            submitOpCallTrace(id);
+          }
           nextPromiseId = (id + 1) & 0xffffffff;
-          let promise = PromisePrototypeThen(
-            setPromise(id),
-            unwrapOpError(core_.eventLoopTick),
-          );
-          promise = handleOpCallTracing(opName, id, promise);
-          promise[promiseIdSymbol] = id;
-          return promise;
+          return setPromise(id);
         };
         break;
       case 7:
@@ -394,14 +337,11 @@
             ErrorCaptureStackTrace(err, async_op_7);
             return PromiseReject(err);
           }
+          if (isOpCallTracingEnabled) {
+            submitOpCallTrace(id);
+          }
           nextPromiseId = (id + 1) & 0xffffffff;
-          let promise = PromisePrototypeThen(
-            setPromise(id),
-            unwrapOpError(core_.eventLoopTick),
-          );
-          promise = handleOpCallTracing(opName, id, promise);
-          promise[promiseIdSymbol] = id;
-          return promise;
+          return setPromise(id);
         };
         break;
       case 8:
@@ -416,14 +356,11 @@
             ErrorCaptureStackTrace(err, async_op_8);
             return PromiseReject(err);
           }
+          if (isOpCallTracingEnabled) {
+            submitOpCallTrace(id);
+          }
           nextPromiseId = (id + 1) & 0xffffffff;
-          let promise = PromisePrototypeThen(
-            setPromise(id),
-            unwrapOpError(core_.eventLoopTick),
-          );
-          promise = handleOpCallTracing(opName, id, promise);
-          promise[promiseIdSymbol] = id;
-          return promise;
+          return setPromise(id);
         };
         break;
       case 9:
@@ -438,14 +375,11 @@
             ErrorCaptureStackTrace(err, async_op_9);
             return PromiseReject(err);
           }
+          if (isOpCallTracingEnabled) {
+            submitOpCallTrace(id);
+          }
           nextPromiseId = (id + 1) & 0xffffffff;
-          let promise = PromisePrototypeThen(
-            setPromise(id),
-            unwrapOpError(core_.eventLoopTick),
-          );
-          promise = handleOpCallTracing(opName, id, promise);
-          promise[promiseIdSymbol] = id;
-          return promise;
+          return setPromise(id);
         };
         break;
       /* END TEMPLATE */
@@ -472,15 +406,12 @@
     registerErrorBuilder,
     buildCustomError,
     registerErrorClass,
-    setOpCallTracingEnabled,
-    isOpCallTracingEnabled,
-    getAllOpCallTraces,
-    getOpCallTraceForPromise,
-    handleOpCallTracing,
     setUpAsyncStub,
-    getPromise,
     hasPromise,
     promiseIdSymbol,
+    __resolvePromise,
+    __setOpCallTracingEnabled,
+    __initializeCoreMethods,
   });
 
   ObjectAssign(globalThis.__bootstrap, { core });

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -6,6 +6,7 @@
     ArrayPrototypeMap,
     ArrayPrototypePush,
     Error,
+    ErrorCaptureStackTrace,
     FunctionPrototypeBind,
     ObjectAssign,
     ObjectFreeze,
@@ -14,6 +15,8 @@
     ObjectHasOwn,
     Proxy,
     setQueueMicrotask,
+    SafeMap,
+    StringPrototypeSlice,
     Symbol,
     SymbolFor,
     TypedArrayPrototypeGetLength,
@@ -24,11 +27,97 @@
   } = window.__bootstrap.primordials;
   const {
     ops,
-    getPromise,
     hasPromise,
     promiseIdSymbol,
     registerErrorClass,
+    __setOpCallTracingEnabled,
+    __initializeCoreMethods,
+    __resolvePromise,
   } = window.Deno.core;
+  const {
+    op_abort_wasm_streaming,
+    op_current_user_call_site,
+    op_decode,
+    op_deserialize,
+    op_destructure_error,
+    op_dispatch_exception,
+    op_encode,
+    op_encode_binary_string,
+    op_eval_context,
+    op_event_loop_has_more_work,
+    op_get_promise_details,
+    op_get_proxy_details,
+    op_has_tick_scheduled,
+    op_lazy_load_esm,
+    op_memory_usage,
+    op_op_names,
+    op_panic,
+    op_print,
+    op_queue_microtask,
+    op_ref_op,
+    op_resources,
+    op_run_microtasks,
+    op_serialize,
+    op_set_handled_promise_rejection_handler,
+    op_set_has_tick_scheduled,
+    op_set_promise_hooks,
+    op_set_wasm_streaming_callback,
+    op_str_byte_length,
+    op_timer_cancel,
+    op_timer_queue,
+    op_timer_ref,
+    op_timer_unref,
+    op_unref_op,
+    op_cancel_handle,
+    op_opcall_tracing_enable,
+    op_opcall_tracing_submit,
+    op_opcall_tracing_get_all,
+    op_opcall_tracing_get,
+
+    op_is_any_array_buffer,
+    op_is_arguments_object,
+    op_is_array_buffer,
+    op_is_array_buffer_view,
+    op_is_async_function,
+    op_is_big_int_object,
+    op_is_boolean_object,
+    op_is_boxed_primitive,
+    op_is_data_view,
+    op_is_date,
+    op_is_generator_function,
+    op_is_generator_object,
+    op_is_map,
+    op_is_map_iterator,
+    op_is_module_namespace_object,
+    op_is_native_error,
+    op_is_number_object,
+    op_is_promise,
+    op_is_proxy,
+    op_is_reg_exp,
+    op_is_set,
+    op_is_set_iterator,
+    op_is_shared_array_buffer,
+    op_is_string_object,
+    op_is_symbol_object,
+    op_is_typed_array,
+    op_is_weak_map,
+    op_is_weak_set,
+  } = ensureFastOps();
+
+  // core/infra collaborative code
+  delete window.Deno.core.__setOpCallTracingEnabled;
+  delete window.Deno.core.__initializeCoreMethods;
+  delete window.Deno.core.__resolvePromise;
+  __initializeCoreMethods(
+    eventLoopTick,
+    submitOpCallTrace,
+  );
+
+  function submitOpCallTrace(id) {
+    const error = new Error();
+    ErrorCaptureStackTrace(error, submitOpCallTrace);
+    op_opcall_tracing_submit(id, StringPrototypeSlice(error.stack, 6));
+  }
 
   let unhandledPromiseRejectionHandler = () => false;
   let timerDepth = 0;
@@ -53,8 +142,7 @@
     for (let i = 0; i < arguments.length - 3; i += 2) {
       const promiseId = arguments[i];
       const res = arguments[i + 1];
-      const promise = getPromise(promiseId);
-      promise.resolve(res);
+      __resolvePromise(promiseId, res);
     }
     // Drain nextTick queue if there's a tick scheduled.
     if (arguments[arguments.length - 1]) {
@@ -400,72 +488,6 @@
   globalThis.console = coreConsole;
   wrapConsole(coreConsole, v8Console);
 
-  const {
-    op_abort_wasm_streaming,
-    op_current_user_call_site,
-    op_decode,
-    op_deserialize,
-    op_destructure_error,
-    op_dispatch_exception,
-    op_encode,
-    op_encode_binary_string,
-    op_eval_context,
-    op_event_loop_has_more_work,
-    op_get_promise_details,
-    op_get_proxy_details,
-    op_has_tick_scheduled,
-    op_lazy_load_esm,
-    op_memory_usage,
-    op_op_names,
-    op_panic,
-    op_print,
-    op_queue_microtask,
-    op_ref_op,
-    op_resources,
-    op_run_microtasks,
-    op_serialize,
-    op_set_handled_promise_rejection_handler,
-    op_set_has_tick_scheduled,
-    op_set_promise_hooks,
-    op_set_wasm_streaming_callback,
-    op_str_byte_length,
-    op_timer_cancel,
-    op_timer_queue,
-    op_timer_ref,
-    op_timer_unref,
-    op_unref_op,
-    op_cancel_handle,
-
-    op_is_any_array_buffer,
-    op_is_arguments_object,
-    op_is_array_buffer,
-    op_is_array_buffer_view,
-    op_is_async_function,
-    op_is_big_int_object,
-    op_is_boolean_object,
-    op_is_boxed_primitive,
-    op_is_data_view,
-    op_is_date,
-    op_is_generator_function,
-    op_is_generator_object,
-    op_is_map,
-    op_is_map_iterator,
-    op_is_module_namespace_object,
-    op_is_native_error,
-    op_is_number_object,
-    op_is_promise,
-    op_is_proxy,
-    op_is_reg_exp,
-    op_is_set,
-    op_is_set_iterator,
-    op_is_shared_array_buffer,
-    op_is_string_object,
-    op_is_symbol_object,
-    op_is_typed_array,
-    op_is_weak_map,
-    op_is_weak_set,
-  } = ensureFastOps();
-
   function propWritable(value) {
     return {
       value,
@@ -586,6 +608,17 @@
     writeSync,
     shutdown,
     print: (msg, isErr) => op_print(msg, isErr),
+    setOpCallTracingEnabled: (enabled) => {
+      __setOpCallTracingEnabled(enabled);
+      op_opcall_tracing_enable(enabled);
+    },
+    isOpCallTracingEnabled: () => false,
+    getAllOpCallTraces: () => {
+      const traces = op_opcall_tracing_get_all();
+      return new SafeMap(traces);
+    },
+    getOpCallTraceForPromise: (promise) =>
+      op_opcall_tracing_get(promise[promiseIdSymbol]),
     setMacrotaskCallback,
     setNextTickCallback,
     runMicrotasks: () => op_run_microtasks(),

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -119,7 +119,11 @@ builtin_ops! {
   ops_builtin_v8::op_current_user_call_site,
   ops_builtin_v8::op_set_format_exception_callback,
   ops_builtin_v8::op_event_loop_has_more_work,
-  ops_builtin_v8::op_arraybuffer_was_detached
+  ops_builtin_v8::op_arraybuffer_was_detached,
+  ops_builtin_v8::op_opcall_tracing_enable,
+  ops_builtin_v8::op_opcall_tracing_submit,
+  ops_builtin_v8::op_opcall_tracing_get_all,
+  ops_builtin_v8::op_opcall_tracing_get
 }
 
 #[op2(fast)]

--- a/core/rebuild_async_stubs.js
+++ b/core/rebuild_async_stubs.js
@@ -17,14 +17,11 @@ function __TEMPLATE__(__ARGS_PARAM__) {
     ErrorCaptureStackTrace(err, __TEMPLATE__);
     return PromiseReject(err);
   }
+  if (isOpCallTracingEnabled) {
+    submitOpCallTrace(id);
+  }
   nextPromiseId = (id + 1) & 0xffffffff;
-  let promise = PromisePrototypeThen(
-    setPromise(id),
-    unwrapOpError(core_.eventLoopTick),
-  );
-  promise = handleOpCallTracing(opName, id, promise);
-  promise[promiseIdSymbol] = id;
-  return promise;
+  return setPromise(id);
 }
 
 const infraJsPath = new URL("00_infra.js", import.meta.url);

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -2132,6 +2132,7 @@ impl JsRuntime {
       }
 
       context_state.unrefed_ops.borrow_mut().remove(&promise_id);
+      context_state.opcall_traces.borrow_mut().remove(&promise_id);
       dispatched_ops |= true;
       args.push(v8::Integer::new(scope, promise_id).into());
       args.push(res.unwrap_or_else(std::convert::identity));

--- a/testing/unit/ops_async_test.ts
+++ b/testing/unit/ops_async_test.ts
@@ -78,7 +78,6 @@ test(async function testAsyncOpCallTrace() {
     assertStackTraceEquals(
       Deno.core.getOpCallTraceForPromise(p1),
       `
-      at handleOpCallTracing (ext:core/00_infra.js:line:col)
       at op_async_barrier_await (ext:core/00_infra.js:line:col)
       at barrierAwait (checkin:async:line:col)
       at testAsyncOpCallTrace (test:///unit/ops_async_test.ts:line:col)


### PR DESCRIPTION
Moves the core of the opcall tracing functionality into Rust. Tested against deno (which will need small source changes).

Re-organizes the op dispatch code a bit as well, but performance is unimpacted per benchmarks (if not slightly faster).