### PR TITLE
feat(core): Implement high-res timer lock

### DIFF
--- a/core/web_timeout.rs
+++ b/core/web_timeout.rs
@@ -363,7 +363,7 @@ impl<T: Clone> WebTimers<T> {
           self.tombstone_count.get() + 1,
           self.timers.borrow().len()
         );
-        #[cfg(all(windows, test))]
+        #[cfg(any(windows, test))]
         debug_assert_eq!(self.high_res_timer_lock.is_locked(), high_res);
         self.high_res_timer_lock.clear();
         self.unrefd_count.set(0);
@@ -602,7 +602,7 @@ impl HighResTimerLock {
   #[inline(always)]
   fn clear(&self) {}
 
-  #[cfg(test)]
+  #[cfg(any(windows, test))]
   fn is_locked(&self) -> bool {
     self.lock_count.get() > 0
   }

--- a/core/web_timeout.rs
+++ b/core/web_timeout.rs
@@ -463,6 +463,9 @@ impl<T: Clone> WebTimers<T> {
       if self.tombstone_count.get() > data.len()
         && self.tombstone_count.get() > COMPACTION_MINIMUM
       {
+        // Run a consistency check on tombstone count before we zero it out. Note that
+        // we aren't changing unref or high-res timer lock counts here, so we don't
+        // check consistency of those.
         debug_assert_eq!(self.tombstone_count.get() + data.len(), timers.len());
         self.tombstone_count.set(0);
         timers.retain(|k| data.contains_key(&k.1));

--- a/core/web_timeout.rs
+++ b/core/web_timeout.rs
@@ -364,10 +364,7 @@ impl<T: Clone> WebTimers<T> {
           self.timers.borrow().len()
         );
         #[cfg(all(windows, test))]
-        debug_assert_eq!(
-          self.high_res_timer_lock.is_locked(),
-          if high_res { true } else { false }
-        );
+        debug_assert_eq!(self.high_res_timer_lock.is_locked(), high_res);
         self.high_res_timer_lock.clear();
         self.unrefd_count.set(0);
         self.timers.borrow_mut().clear();


### PR DESCRIPTION
This was previously implemented in Deno, but we want it to work here in WebTimers implementation.

To enable more comprehensive testing, #[cfg(test)] will do everything except call the WinMM APIs required to set the timer period. These APIs are imported directly to avoid adding an extra dep.