### PR TITLE
[WIP] refactor: add v8::OneByteConst to FastString::StaticAscii

### DIFF
--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -357,7 +357,13 @@ impl ModuleMap {
           // synthetic module.
           CustomModuleEvaluationKind::Synthetic(value_global) => {
             let value = v8::Local::new(scope, value_global);
-            let exports = vec![(FastString::StaticAscii("default"), value)];
+            let exports = vec![(
+              FastString::StaticAscii(
+                "default",
+                v8::String::create_external_onebyte_const(b"default"),
+              ),
+              value,
+            )];
             self.new_synthetic_module(
               scope,
               module_url_found,
@@ -375,7 +381,13 @@ impl ModuleMap {
           ) => {
             let (url1, url2) = module_url_found.into_cheap_copy();
             let value = v8::Local::new(scope, synthetic_value);
-            let exports = vec![(FastString::StaticAscii("default"), value)];
+            let exports = vec![(
+              FastString::StaticAscii(
+                "default",
+                v8::String::create_external_onebyte_const(b"default"),
+              ),
+              value,
+            )];
             let _synthetic_mod_id = self.new_synthetic_module(
               scope,
               url1,
@@ -625,7 +637,13 @@ impl ModuleMap {
         return Err(ModuleError::Exception(exception));
       }
     };
-    let exports = vec![(FastString::StaticAscii("default"), parsed_json)];
+    let exports = vec![(
+      FastString::StaticAscii(
+        "default",
+        v8::String::create_external_onebyte_const(b"default"),
+      ),
+      parsed_json,
+    )];
     self.new_synthetic_module(tc_scope, name, ModuleType::Json, exports)
   }
 

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -811,7 +811,13 @@ pub fn create_exports_for_ops_virtual_module<'s>(
       op_fn = result.try_into().unwrap()
     }
 
-    exports.push((FastString::StaticAscii(op_ctx.decl.name), op_fn.into()));
+    exports.push((
+      FastString::StaticAscii(
+        op_ctx.decl.name,
+        v8::String::create_external_onebyte_const(op_ctx.decl.name.as_bytes()),
+      ),
+      op_fn.into(),
+    ));
   }
 
   exports

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -980,7 +980,12 @@ impl JsRuntime {
     let mod_id = module_map
       .new_synthetic_module(
         scope,
-        FastString::StaticAscii(VIRTUAL_OPS_MODULE_NAME),
+        FastString::StaticAscii(
+          VIRTUAL_OPS_MODULE_NAME,
+          v8::String::create_external_onebyte_const(
+            VIRTUAL_OPS_MODULE_NAME.as_bytes(),
+          ),
+        ),
         crate::ModuleType::JavaScript,
         synthetic_module_exports,
       )


### PR DESCRIPTION
This might be not needed, but I'm trying to figure out how to pass external references to these strings.