### PR TITLE
fix(core): fix for panic in repl w/unhandled rejection

### DIFF
--- a/core/runtime/exception_state.rs
+++ b/core/runtime/exception_state.rs
@@ -144,6 +144,8 @@ impl ExceptionState {
         let previous_len = rejections.len();
         rejections.retain(|(key, _)| key != &promise_global);
         if rejections.len() == previous_len {
+          // Don't hold the lock while we go back into v8
+          drop(rejections);
           // The unhandled rejection was already delivered, so this means we need to deliver a
           // "rejectionhandled" event if anyone cares.
           if self.js_handled_promise_rejection_cb.borrow().is_some() {


### PR DESCRIPTION
I cannot seem to repro this in deno_core itself, but this is a test in Deno that is fixed by this PR:

```
diff --git a/tests/integration/repl_tests.rs b/tests/integration/repl_tests.rs
index 0e63f1589..557cb70ac 100644
--- a/tests/integration/repl_tests.rs
+++ b/tests/integration/repl_tests.rs
@@ -1119,3 +1119,14 @@ fn pty_promise_was_collected_regression_test() {
   assert_contains!(out, "Uint8Array(67108864)");
   assert!(err.is_empty());
 }
+
+#[test]
+fn eval_file_promise_error() {
+  let (out, err) = util::run_and_collect_output_with_args(
+    true,
+    vec!["repl", "--eval-file=./repl/promise_panic.ts"],
+    None,
+    false,
+  );
+  assert!(err.is_empty());
+}
diff --git a/tests/testdata/repl/promise_panic.ts b/tests/testdata/repl/promise_panic.ts
new file mode 100644
index 000000000..2927a9596
--- /dev/null
+++ b/tests/testdata/repl/promise_panic.ts
@@ -0,0 +1,2 @@
+async function rejects() { return Promise.reject(); }
+await rejects();
```