### PR TITLE
refactor(core): execute_script_static -> execute_script

### DIFF
--- a/core/benches/ops/async.rs
+++ b/core/benches/ops/async.rs
@@ -138,7 +138,7 @@ fn bench_op(
 
   // Prime the optimizer
   runtime
-    .execute_script("", FastString::Owned(harness.into()))
+    .execute_script("", harness)
     .map_err(err_mapper)
     .unwrap();
   let guard = tokio.enter();

--- a/core/benches/ops/sync.rs
+++ b/core/benches/ops/sync.rs
@@ -191,7 +191,7 @@ fn bench_op(
 
   // Prime the optimizer
   runtime
-    .execute_script("", FastString::Owned(harness.into()))
+    .execute_script("", harness)
     .map_err(err_mapper)
     .unwrap();
   let bench = runtime.execute_script("", ascii_str!("bench")).unwrap();

--- a/core/examples/disable_ops.rs
+++ b/core/examples/disable_ops.rs
@@ -24,6 +24,6 @@ fn main() {
 
   // Deno.core.print() will now be a NOP
   runtime
-    .execute_script_static("<usage>", r#"Deno.core.print("I'm broken")"#)
+    .execute_script("<usage>", r#"Deno.core.print("I'm broken")"#)
     .unwrap();
 }

--- a/core/examples/eval_js_value.rs
+++ b/core/examples/eval_js_value.rs
@@ -28,7 +28,7 @@ fn eval(
   context: &mut JsRuntime,
   code: &'static str,
 ) -> Result<serde_json::Value, String> {
-  let res = context.execute_script_static("<anon>", code);
+  let res = context.execute_script("<anon>", code);
   match res {
     Ok(global) => {
       let scope = &mut context.handle_scope();

--- a/core/examples/hello_world.rs
+++ b/core/examples/hello_world.rs
@@ -32,7 +32,7 @@ fn main() {
   // contains a Deno.core object with several functions for interacting with it.
   // You can find its definition in core.js.
   runtime
-    .execute_script_static(
+    .execute_script(
       "<usage>",
       r#"
 // Print helper function, calling Deno.core.print()

--- a/core/fast_string.rs
+++ b/core/fast_string.rs
@@ -187,6 +187,14 @@ impl PartialEq for FastString {
 
 impl Eq for FastString {}
 
+/// [`FastString`] can be made cheaply from `&'static str` as we know it's owned and don't need to do an
+/// ASCII check.
+impl From<&'static str> for FastString {
+  fn from(value: &'static str) -> Self {
+    FastString::from_static(value)
+  }
+}
+
 /// [`FastString`] can be made cheaply from [`Url`] as we know it's owned and don't need to do an
 /// ASCII check.
 impl From<Url> for FastString {

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -344,7 +344,7 @@ fn test_mods() {
   });
 
   runtime
-    .execute_script_static(
+    .execute_script(
       "setup.js",
       r#"
       function assert(cond) {
@@ -426,7 +426,7 @@ fn test_lazy_loaded_esm() {
   });
 
   runtime
-    .execute_script_static(
+    .execute_script(
       "setup.js",
       r#"
       Deno.core.print("1\n");
@@ -449,7 +449,7 @@ fn test_json_module() {
   });
 
   runtime
-    .execute_script_static(
+    .execute_script(
       "setup.js",
       r#"
         function assert(cond) {
@@ -942,7 +942,7 @@ async fn dyn_import_err() {
   // Test an erroneous dynamic import where the specified module isn't found.
   poll_fn(move |cx| {
     runtime
-      .execute_script_static(
+      .execute_script(
         "file:///dyn_import2.js",
         r#"
       (async () => {
@@ -974,7 +974,7 @@ async fn dyn_import_ok() {
   poll_fn(move |cx| {
     // Dynamically import mod_b
     runtime
-      .execute_script_static(
+      .execute_script(
         "file:///dyn_import3.js",
         r#"
         (async () => {
@@ -1021,7 +1021,7 @@ async fn dyn_import_borrow_mut_error() {
 
   poll_fn(move |cx| {
     runtime
-      .execute_script_static(
+      .execute_script(
         "file:///dyn_import3.js",
         r#"
         (async () => {
@@ -1434,7 +1434,7 @@ fn dynamic_imports_snapshot() {
   });
 
   //Evaluate the snapshot with an empty function
-  runtime2.execute_script_static("check.js", "true").unwrap();
+  runtime2.execute_script("check.js", "true").unwrap();
 }
 
 #[test]
@@ -1477,7 +1477,7 @@ fn import_meta_snapshot() {
   });
 
   runtime2
-    .execute_script_static(
+    .execute_script(
       "check.js",
       "if (globalThis.url !== 'file:///main_with_code.js') throw Error('x')",
     )

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -261,40 +261,13 @@ impl JsRealm {
   /// The same `name` value can be used for multiple executions.
   ///
   /// `Error` can usually be downcast to `JsError`.
-  #[cfg(test)]
-  pub fn execute_script_static(
-    &self,
-    isolate: &mut v8::Isolate,
-    name: &'static str,
-    source_code: &'static str,
-  ) -> Result<v8::Global<v8::Value>, Error> {
-    self.execute_script(
-      isolate,
-      name,
-      ModuleCodeString::from_static(source_code),
-    )
-  }
-
-  /// Executes traditional JavaScript code (traditional = not ES modules) in the
-  /// realm's context.
-  ///
-  /// For info on the [`v8::Isolate`] parameter, check [`JsRealm#panics`].
-  ///
-  /// The `name` parameter can be a filepath or any other string. E.g.:
-  ///
-  ///   - "/some/file/path.js"
-  ///   - "<anon>"
-  ///   - "[native code]"
-  ///
-  /// The same `name` value can be used for multiple executions.
-  ///
-  /// `Error` can usually be downcast to `JsError`.
   pub fn execute_script(
     &self,
     isolate: &mut v8::Isolate,
     name: &'static str,
-    source_code: ModuleCodeString,
+    source_code: impl Into<ModuleCodeString>,
   ) -> Result<v8::Global<v8::Value>, Error> {
+    let source_code = source_code.into();
     let scope = &mut self.0.handle_scope(isolate);
 
     let source = source_code.v8_string(scope);

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1282,40 +1282,13 @@ impl JsRuntime {
   pub fn execute_script(
     &mut self,
     name: &'static str,
-    source_code: ModuleCodeString,
+    source_code: impl Into<ModuleCodeString>,
   ) -> Result<v8::Global<v8::Value>, Error> {
     let isolate = &mut self.inner.v8_isolate;
     self
       .inner
       .main_realm
       .execute_script(isolate, name, source_code)
-  }
-
-  /// Executes traditional JavaScript code (traditional = not ES modules).
-  ///
-  /// The execution takes place on the current main realm, so it is possible
-  /// to maintain local JS state and invoke this method multiple times.
-  ///
-  /// `name` can be a filepath or any other string, but it is required to be 7-bit ASCII, eg.
-  ///
-  ///   - "/some/file/path.js"
-  ///   - "<anon>"
-  ///   - "[native code]"
-  ///
-  /// The same `name` value can be used for multiple executions.
-  ///
-  /// `Error` can usually be downcast to `JsError`.
-  pub fn execute_script_static(
-    &mut self,
-    name: &'static str,
-    source_code: &'static str,
-  ) -> Result<v8::Global<v8::Value>, Error> {
-    let isolate = &mut self.inner.v8_isolate;
-    self.inner.main_realm.execute_script(
-      isolate,
-      name,
-      ModuleCodeString::from_static(source_code),
-    )
   }
 
   /// Call a function and return a future resolving with the return value of the

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -521,7 +521,6 @@ mod tests {
   use crate::external::ExternalPointer;
   use crate::op2;
   use crate::runtime::JsRuntimeState;
-  use crate::FastString;
   use crate::JsRuntime;
   use crate::OpState;
   use crate::RuntimeOptions;
@@ -659,39 +658,31 @@ mod tests {
     runtime
       .execute_script(
         "",
-        FastString::Owned(
-          format!(
-            r"
-            const {{ op_test_fail, op_test_print_debug, {op} }} = Deno.core.ensureFastOps();
-            function assert(b) {{
-              if (!b) {{
-                op_test_fail();
-              }}
+        format!(r"
+          const {{ op_test_fail, op_test_print_debug, {op} }} = Deno.core.ensureFastOps();
+          function assert(b) {{
+            if (!b) {{
+              op_test_fail();
             }}
-            function assertErrorContains(e, s) {{
-              assert(String(e).indexOf(s) != -1)
-            }}
-            function log(s) {{
-              op_test_print_debug(String(s))
-            }}
-          "
-          )
-          .into(),
-        ),
+          }}
+          function assertErrorContains(e, s) {{
+            assert(String(e).indexOf(s) != -1)
+          }}
+          function log(s) {{
+            op_test_print_debug(String(s))
+          }}
+        ")
       )
       .map_err(err_mapper)?;
     FAIL.with(|b| b.set(false));
     runtime.execute_script(
       "",
-      FastString::Owned(
-        format!(
-          r"
-      for (let __index__ = 0; __index__ < {repeat}; __index__++) {{
-        {test}
-      }}
-    "
-        )
-        .into(),
+      format!(
+        r"
+        for (let __index__ = 0; __index__ < {repeat}; __index__++) {{
+          {test}
+        }}
+      "
       ),
     )?;
     if FAIL.with(|b| b.get()) {
@@ -716,41 +707,33 @@ mod tests {
     runtime
       .execute_script(
         "",
-        FastString::Owned(
-          format!(
-            r"
-            const {{ op_test_fail, op_test_print_debug, {op} }} = Deno.core.ensureFastOps();
-            function assert(b) {{
-              if (!b) {{
-                op_test_fail();
-              }}
+        format!(r"
+          const {{ op_test_fail, op_test_print_debug, {op} }} = Deno.core.ensureFastOps();
+          function assert(b) {{
+            if (!b) {{
+              op_test_fail();
             }}
-            function assertErrorContains(e, s) {{
-              assert(String(e).indexOf(s) != -1)
-            }}
-            function log(s) {{
-              op_test_print_debug(String(s))
-            }}
-          "
-          )
-          .into(),
-        ),
+          }}
+          function assertErrorContains(e, s) {{
+            assert(String(e).indexOf(s) != -1)
+          }}
+          function log(s) {{
+            op_test_print_debug(String(s))
+          }}
+        ")
       )
       .map_err(err_mapper)?;
     FAIL.with(|b| b.set(false));
     runtime.execute_script(
       "",
-      FastString::Owned(
-        format!(
-          r"
-            (async () => {{
-              for (let __index__ = 0; __index__ < {repeat}; __index__++) {{
-                {test}
-              }}
-            }})()
-          "
-        )
-        .into(),
+      format!(
+        r"
+        (async () => {{
+          for (let __index__ = 0; __index__ < {repeat}; __index__++) {{
+            {test}
+          }}
+        }})()
+      "
       ),
     )?;
 

--- a/core/runtime/snapshot.rs
+++ b/core/runtime/snapshot.rs
@@ -178,7 +178,7 @@ pub fn create_snapshot(
       with_runtime_cb(&mut js_runtime);
     }
 
-    js_runtime.execute_script_static("warmup", warmup_script)?;
+    js_runtime.execute_script("warmup", warmup_script)?;
 
     snapshot = js_runtime.snapshot();
   }

--- a/core/runtime/tests/error.rs
+++ b/core/runtime/tests/error.rs
@@ -27,7 +27,7 @@ async fn test_error_builder() {
   });
   poll_fn(move |cx| {
     runtime
-      .execute_script_static(
+      .execute_script(
         "error_builder_test.js",
         include_str!("error_builder_test.js"),
       )
@@ -45,7 +45,7 @@ async fn test_error_builder() {
 fn syntax_error() {
   let mut runtime = JsRuntime::new(Default::default());
   let src = "hocuspocus(";
-  let r = runtime.execute_script_static("i.js", src);
+  let r = runtime.execute_script("i.js", src);
   let e = r.unwrap_err();
   let js_error = e.downcast::<JsError>().unwrap();
   let frame = js_error.frames.first().unwrap();

--- a/core/runtime/tests/jsrealm.rs
+++ b/core/runtime/tests/jsrealm.rs
@@ -28,8 +28,7 @@ fn test_set_format_exception_callback_realms() {
               return `{realm_name} / ${{error}}`;
             }});
           "#
-        )
-        .into(),
+        ),
       )
       .unwrap();
   }
@@ -40,7 +39,7 @@ fn test_set_format_exception_callback_realms() {
       let result = realm.execute_script(
         runtime.v8_isolate(),
         "",
-        format!("throw new Error('{realm_name}');").into(),
+        format!("throw new Error('{realm_name}');"),
       );
       assert!(result.is_err());
 
@@ -57,7 +56,7 @@ fn test_set_format_exception_callback_realms() {
         .execute_script(
           runtime.v8_isolate(),
           "",
-          format!("Promise.reject(new Error('{realm_name}'));").into(),
+          format!("Promise.reject(new Error('{realm_name}'));"),
         )
         .unwrap();
 
@@ -91,7 +90,7 @@ async fn js_realm_ref_unref_ops() {
     let main_realm = runtime.main_realm();
 
     main_realm
-      .execute_script_static(
+      .execute_script(
         runtime.v8_isolate(),
         "",
         r#"
@@ -106,7 +105,7 @@ async fn js_realm_ref_unref_ops() {
     ));
 
     main_realm
-      .execute_script_static(
+      .execute_script(
         runtime.v8_isolate(),
         "",
         r#"
@@ -150,9 +149,7 @@ fn es_snapshot() {
 
   // The module was evaluated ahead of time
   {
-    let global_test = runtime
-      .execute_script_static("", "globalThis.TEST")
-      .unwrap();
+    let global_test = runtime.execute_script("", "globalThis.TEST").unwrap();
     let scope = &mut runtime.handle_scope();
     let global_test = v8::Local::new(scope, global_test);
     assert!(global_test.is_string());
@@ -162,10 +159,7 @@ fn es_snapshot() {
   // The module can be imported
   {
     let test_export_promise = runtime
-      .execute_script_static(
-        "",
-        "import('mod:test').then(module => module.TEST)",
-      )
+      .execute_script("", "import('mod:test').then(module => module.TEST)")
       .unwrap();
     #[allow(deprecated)]
     let test_export =

--- a/core/runtime/tests/mod.rs
+++ b/core/runtime/tests/mod.rs
@@ -88,7 +88,7 @@ fn setup(mode: Mode) -> (JsRuntime, Arc<AtomicUsize>) {
   });
 
   runtime
-    .execute_script_static(
+    .execute_script(
       "setup.js",
       r#"
       function assert(cond) {

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -49,7 +49,7 @@ async fn test_async_opstate_borrow() {
   });
 
   runtime
-    .execute_script_static(
+    .execute_script(
       "op_async_borrow.js",
       "const { op_async_borrow } = Deno.core.ensureFastOps(); op_async_borrow();",
     )
@@ -80,7 +80,7 @@ async fn test_sync_op_serialize_object_with_numbers_as_keys() {
   });
 
   runtime
-    .execute_script_static(
+    .execute_script(
       "op_sync_serialize_object_with_numbers_as_keys.js",
       r#"
 Deno.core.ops.op_sync_serialize_object_with_numbers_as_keys({
@@ -122,7 +122,7 @@ async fn test_async_op_serialize_object_with_numbers_as_keys() {
   });
 
   runtime
-    .execute_script_static(
+    .execute_script(
       "op_async_serialize_object_with_numbers_as_keys.js",
       r#"
         const { op_async_serialize_object_with_numbers_as_keys } = Deno.core.ensureFastOps();
@@ -156,7 +156,7 @@ fn test_op_return_serde_v8_error() {
     ..Default::default()
   });
   assert!(runtime
-    .execute_script_static(
+    .execute_script(
       "test_op_return_serde_v8_error.js",
       "Deno.core.ops.op_err()"
     )
@@ -182,7 +182,7 @@ fn test_op_high_arity() {
     ..Default::default()
   });
   let r = runtime
-    .execute_script_static("test.js", "Deno.core.ops.op_add_4(1, 2, 3, 4)")
+    .execute_script("test.js", "Deno.core.ops.op_add_4(1, 2, 3, 4)")
     .unwrap();
   let scope = &mut runtime.handle_scope();
   assert_eq!(r.open(scope).integer_value(scope), Some(10));
@@ -207,7 +207,7 @@ fn test_op_disabled() {
   });
   // Disabled op should be replaced with a function that throws.
   let err = runtime
-    .execute_script_static("test.js", "Deno.core.ops.op_foo()")
+    .execute_script("test.js", "Deno.core.ops.op_foo()")
     .unwrap_err();
   assert!(err.to_string().contains("op is disabled"));
 }
@@ -234,7 +234,7 @@ fn test_op_detached_buffer() {
   });
 
   runtime
-    .execute_script_static(
+    .execute_script(
       "test.js",
       r#"
       const a1 = new Uint8Array([1,2,3]);
@@ -266,7 +266,7 @@ fn test_op_detached_buffer() {
     .unwrap();
 
   runtime
-    .execute_script_static(
+    .execute_script(
       "test.js",
       r#"
       const wmem = new WebAssembly.Memory({ initial: 1, maximum: 2 });
@@ -349,14 +349,14 @@ fn ops_in_js_have_proper_names() {
     throw new Error();
   }
   "#;
-  runtime.execute_script_static("test", src).unwrap();
+  runtime.execute_script("test", src).unwrap();
 }
 
 #[tokio::test]
 async fn test_ref_unref_ops() {
   let (mut runtime, _dispatch_count) = setup(Mode::AsyncDeferred);
   runtime
-    .execute_script_static(
+    .execute_script(
       "filename.js",
       r#"
       const { op_test } = Deno.core.ensureFastOps();
@@ -371,7 +371,7 @@ async fn test_ref_unref_ops() {
     assert_eq!(realm.num_unrefed_ops(), 0);
   }
   runtime
-    .execute_script_static(
+    .execute_script(
       "filename.js",
       r#"
       Deno.core.unrefOpPromise(p1);
@@ -385,7 +385,7 @@ async fn test_ref_unref_ops() {
     assert_eq!(realm.num_unrefed_ops(), 2);
   }
   runtime
-    .execute_script_static(
+    .execute_script(
       "filename.js",
       r#"
       Deno.core.refOpPromise(p1);
@@ -404,7 +404,7 @@ async fn test_ref_unref_ops() {
 fn test_dispatch() {
   let (mut runtime, dispatch_count) = setup(Mode::Async);
   runtime
-    .execute_script_static(
+    .execute_script(
       "filename.js",
       r#"
       let control = 42;
@@ -424,7 +424,7 @@ fn test_dispatch() {
 fn test_dispatch_no_zero_copy_buf() {
   let (mut runtime, dispatch_count) = setup(Mode::AsyncZeroCopy(false));
   runtime
-    .execute_script_static(
+    .execute_script(
       "filename.js",
       r#"
       const { op_test } = Deno.core.ensureFastOps();
@@ -439,7 +439,7 @@ fn test_dispatch_no_zero_copy_buf() {
 fn test_dispatch_stack_zero_copy_bufs() {
   let (mut runtime, dispatch_count) = setup(Mode::AsyncZeroCopy(true));
   runtime
-    .execute_script_static(
+    .execute_script(
       "filename.js",
       r#"
       const { op_test } = Deno.core.ensureFastOps();
@@ -455,7 +455,7 @@ fn test_dispatch_stack_zero_copy_bufs() {
 fn test_call_site() {
   let (mut runtime, _) = setup(Mode::Async);
   runtime
-    .execute_script_static(
+    .execute_script(
       "file:///filename.js",
       r#"
       const cs = Deno.core.currentUserCallSite();
@@ -634,7 +634,7 @@ pub async fn test_op_metrics() {
   });
 
   let promise = runtime
-  .execute_script_static(
+  .execute_script(
     "filename.js",
     r#"
     const { op_sync, op_sync_error, op_async, op_async_error, op_async_yield, op_async_yield_error, op_async_deferred, op_async_lazy, op_async_impl_future_error, op_sync_arg_error, op_async_arg_error } = Deno.core.ensureFastOps();
@@ -706,7 +706,7 @@ pub async fn test_op_metrics_summary_tracker() {
   });
 
   let promise = runtime
-  .execute_script_static(
+  .execute_script(
     "filename.js",
     r#"
     const { op_sync, op_sync_error, op_async, op_async_error, op_async_yield, op_async_yield_error, op_async_deferred, op_async_lazy, op_async_impl_future_error, op_sync_arg_error, op_async_arg_error } = Deno.core.ensureFastOps();

--- a/core/runtime/tests/snapshot.rs
+++ b/core/runtime/tests/snapshot.rs
@@ -16,7 +16,7 @@ use self::runtime::CreateSnapshotOptions;
 fn will_snapshot() {
   let snapshot = {
     let mut runtime = JsRuntimeForSnapshot::new(Default::default());
-    runtime.execute_script_static("a.js", "a = 1 + 2").unwrap();
+    runtime.execute_script("a.js", "a = 1 + 2").unwrap();
     runtime.snapshot()
   };
 
@@ -26,7 +26,7 @@ fn will_snapshot() {
     ..Default::default()
   });
   runtime2
-    .execute_script_static("check.js", "if (a != 3) throw Error('x')")
+    .execute_script("check.js", "if (a != 3) throw Error('x')")
     .unwrap();
 }
 
@@ -34,9 +34,7 @@ fn will_snapshot() {
 fn will_snapshot2() {
   let startup_data = {
     let mut runtime = JsRuntimeForSnapshot::new(Default::default());
-    runtime
-      .execute_script_static("a.js", "let a = 1 + 2")
-      .unwrap();
+    runtime.execute_script("a.js", "let a = 1 + 2").unwrap();
     runtime.snapshot()
   };
 
@@ -48,9 +46,9 @@ fn will_snapshot2() {
 
   let startup_data = {
     runtime
-      .execute_script_static("check_a.js", "if (a != 3) throw Error('x')")
+      .execute_script("check_a.js", "if (a != 3) throw Error('x')")
       .unwrap();
-    runtime.execute_script_static("b.js", "b = 2 + 3").unwrap();
+    runtime.execute_script("b.js", "b = 2 + 3").unwrap();
     runtime.snapshot()
   };
 
@@ -61,10 +59,10 @@ fn will_snapshot2() {
       ..Default::default()
     });
     runtime
-      .execute_script_static("check_b.js", "if (b != 5) throw Error('x')")
+      .execute_script("check_b.js", "if (b != 5) throw Error('x')")
       .unwrap();
     runtime
-      .execute_script_static("check2.js", "if (!Deno.core) throw Error('x')")
+      .execute_script("check2.js", "if (!Deno.core) throw Error('x')")
       .unwrap();
   }
 }
@@ -74,7 +72,7 @@ fn test_snapshot_callbacks() {
   let snapshot = {
     let mut runtime = JsRuntimeForSnapshot::new(Default::default());
     runtime
-      .execute_script_static(
+      .execute_script(
         "a.js",
         r#"
         Deno.core.setMacrotaskCallback(() => {
@@ -99,7 +97,7 @@ fn test_snapshot_callbacks() {
     ..Default::default()
   });
   runtime2
-    .execute_script_static("check.js", "if (a != 3) throw Error('x')")
+    .execute_script("check.js", "if (a != 3) throw Error('x')")
     .unwrap();
 }
 
@@ -107,7 +105,7 @@ fn test_snapshot_callbacks() {
 fn test_from_snapshot() {
   let snapshot = {
     let mut runtime = JsRuntimeForSnapshot::new(Default::default());
-    runtime.execute_script_static("a.js", "a = 1 + 2").unwrap();
+    runtime.execute_script("a.js", "a = 1 + 2").unwrap();
     runtime.snapshot()
   };
 
@@ -117,7 +115,7 @@ fn test_from_snapshot() {
     ..Default::default()
   });
   runtime2
-    .execute_script_static("check.js", "if (a != 3) throw Error('x')")
+    .execute_script("check.js", "if (a != 3) throw Error('x')")
     .unwrap();
 }
 
@@ -131,7 +129,7 @@ fn test_snapshot_creator() {
       skip_op_registration: false,
       extensions: vec![],
       with_runtime_cb: Some(Box::new(|runtime| {
-        runtime.execute_script_static("a.js", "a = 1 + 2").unwrap();
+        runtime.execute_script("a.js", "a = 1 + 2").unwrap();
       })),
     },
     None,
@@ -145,7 +143,7 @@ fn test_snapshot_creator() {
     ..Default::default()
   });
   runtime2
-    .execute_script_static("check.js", "if (a != 3) throw Error('x')")
+    .execute_script("check.js", "if (a != 3) throw Error('x')")
     .unwrap();
 }
 
@@ -163,7 +161,7 @@ fn test_snapshot_creator_warmup() {
       with_runtime_cb: Some(Box::new(move |runtime| {
         c.replace_with(|&mut c| c + 1);
 
-        runtime.execute_script_static("a.js", "a = 1 + 2").unwrap();
+        runtime.execute_script("a.js", "a = 1 + 2").unwrap();
       })),
     },
     Some("const b = 'Hello'"),
@@ -181,7 +179,7 @@ fn test_snapshot_creator_warmup() {
     ..Default::default()
   });
   runtime2
-    .execute_script_static("check.js", "if (a != 3) throw Error('x')")
+    .execute_script("check.js", "if (a != 3) throw Error('x')")
     .unwrap();
 }
 
@@ -312,7 +310,7 @@ fn es_snapshot() {
     const mod = await import("file:///400.js");
     return mod.f400() + " " + Deno.core.ops.op_test();
   })();"#;
-  let val = runtime3.execute_script_static(".", source_code).unwrap();
+  let val = runtime3.execute_script(".", source_code).unwrap();
   #[allow(deprecated)]
   let val = futures::executor::block_on(runtime3.resolve_value(val)).unwrap();
   {
@@ -363,7 +361,7 @@ pub(crate) fn es_snapshot_without_runtime_module_loader() {
 
   // Dynamic imports of ext: from non-ext: modules are not allowed.
   let dyn_import_promise = realm
-    .execute_script_static(
+    .execute_script(
       runtime.v8_isolate(),
       "",
       "import('ext:module_snapshot/test.js')",
@@ -379,7 +377,7 @@ pub(crate) fn es_snapshot_without_runtime_module_loader() {
 
   // But not a new one
   let dyn_import_promise = realm
-    .execute_script_static(
+    .execute_script(
       runtime.v8_isolate(),
       "",
       "import('ext:module_snapshot/test2.js')",


### PR DESCRIPTION
Split out from #620 

We can simplify this embedder-facing API by using a single overload. This reduces the noise of the other PR significantly.