### PR TITLE
chore: add a tools/check.ts for lint and format

### DIFF
--- a/.github/workflows/ci-lint/action.yml
+++ b/.github/workflows/ci-lint/action.yml
@@ -5,21 +5,8 @@ runs:
     - name: Format
       shell: bash
       run: |
-        cargo fmt -- --check
-        deno fmt --check ./core/ ./ops/ ./serde_v8/
-    - name: tsc
-      shell: bash
-      run: |
-        deno run --allow-read --allow-env npm:typescript@5.3.3/tsc --noEmit -p testing/tsconfig.json
+        tools/check.ts format --check
     - name: Lint
       shell: bash
       run: |
-        cargo clippy --locked --release --all-features --all-targets -- -D clippy::all
-    - name: Lint
-      shell: bash
-      run: |
-        deno lint
-    - name: Lint
-      shell: bash
-      run: |
-        tools/copyright_checker.js
+        tools/check.ts lint --check

--- a/tools/check.ts
+++ b/tools/check.ts
@@ -1,0 +1,218 @@
+#!/usr/bin/env -S deno run --quiet --allow-read --allow-write --allow-run --allow-env
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+import { $, dax } from "https://deno.land/x/dax@0.39.2/mod.ts";
+
+const isCI = !!Deno.env.get("CI");
+const divider =
+  "--------------------------------------------------------------";
+
+class CommandState {
+  stdout: string = "";
+  stderr: string = "";
+  lastLine: string = "";
+  lastLineTimestamp: number = 0;
+  success: boolean;
+  running: boolean;
+
+  constructor(public name) {
+    this.success = true;
+    this.running = true;
+  }
+
+  makeReader(which, callback) {
+    // deno-lint-ignore no-this-alias
+    const self = this;
+    const textDecoder = new TextDecoderStream();
+    textDecoder.readable.pipeTo(
+      new WritableStream({
+        write(chunk) {
+          self[which] += chunk;
+          if (chunk.includes("\n")) {
+            const lines = self[which].split("\n");
+            while (lines.length > 0) {
+              const line = lines[lines.length - 1].trim().replace(
+                // deno-lint-ignore no-control-regex
+                /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
+                "",
+              );
+              if (line.length == 0) {
+                lines.pop();
+                continue;
+              }
+
+              if (line != self.lastLine) {
+                self.lastLine = line;
+                self.lastLineTimestamp = new Date().valueOf();
+                callback();
+              }
+              break;
+            }
+          }
+        },
+      }),
+    );
+    return textDecoder.writable;
+  }
+
+  toString() {
+    if (!this.running) {
+      if (this.success) {
+        return `✅ ${this.name}`;
+      } else {
+        return `❌ ${this.name}`;
+      }
+    }
+
+    return `⏳ ${this.name}`;
+  }
+}
+
+async function runCommands(
+  mode: string,
+  commands: { [name: string]: dax.CommandBuilder },
+) {
+  function makeProgress() {
+    if (isCI) {
+      return null;
+    }
+    return $.progress(mode);
+  }
+
+  let pb = makeProgress();
+  const promises: Promise<void>[] = [];
+  const processes: Set<CommandState> = new Set();
+
+  function updateProgress(final: boolean = false) {
+    if (isCI) {
+      if (final) {
+        console.log(divider);
+        console.log("Done: " + [...processes.values()].flat().join(", "));
+      }
+      return;
+    }
+    const processString = [...processes.values()].flat().join(", ");
+    let lastLine = "";
+    let lastTime = 0;
+    let complete = 0;
+    for (const process of processes) {
+      if (process.running && process.lastLineTimestamp > lastTime) {
+        let line = process.lastLine;
+        if (line.length > 50) {
+          line = line.slice(0, 50) + "᠁";
+        }
+        lastLine = ` (${line})`;
+        lastTime = process.lastLineTimestamp;
+      }
+      if (!process.running) {
+        complete++;
+      }
+    }
+    pb.length(processes.size);
+    pb.position(complete);
+    pb.message(processString + lastLine);
+  }
+
+  for (const [name, command] of Object.entries(commands)) {
+    const state = new CommandState(name);
+    processes.add(state);
+
+    const promise = (async () => {
+      try {
+        await command
+          .stdout(state.makeReader("stdout", updateProgress))
+          .stderr(state.makeReader("stderr", updateProgress));
+        if (isCI) {
+          console.log(`✅ ${state.name} passed`);
+          console.log(state.stderr.trim());
+          console.log(state.stdout.trim());
+        }
+      } catch (e) {
+        state.success = false;
+        if (!isCI) {
+          pb.finish();
+        }
+        console.log(`❌ ${state.name} failed!`);
+        if (!e.message.includes("Exited with code")) {
+          console.log(e);
+        }
+        console.log(divider);
+        console.log(state.stderr.trim());
+        console.log(state.stdout.trim());
+        console.log(divider);
+        pb = makeProgress();
+        updateProgress();
+      } finally {
+        state.running = false;
+        updateProgress();
+      }
+      return;
+    })();
+    promises.push(promise);
+  }
+
+  updateProgress();
+  await Promise.all(promises);
+
+  updateProgress(true);
+
+  if (!isCI) {
+    pb.noClear();
+    pb.prefix("Done");
+    pb.forceRender();
+    pb.finish();
+  }
+
+  for (const process of processes) {
+    if (!process.success) {
+      Deno.exit(1);
+    }
+  }
+}
+
+export async function main(command, flag) {
+  if (command == "format") {
+    const check = flag == "--check";
+    if (check) {
+      await runCommands("Formatting (--check)", {
+        "cargo fmt": $`cargo fmt -- --check`,
+        "deno fmt":
+          $`deno fmt --check ./core/ ./ops/ ./serde_v8/ ./testing/ ./tools/`,
+      });
+    } else {
+      await runCommands("Formatting", {
+        "cargo fmt": $`cargo fmt`,
+        "deno fmt": $`deno fmt ./core/ ./ops/ ./serde_v8/ ./testing/ ./tools/`,
+      });
+    }
+  } else if (command == "lint") {
+    const fix = flag == "--fix";
+    if (fix) {
+      await runCommands("Linting (--fix)", {
+        "cargo clippy":
+          $`cargo clippy --fix --allow-dirty --allow-staged --locked --release --all-features --all-targets -- -D clippy::all`,
+      });
+    } else {
+      await runCommands("Linting", {
+        "copyright": $`tools/copyright_checker.js`,
+        "deno lint": $`deno lint`,
+        "tsc":
+          $`deno run --allow-read --allow-env npm:typescript@5.3.3/tsc --noEmit -p testing/tsconfig.json`,
+        "cargo clippy":
+          $`cargo clippy --locked --release --all-features --all-targets -- -D clippy::all`,
+      });
+    }
+  }
+}
+
+if (import.meta.main) {
+  if (Deno.args.length == 0) {
+    console.error("Usage:");
+    console.error("  check.ts lint [--fix]");
+    console.error("  check.ts format [--check]");
+    Deno.exit(1);
+  }
+  const command = Deno.args[0];
+  const flag = Deno.args[1];
+  await main(command, flag);
+}

--- a/tools/format.ts
+++ b/tools/format.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env -S deno run --quiet --allow-read --allow-write --allow-run --allow-env
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import { main } from "./check.ts";
+
+await main("format", Deno.args[0]);

--- a/tools/lint.ts
+++ b/tools/lint.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env -S deno run --quiet --allow-read --allow-write --allow-run --allow-env
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+import { main } from "./check.ts";
+
+await main("lint", Deno.args[0]);


### PR DESCRIPTION
Usage:
 - `tools/check.ts lint`: runs a lint and reports errors
 - `tools/check.ts lint --fix`: attempts to fix lint problems
 - `tools/check.ts format`: formats the codebase
 - `tools/check.ts format --check`: checks if the codebase is formatted, fails if not