### PR TITLE
refactor: Use v8::OneByteConst for internals scripts

### DIFF
--- a/core/main.rs
+++ b/core/main.rs
@@ -3,10 +3,13 @@
 use anyhow::anyhow;
 use anyhow::Context;
 use deno_core::anyhow::Error;
+use deno_core::snapshot::CreateSnapshotOptions;
+use deno_core::snapshot::SnapshotFileSerializer;
 use deno_core::CustomModuleEvaluationKind;
 use deno_core::FastString;
 use deno_core::FsModuleLoader;
 use deno_core::JsRuntime;
+use deno_core::JsRuntimeForSnapshot;
 use deno_core::ModuleSourceCode;
 use deno_core::RuntimeOptions;
 use std::borrow::Cow;
@@ -69,6 +72,9 @@ fn text_module(
   )))
 }
 
+// TODO(bartlomieju): figure out how we can incorporate snapshotting here
+// static SNAPSHOT_BYTES: &[u8] = include_bytes!("../snapshot.bin");
+
 fn main() -> Result<(), Error> {
   let args: Vec<String> = std::env::args().collect();
   eprintln!(
@@ -81,7 +87,26 @@ fn main() -> Result<(), Error> {
   let main_url = &args[1];
   println!("Run {main_url}");
 
+  // TODO(bartlomieju): figure out how we can incorporate snapshotting here
+  // deno_core::snapshot::create_snapshot(
+  //   CreateSnapshotOptions {
+  //     serializer: Box::new(SnapshotFileSerializer::new(
+  //       std::fs::File::create("./snapshot.bin").unwrap(),
+  //     )),
+  //     extensions: vec![],
+  //     cargo_manifest_dir: env!("CARGO_MANIFEST_DIR"),
+  //     startup_snapshot: None,
+  //     with_runtime_cb: None,
+  //     skip_op_registration: false,
+  //   },
+  //   None,
+  // )
+  // .unwrap();
+  // return Ok(());
+
   let mut js_runtime = JsRuntime::new(RuntimeOptions {
+    // TODO(bartlomieju): figure out how we can incorporate snapshotting here
+    // startup_snapshot: Some(deno_core::Snapshot::Static(SNAPSHOT_BYTES)),
     module_loader: Some(Rc::new(FsModuleLoader)),
     custom_module_evaluation_cb: Some(Box::new(custom_module_evaluation_cb)),
     ..Default::default()

--- a/core/main.rs
+++ b/core/main.rs
@@ -3,13 +3,10 @@
 use anyhow::anyhow;
 use anyhow::Context;
 use deno_core::anyhow::Error;
-use deno_core::snapshot::CreateSnapshotOptions;
-use deno_core::snapshot::SnapshotFileSerializer;
 use deno_core::CustomModuleEvaluationKind;
 use deno_core::FastString;
 use deno_core::FsModuleLoader;
 use deno_core::JsRuntime;
-use deno_core::JsRuntimeForSnapshot;
 use deno_core::ModuleSourceCode;
 use deno_core::RuntimeOptions;
 use std::borrow::Cow;

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -6,17 +6,8 @@ use std::path::PathBuf;
 use url::Url;
 use v8::MapFnTo;
 
+use super::jsruntime::BUILTIN_SOURCES;
 use super::jsruntime::CONTEXT_SETUP_SOURCES;
-use super::jsruntime::CORE_SOURCE;
-use super::jsruntime::ERROR_SOURCE;
-use super::jsruntime::INFRA_SOURCE;
-use super::jsruntime::INFRA_SOURCE_ONEBYTE;
-use super::jsruntime::INFRA_SPECIFIER;
-use super::jsruntime::INFRA_SPECIFIER_ONEBYTE;
-use super::jsruntime::PRIMORDIALS_SOURCE;
-use super::jsruntime::PRIMORDIALS_SOURCE_ONEBYTE;
-use super::jsruntime::PRIMORDIALS_SPECIFIER;
-use super::jsruntime::PRIMORDIALS_SPECIFIER_ONEBYTE;
 use crate::error::has_call_site;
 use crate::error::is_instance_of_error;
 use crate::error::throw_type_error;
@@ -39,8 +30,12 @@ pub(crate) fn create_external_references(
   additional_references: &[v8::ExternalReference],
 ) -> &'static v8::ExternalReferences {
   // Overallocate a bit, it's better than having to resize the vector.
-  let mut references =
-    Vec::with_capacity(6 + (ops.len() * 4) + additional_references.len());
+  let mut references = Vec::with_capacity(
+    6 + CONTEXT_SETUP_SOURCES.len()
+      + BUILTIN_SOURCES.len()
+      + (ops.len() * 4)
+      + additional_references.len(),
+  );
 
   references.push(v8::ExternalReference {
     function: call_console.map_fn_to(),
@@ -57,25 +52,25 @@ pub(crate) fn create_external_references(
   references.push(v8::ExternalReference {
     function: op_disabled_fn.map_fn_to(),
   });
-
-  references.push(v8::ExternalReference {
-    pointer: PRIMORDIALS_SOURCE.as_ptr() as *mut c_void,
-  });
-  references.push(v8::ExternalReference {
-    pointer: INFRA_SOURCE.as_ptr() as *mut c_void,
-  });
-  references.push(v8::ExternalReference {
-    pointer: CORE_SOURCE.as_ptr() as *mut c_void,
-  });
-  references.push(v8::ExternalReference {
-    pointer: ERROR_SOURCE.as_ptr() as *mut c_void,
-  });
-
   let syn_module_eval_fn: v8::SyntheticModuleEvaluationSteps =
     synthetic_module_evaluation_steps.map_fn_to();
   references.push(v8::ExternalReference {
     pointer: syn_module_eval_fn as *mut c_void,
   });
+
+  // Using v8::OneByteConst and passing external references to the source code
+  // allows V8 to take an optimized path when deserializing the snapshot.
+  for source_file in &CONTEXT_SETUP_SOURCES {
+    references.push(v8::ExternalReference {
+      pointer: source_file.source.as_ptr() as *mut c_void,
+    });
+  }
+
+  for source_file in &BUILTIN_SOURCES {
+    references.push(v8::ExternalReference {
+      pointer: source_file.source.as_ptr() as *mut c_void,
+    });
+  }
 
   for ctx in ops {
     if ctx.metrics_enabled() {
@@ -271,50 +266,26 @@ pub(crate) fn initialize_deno_core_namespace<'s>(
 pub(crate) fn initialize_primordials_and_infra(
   scope: &mut v8::HandleScope,
 ) -> Result<(), AnyError> {
-  // for file_source in &CONTEXT_SETUP_SOURCES {
-  //   let code = file_source.load().unwrap();
-  //   let source_str = code.v8_string(scope).unwrap();
-  //   let name = v8_static_strings::new_from_static_str(
-  //     scope,
-  //     file_source.specifier.as_bytes(),
-  //   );
-  //   let origin = script_origin(scope, name);
-  //   // TODO(bartlomieju): these two calls will panic if there's any problem in the JS code
-  //   let script = v8::Script::compile(scope, source_str, Some(&origin))
-  //     .with_context(|| format!("Failed to parse {}", file_source.specifier))?;
-  //   script.run(scope).with_context(|| {
-  //     format!("Failed to execute {}", file_source.specifier)
-  //   })?;
-  // }
+  for source_file in &CONTEXT_SETUP_SOURCES {
+    let name = v8::String::new_from_onebyte_const(
+      scope,
+      &source_file.specifier_onebyte_const,
+    )
+    .unwrap();
+    let source_str = v8::String::new_from_onebyte_const(
+      scope,
+      &source_file.source_onebyte_const,
+    )
+    .unwrap();
 
-  let name =
-    v8::String::new_from_onebyte_const(scope, &PRIMORDIALS_SPECIFIER_ONEBYTE)
-      .unwrap();
-  let source_str =
-    v8::String::new_from_onebyte_const(scope, &PRIMORDIALS_SOURCE_ONEBYTE)
-      .unwrap();
-
-  let origin = script_origin(scope, name);
-  // TODO(bartlomieju): these two calls will panic if there's any problem in the JS code
-  let script = v8::Script::compile(scope, source_str, Some(&origin))
-    .with_context(|| format!("Failed to parse {}", PRIMORDIALS_SPECIFIER))?;
-  script
-    .run(scope)
-    .with_context(|| format!("Failed to execute {}", PRIMORDIALS_SPECIFIER))?;
-
-  let name =
-    v8::String::new_from_onebyte_const(scope, &INFRA_SPECIFIER_ONEBYTE)
-      .unwrap();
-  let source_str =
-    v8::String::new_from_onebyte_const(scope, &INFRA_SOURCE_ONEBYTE).unwrap();
-
-  let origin = script_origin(scope, name);
-  // TODO(bartlomieju): these two calls will panic if there's any problem in the JS code
-  let script = v8::Script::compile(scope, source_str, Some(&origin))
-    .with_context(|| format!("Failed to parse {}", INFRA_SPECIFIER))?;
-  script
-    .run(scope)
-    .with_context(|| format!("Failed to execute {}", INFRA_SPECIFIER))?;
+    let origin = script_origin(scope, name);
+    // TODO(bartlomieju): these two calls will panic if there's any problem in the JS code
+    let script = v8::Script::compile(scope, source_str, Some(&origin))
+      .with_context(|| format!("Failed to parse {}", source_file.specifier))?;
+    script.run(scope).with_context(|| {
+      format!("Failed to execute {}", source_file.specifier)
+    })?;
+  }
 
   Ok(())
 }

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -50,6 +50,7 @@ use crate::OpState;
 use crate::Snapshot;
 use anyhow::anyhow;
 use anyhow::bail;
+use anyhow::Context as _;
 use anyhow::Error;
 use futures::future::poll_fn;
 use futures::task::AtomicWaker;
@@ -259,50 +260,42 @@ impl Future for RcPromiseFuture {
 
 const VIRTUAL_OPS_MODULE_NAME: &str = "ext:core/ops";
 
+pub(crate) struct InternalSourceFile {
+  pub specifier: &'static str,
+  pub specifier_onebyte_const: v8::OneByteConst,
+  pub source: &'static [u8],
+  pub source_onebyte_const: v8::OneByteConst,
+}
+
+macro_rules! internal_source_file {
+  ($str_:literal) => {{
+    let specifier = concat!("ext:core/", $str_);
+    let source = include_bytes!(concat!("../", $str_));
+
+    InternalSourceFile {
+      specifier,
+      specifier_onebyte_const: v8::String::create_external_onebyte_const(
+        specifier.as_bytes(),
+      ),
+      source,
+      source_onebyte_const: v8::String::create_external_onebyte_const(source),
+    }
+  }};
+}
+
 /// These files are executed just after a new context is created. They provided
 /// the necessary infrastructure to bind ops.
-pub(crate) static CONTEXT_SETUP_SOURCES: [ExtensionFileSource; 2] = include_js_files!(
-  core
-  "00_primordials.js",
-  "00_infra.js",
-);
-
-pub(crate) static PRIMORDIALS_SPECIFIER: &str = "ext:core/00_primordials.js";
-pub(crate) static PRIMORDIALS_SPECIFIER_ONEBYTE: v8::OneByteConst =
-  v8::String::create_external_onebyte_const(PRIMORDIALS_SPECIFIER.as_bytes());
-pub(crate) static PRIMORDIALS_SOURCE: &[u8] =
-  include_bytes!("../00_primordials.js");
-pub(crate) static PRIMORDIALS_SOURCE_ONEBYTE: v8::OneByteConst =
-  v8::String::create_external_onebyte_const(PRIMORDIALS_SOURCE);
-
-pub(crate) static INFRA_SPECIFIER: &str = "ext:core/00_infra.js";
-pub(crate) static INFRA_SPECIFIER_ONEBYTE: v8::OneByteConst =
-  v8::String::create_external_onebyte_const(INFRA_SPECIFIER.as_bytes());
-pub(crate) static INFRA_SOURCE: &[u8] = include_bytes!("../00_infra.js");
-pub(crate) static INFRA_SOURCE_ONEBYTE: v8::OneByteConst =
-  v8::String::create_external_onebyte_const(INFRA_SOURCE);
+pub(crate) static CONTEXT_SETUP_SOURCES: [InternalSourceFile; 2] = [
+  internal_source_file!("00_primordials.js"),
+  internal_source_file!("00_infra.js"),
+];
 
 /// These files are executed when we start setting up extensions. They rely
 /// on ops being already fully set up.
-pub(crate) static BUILTIN_SOURCES: [ExtensionFileSource; 2] = include_js_files!(
-  core
-  "01_core.js",
-  "02_error.js",
-);
-
-pub(crate) static CORE_SPECIFIER: &str = "ext:core/01_core.js";
-pub(crate) static CORE_SPECIFIER_ONEBYTE: v8::OneByteConst =
-  v8::String::create_external_onebyte_const(CORE_SPECIFIER.as_bytes());
-pub(crate) static CORE_SOURCE: &[u8] = include_bytes!("../01_core.js");
-pub(crate) static CORE_SOURCE_ONEBYTE: v8::OneByteConst =
-  v8::String::create_external_onebyte_const(CORE_SOURCE);
-
-pub(crate) static ERROR_SPECIFIER: &str = "ext:core/02_error.js";
-pub(crate) static ERROR_SPECIFIER_ONEBYTE: v8::OneByteConst =
-  v8::String::create_external_onebyte_const(ERROR_SPECIFIER.as_bytes());
-pub(crate) static ERROR_SOURCE: &[u8] = include_bytes!("../02_error.js");
-pub(crate) static ERROR_SOURCE_ONEBYTE: v8::OneByteConst =
-  v8::String::create_external_onebyte_const(ERROR_SOURCE);
+pub(crate) static BUILTIN_SOURCES: [InternalSourceFile; 2] = [
+  internal_source_file!("01_core.js"),
+  internal_source_file!("02_error.js"),
+];
 
 /// Executed after `BUILTIN_SOURCES` are executed. Provides a thin ES module
 /// that exports `core`, `internals` and `primordials` objects.
@@ -1030,59 +1023,34 @@ impl JsRuntime {
     module_map: &Rc<ModuleMap>,
     files_loaded: &mut Vec<&'static str>,
   ) -> Result<(), Error> {
-    // for file_source in &BUILTIN_SOURCES {
-    //   mark_as_loaded_from_fs_during_snapshot(files_loaded, &file_source.code);
-    //   realm.execute_script(
-    //     self.v8_isolate(),
-    //     file_source.specifier,
-    //     file_source.load()?,
-    //   )?;
-    // }
+    let scope = &mut realm.handle_scope(self.v8_isolate());
 
-    {
-      let scope = &mut realm.handle_scope(self.v8_isolate());
-      let name =
-        v8::String::new_from_onebyte_const(scope, &CORE_SPECIFIER_ONEBYTE)
-          .unwrap();
-      let source_str =
-        v8::String::new_from_onebyte_const(scope, &CORE_SOURCE_ONEBYTE)
-          .unwrap();
+    for source_file in &BUILTIN_SOURCES {
+      let name = v8::String::new_from_onebyte_const(
+        scope,
+        &source_file.specifier_onebyte_const,
+      )
+      .unwrap();
+      let source_str = v8::String::new_from_onebyte_const(
+        scope,
+        &source_file.source_onebyte_const,
+      )
+      .unwrap();
 
       let origin = bindings::script_origin(scope, name);
-      // TODO(bartlomieju): these two calls will panic if there's any problem in the JS code
-      let script =
-        v8::Script::compile(scope, source_str, Some(&origin)).unwrap();
-      // .with_context(|| {
-      //   format!("Failed to parse {}", PRIMORDIALS_SPECIFIER)
-      // })?;
-      script.run(scope).unwrap();
-      // .with_context(|| {
-      //   format!("Failed to execute {}", PRIMORDIALS_SPECIFIER)
-      // })?;
-
-      let name =
-        v8::String::new_from_onebyte_const(scope, &ERROR_SPECIFIER_ONEBYTE)
-          .unwrap();
-      let source_str =
-        v8::String::new_from_onebyte_const(scope, &ERROR_SOURCE_ONEBYTE)
-          .unwrap();
-
-      let origin = bindings::script_origin(scope, name);
-      // TODO(bartlomieju): these two calls will panic if there's any problem in the JS code
-      let script =
-        v8::Script::compile(scope, source_str, Some(&origin)).unwrap();
-
-      // .with_context(|| format!("Failed to parse {}", INFRA_SPECIFIER))?;
-      script.run(scope).unwrap();
-
-      // .with_context(|| format!("Failed to execute {}", INFRA_SPECIFIER))?;
+      let script = v8::Script::compile(scope, source_str, Some(&origin))
+        .with_context(|| {
+          format!("Failed to parse {}", source_file.specifier)
+        })?;
+      script.run(scope).with_context(|| {
+        format!("Failed to execute {}", source_file.specifier)
+      })?;
     }
 
     for file_source in &BUILTIN_ES_MODULES {
       mark_as_loaded_from_fs_during_snapshot(files_loaded, &file_source.code);
-      let mut scope = realm.handle_scope(self.v8_isolate());
       module_map.lazy_load_es_module_from_code(
-        &mut scope,
+        scope,
         file_source.specifier,
         file_source.load()?,
       )?;

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -267,6 +267,14 @@ pub(crate) static CONTEXT_SETUP_SOURCES: [ExtensionFileSource; 2] = include_js_f
   "00_infra.js",
 );
 
+pub(crate) static CONTEXT_SETUP_SOURCES2: [(&str, &str); 2] = [
+  (
+    "ext:core/00_primordials.js",
+    include_str!("../00_primordials.js"),
+  ),
+  ("ext:core/00_infra.js", include_str!("../00_infra.js")),
+];
+
 /// These files are executed when we start setting up extensions. They rely
 /// on ops being already fully set up.
 pub(crate) static BUILTIN_SOURCES: [ExtensionFileSource; 2] = include_js_files!(


### PR DESCRIPTION
This commit changes internal JS source code of "deno_core"
to be included in the binary. We now use "v8::OneByteConst" and
pass external references to the sources which allows V8 to take
an optimized path when deserializing the snapshot. Local tests
with flamegraphs confirm that it's now cheaper to deserialize the
snapshot.

Closes https://github.com/denoland/deno_core/issues/589