### PR TITLE
feat: Allow to serialize source files into a snapshot

### DIFF
--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -98,6 +98,20 @@ impl ExtensionFileSource {
     }
   }
 
+  pub const fn external_ref_backed(
+    specifier: &'static str,
+    code: &'static str,
+    onebyte_const: &'static v8::OneByteConst,
+  ) -> Self {
+    #[allow(deprecated)]
+    Self {
+      specifier,
+      code: ExtensionFileSourceCode::ExternalRefBacked(code, &onebyte_const),
+      source_map: None,
+      _unconstructable_use_new: PhantomData,
+    }
+  }
+
   pub const fn loaded_from_memory_during_snapshot(
     specifier: &'static str,
     code: &'static str,
@@ -679,6 +693,22 @@ impl Extension {
 
   pub fn get_lazy_loaded_esm_sources(&self) -> &[ExtensionFileSource] {
     &self.lazy_loaded_esm_files
+  }
+
+  pub fn get_external_refs_backed_sources(
+    &self,
+  ) -> Vec<ExtensionFileSourceCode> {
+    self
+      .esm_files
+      .iter()
+      .filter_map(|f| {
+        if matches!(f.code, ExtensionFileSourceCode::ExternalRefBacked(_, _)) {
+          Some(f.code.clone())
+        } else {
+          None
+        }
+      })
+      .collect::<Vec<_>>()
   }
 
   pub fn get_esm_entry_point(&self) -> Option<&'static str> {

--- a/core/fast_string.rs
+++ b/core/fast_string.rs
@@ -138,6 +138,7 @@ impl FastString {
     scope: &mut v8::HandleScope<'a>,
   ) -> v8::Local<'a, v8::String> {
     if let Self::ExternalRefBacked(_code, v8_onebyte_const) = self {
+      eprintln!("v8_string returns new_from_onebyte_const");
       return v8::String::new_from_onebyte_const(scope, v8_onebyte_const)
         .unwrap();
     }

--- a/core/main.rs
+++ b/core/main.rs
@@ -81,7 +81,7 @@ static SNAPSHOT_BYTES: &[u8] = include_bytes!("../snapshot.bin");
 //     "ext:testing_snapshotting/main.js",
 //     SOURCE_CODE,
 //     &ONEBYTE_CONST,
-//   )];
+// )];
 
 fn main() -> Result<(), Error> {
   let args: Vec<String> = std::env::args().collect();

--- a/core/main.rs
+++ b/core/main.rs
@@ -72,15 +72,16 @@ fn text_module(
 // TODO(bartlomieju): figure out how we can incorporate snapshotting here
 static SNAPSHOT_BYTES: &[u8] = include_bytes!("../snapshot.bin");
 
-static SOURCE_CODE: &str = include_str!("./testing_snapshotting.js");
-static ONEBYTE_CONST: v8::OneByteConst =
-  v8::String::create_external_onebyte_const(SOURCE_CODE.as_bytes());
-static ESM_FILES: &[deno_core::ExtensionFileSource] =
-  &[deno_core::ExtensionFileSource::external_ref_backed(
-    "ext:testing_snapshotting/main.js",
-    SOURCE_CODE,
-    &ONEBYTE_CONST,
-  )];
+// static SOURCE_CODE: &str = include_str!("./testing_snapshotting.js");
+// #[allow(long_running_const_eval)]
+// static ONEBYTE_CONST: v8::OneByteConst =
+//   v8::String::create_external_onebyte_const(SOURCE_CODE.as_bytes());
+// static ESM_FILES: &[deno_core::ExtensionFileSource] =
+//   &[deno_core::ExtensionFileSource::external_ref_backed(
+//     "ext:testing_snapshotting/main.js",
+//     SOURCE_CODE,
+//     &ONEBYTE_CONST,
+//   )];
 
 fn main() -> Result<(), Error> {
   let args: Vec<String> = std::env::args().collect();

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -28,13 +28,15 @@ use crate::ModuleType;
 pub(crate) fn create_external_references(
   ops: &[OpCtx],
   additional_references: &[v8::ExternalReference],
+  source_files: Vec<&'static [u8]>,
 ) -> &'static v8::ExternalReferences {
   // Overallocate a bit, it's better than having to resize the vector.
   let mut references = Vec::with_capacity(
     6 + CONTEXT_SETUP_SOURCES.len()
       + BUILTIN_SOURCES.len()
       + (ops.len() * 4)
-      + additional_references.len(),
+      + additional_references.len()
+      + source_files.len(),
   );
 
   references.push(v8::ExternalReference {
@@ -105,6 +107,12 @@ pub(crate) fn create_external_references(
   }
 
   references.extend_from_slice(additional_references);
+
+  for source_file in source_files {
+    references.push(v8::ExternalReference {
+      pointer: source_file.as_ptr() as _,
+    })
+  }
 
   let refs = v8::ExternalReferences::new(&references);
   let refs: &'static v8::ExternalReferences = Box::leak(Box::new(refs));

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -688,10 +688,8 @@ impl JsRuntime {
       global_object_middlewares,
       additional_references,
     ) = extension_set::get_middlewares_and_external_refs(&mut extensions);
-    let external_refs =
-      bindings::create_external_references(&op_ctxs, &additional_references);
 
-    let (maybe_startup_snapshot, sidecar_data, _source_files) = options
+    let (maybe_startup_snapshot, sidecar_data, source_files) = options
       .startup_snapshot
       .take()
       .map(|snapshot| {
@@ -699,6 +697,13 @@ impl JsRuntime {
         (Some(a), Some(b), Some(c))
       })
       .unwrap_or_else(|| (None, None, None));
+
+    let external_refs = bindings::create_external_references(
+      &op_ctxs,
+      &additional_references,
+      source_files.unwrap_or_default(),
+    );
+
     let mut isolate = setup::create_isolate(
       will_snapshot,
       options.create_params.take(),

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -712,15 +712,20 @@ impl JsRuntime {
         external_ref_backed_sources
           .iter()
           .map(|c| {
-            let ExtensionFileSourceCode::ExternalRefBacked(source, _) = c
+            let ExtensionFileSourceCode::ExternalRefBacked(_source, onebyte) =
+              c
             else {
               unreachable!()
             };
-            source.as_bytes()
+            *onebyte
           })
           .collect::<Vec<_>>()
       } else {
-        source_files.unwrap_or_default()
+        if let Some(sf) = source_files.as_ref() {
+          sf.iter().map(|(_, o)| o).collect()
+        } else {
+          vec![]
+        }
       },
     );
 

--- a/core/runtime/snapshot.rs
+++ b/core/runtime/snapshot.rs
@@ -29,7 +29,7 @@ pub(crate) fn deconstruct(
 ) -> (
   V8Snapshot,
   SerializableSnapshotSidecarData,
-  Vec<&'static [u8]>,
+  Vec<(&'static [u8], v8::OneByteConst)>,
 ) {
   let lengths = &slice[slice.len() - 4 * ULEN..];
 
@@ -70,7 +70,8 @@ pub(crate) fn deconstruct(
     //   "source file {}",
     //   String::from_utf8(source_file.to_vec()).unwrap()
     // );
-    files.push(source_file);
+    let onebyte_const = v8::String::create_external_onebyte_const(source_file);
+    files.push((source_file, onebyte_const));
     current_offset = current_offset + source_file_len;
   }
 

--- a/core/testing_snapshotting.js
+++ b/core/testing_snapshotting.js
@@ -1,0 +1,6 @@
+console.log("This gets executed");
+
+globalThis.foo = "foo";
+globalThis.testingSnapshot = function () {
+  console.log("Hello from testing_snapshotting.js!");
+};

--- a/foo.js
+++ b/foo.js
@@ -1,0 +1,2 @@
+console.log("globalThis.foo:", globalThis.foo);
+globalThis.testingSnapshot();

--- a/foo.js
+++ b/foo.js
@@ -1,2 +1,2 @@
-console.log("globalThis.foo:", globalThis.foo);
-globalThis.testingSnapshot();
+console.log("globalThis.tsInstalled:", globalThis.tsInstalled);
+globalThis.testingSnapshot;


### PR DESCRIPTION
This commit changes snapshotting methods to allow to serde
source files.

The pointers to these source files are passed to V8, but we currently
don't use this functionality. I'll try to implement that before landing this PR.