### PR TITLE
Revert "chore: update rusty_v8 to 0.84.0 (#587)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2242,9 +2242,9 @@ checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 
 [[package]]
 name = "v8"
-version = "0.84.0"
+version = "0.83.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9205df12ea9e4e9e966c44a408b1b905ce8784ff70ef27c4ed1e73daec51b97"
+checksum = "9f6c8a960dd2eb74b22eda64f7e9f3d1688f82b80202828dc0425ebdeda826ef"
 dependencies = [
  "bitflags 2.4.2",
  "fslock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ deno_core = { version = "0.263.0", path = "./core" }
 deno_ops = { version = "0.139.0", path = "./ops" }
 serde_v8 = { version = "0.172.0", path = "./serde_v8" }
 
-v8 = { version = "0.84.0", default-features = false }
+v8 = { version = "0.83.2", default-features = false }
 deno_ast = { version = "=0.32.0", features = ["transpiling"] }
 deno_unsync = "0.3.2"
 deno_core_icudata = "0.0.73"

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -544,7 +544,7 @@ impl ModuleMap {
         .get_specifier()
         .to_rust_string_lossy(tc_scope);
 
-      let import_attributes = module_request.get_import_attributes();
+      let import_attributes = module_request.get_import_assertions();
 
       let attributes = parse_import_attributes(
         tc_scope,

--- a/testing/unit/tc39_test.ts
+++ b/testing/unit/tc39_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
-import { assert, assertEquals, fail, test } from "checkin:testing";
+import { fail, test } from "checkin:testing";
 
 // Verify that "array by copy" proposal is enabled (https://github.com/tc39/proposal-change-array-by-copy)
 test(function testArrayByCopy() {
@@ -36,29 +36,5 @@ test(function testIteratorHelpers() {
   const a = naturals().take(5).toArray();
   if (a[0] !== 0 || a[1] !== 1 || a[2] !== 2 || a[3] !== 3 || a[4] !== 4) {
     fail("failed");
-  }
-});
-
-// Verify that "Set Methods" proposal is enabled (https://github.com/tc39/proposal-set-methods)
-test(function testSetMethods() {
-  {
-    const odds = new Set([1, 3, 5, 7, 9]);
-    const squares = new Set([1, 4, 9]);
-    const intersection = odds.intersection(squares);
-    assertEquals(intersection.size, 2);
-    assert(intersection.has(1));
-    assert(intersection.has(9));
-  }
-  {
-    const evens = new Set([2, 4, 6, 8]);
-    const squares = new Set([1, 4, 9]);
-    const union = evens.union(squares);
-    assertEquals(union.size, 6);
-    assert(union.has(2));
-    assert(union.has(4));
-    assert(union.has(6));
-    assert(union.has(8));
-    assert(union.has(1));
-    assert(union.has(9));
   }
 });


### PR DESCRIPTION
This reverts commit 312cf8e0f668325605cf35900e8c8486a34ebda4.

This V8 upgrade causes some serious test failures in Deno: 
https://github.com/denoland/deno/actions/runs/7981611991/job/21793650383?pr=22505

This will require more work. I don't want to block others before the Deno v1.41 release.