### PR TITLE
feat: support for v8 code cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2497,9 +2497,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.85.0"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8e09551fa5c3500b47f08912b4a39e07ae20a3874051941408fbd52e3e5190"
+checksum = "0d30d72faeef07020ec4428dbfa2909801e5e36becf650c1b49c92b70f6771d8"
 dependencies = [
  "bitflags 2.4.2",
  "fslock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ deno_core = { version = "0.270.0", path = "./core" }
 deno_ops = { version = "0.146.0", path = "./ops" }
 serde_v8 = { version = "0.179.0", path = "./serde_v8" }
 
-v8 = { version = "0.85.0", default-features = false }
+v8 = { version = "0.86.0", default-features = false }
 deno_ast = { version = "=0.32.0", features = ["transpiling"] }
 deno_unsync = "0.3.2"
 deno_core_icudata = "0.0.73"

--- a/core/examples/ts_module_loader.rs
+++ b/core/examples/ts_module_loader.rs
@@ -123,6 +123,7 @@ impl ModuleLoader for TypescriptModuleLoader {
         module_type,
         ModuleSourceCode::String(code.into()),
         module_specifier,
+        None,
       ))
     }
 

--- a/core/modules/loaders.rs
+++ b/core/modules/loaders.rs
@@ -87,12 +87,12 @@ pub trait ModuleLoader {
   /// can store the provided code cache for future executions of the same module.
   ///
   /// It's not required to implement this method.
-  fn store_code_cache(
+  fn code_cache_ready(
     &self,
     _module_specifier: &ModuleSpecifier,
     _code_cache: &[u8],
-  ) -> Result<(), Error> {
-    Ok(())
+  ) -> Pin<Box<dyn Future<Output = ()>>> {
+    async {}.boxed_local()
   }
 }
 

--- a/core/modules/loaders.rs
+++ b/core/modules/loaders.rs
@@ -82,6 +82,18 @@ pub trait ModuleLoader {
   ) -> Pin<Box<dyn Future<Output = Result<(), Error>>>> {
     async { Ok(()) }.boxed_local()
   }
+
+  /// Called when new v8 code cache is available for this module. Implementors
+  /// can store the provided code cache for future executions of the same module.
+  ///
+  /// It's not required to implement this method.
+  fn store_code_cache(
+    &self,
+    _module_specifier: &ModuleSpecifier,
+    _code_cache: &[u8],
+  ) -> Result<(), Error> {
+    Ok(())
+  }
 }
 
 /// Placeholder structure used when creating
@@ -186,6 +198,7 @@ impl ModuleLoader for ExtModuleLoader {
       ModuleType::JavaScript,
       ModuleSourceCode::String(source),
       specifier,
+      None,
     )))
   }
 
@@ -240,6 +253,7 @@ impl ModuleLoader for LazyEsmModuleLoader {
       ModuleType::JavaScript,
       ModuleSourceCode::String(source),
       specifier,
+      None,
     )))
   }
 
@@ -316,6 +330,7 @@ impl ModuleLoader for FsModuleLoader {
         module_type,
         ModuleSourceCode::Bytes(code.into_boxed_slice().into()),
         &module_specifier,
+        None,
       );
       Ok(module)
     }
@@ -377,6 +392,7 @@ impl ModuleLoader for StaticModuleLoader {
         ModuleType::JavaScript,
         ModuleSourceCode::String(code.try_clone().unwrap()),
         module_specifier,
+        None,
       ))
     } else {
       Err(generic_error("Module not found"))

--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -205,8 +205,7 @@ pub type CustomModuleEvaluationCb = Box<
 pub type EvalContextGetCodeCacheCb =
   Box<dyn Fn(&str) -> Result<Option<Cow<'static, [u8]>>, AnyError>>;
 
-pub type EvalContextStoreCodeCacheCb =
-  Box<dyn Fn(&str, &[u8]) -> Result<(), AnyError>>;
+pub type EvalContextCodeCacheReadyCb = Box<dyn Fn(&str, &[u8])>;
 
 pub enum CustomModuleEvaluationKind {
   /// This evaluation results in a single, "synthetic" module.

--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -202,6 +202,12 @@ pub type CustomModuleEvaluationCb = Box<
   ) -> Result<CustomModuleEvaluationKind, AnyError>,
 >;
 
+pub type EvalContextGetCodeCacheCb =
+  Box<dyn Fn(&str) -> Result<Option<Cow<'static, [u8]>>, AnyError>>;
+
+pub type EvalContextStoreCodeCacheCb =
+  Box<dyn Fn(&str, &[u8]) -> Result<(), AnyError>>;
+
 pub enum CustomModuleEvaluationKind {
   /// This evaluation results in a single, "synthetic" module.
   Synthetic(v8::Global<v8::Value>),
@@ -353,6 +359,7 @@ impl ModuleType {
 pub struct ModuleSource {
   pub code: ModuleSourceCode,
   pub module_type: ModuleType,
+  pub code_cache: Option<Cow<'static, [u8]>>,
   module_url_specified: ModuleName,
   /// If the module was found somewhere other than the specified address, this will be [`Some`].
   module_url_found: Option<ModuleName>,
@@ -364,11 +371,13 @@ impl ModuleSource {
     module_type: impl Into<ModuleType>,
     code: ModuleSourceCode,
     specifier: &ModuleSpecifier,
+    code_cache: Option<Cow<'static, [u8]>>,
   ) -> Self {
     let module_url_specified = specifier.as_ref().to_owned().into();
     Self {
       code,
       module_type: module_type.into(),
+      code_cache,
       module_url_specified,
       module_url_found: None,
     }
@@ -381,6 +390,7 @@ impl ModuleSource {
     code: ModuleSourceCode,
     specifier: &ModuleSpecifier,
     specifier_found: &ModuleSpecifier,
+    code_cache: Option<Cow<'static, [u8]>>,
   ) -> Self {
     let module_url_found = if specifier == specifier_found {
       None
@@ -391,6 +401,7 @@ impl ModuleSource {
     Self {
       code,
       module_type: module_type.into(),
+      code_cache,
       module_url_specified,
       module_url_found,
     }
@@ -401,6 +412,7 @@ impl ModuleSource {
     Self {
       code: ModuleSourceCode::String(code.into_module_code()),
       module_type: ModuleType::JavaScript,
+      code_cache: None,
       module_url_specified: file.as_ref().to_owned().into(),
       module_url_found: None,
     }
@@ -412,6 +424,7 @@ impl ModuleSource {
     code: &'static str,
     specified: impl AsRef<str>,
     found: impl AsRef<str>,
+    code_cache: Option<Cow<'static, [u8]>>,
   ) -> Self {
     let specified = specified.as_ref().to_string();
     let found = found.as_ref().to_string();
@@ -423,6 +436,7 @@ impl ModuleSource {
     Self {
       code: ModuleSourceCode::String(code.into_module_code()),
       module_type: ModuleType::JavaScript,
+      code_cache,
       module_url_specified: specified.into(),
       module_url_found: found,
     }

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -270,15 +270,15 @@ impl ModuleLoader for MockLoader {
     )
   }
 
-  fn store_code_cache(
+  fn code_cache_ready(
     &self,
     module_specifier: &ModuleSpecifier,
     code_cache: &[u8],
-  ) -> Result<(), Error> {
+  ) -> Pin<Box<dyn Future<Output = ()>>> {
     let mut updated_code_cache = self.updated_code_cache.lock();
     updated_code_cache
       .insert(module_specifier.to_string(), code_cache.to_vec());
-    Ok(())
+    async {}.boxed_local()
   }
 }
 

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -245,14 +245,43 @@ pub fn op_eval_context<'a>(
   source: v8::Local<'a, v8::Value>,
   #[string] specifier: String,
 ) -> Result<EvalContextResult<'a>, Error> {
+  let state = JsRuntime::state_from(scope);
   let tc_scope = &mut v8::TryCatch::new(scope);
   let source = v8::Local::<v8::String>::try_from(source)
     .map_err(|_| type_error("Invalid source"))?;
   let specifier = resolve_url(&specifier)?.to_string();
-  let specifier = v8::String::new(tc_scope, &specifier).unwrap();
-  let origin = script_origin(tc_scope, specifier);
+  let specifier_v8 = v8::String::new(tc_scope, &specifier).unwrap();
+  let origin = script_origin(tc_scope, specifier_v8);
 
-  let script = match v8::Script::compile(tc_scope, source, Some(&origin)) {
+  let (script, try_store_code_cache) = state
+    .eval_context_get_code_cache_cb
+    .as_ref()
+    .and_then(|cb| {
+      cb(&specifier).unwrap().map(|code_cache| {
+        let mut source = v8::script_compiler::Source::new_with_cached_data(
+          source,
+          Some(&origin),
+          v8::CachedData::new(&code_cache),
+        );
+        let script = v8::script_compiler::compile(
+          tc_scope,
+          &mut source,
+          v8::script_compiler::CompileOptions::ConsumeCodeCache,
+          v8::script_compiler::NoCacheReason::NoReason,
+        );
+        // Check if the provided code cache is rejected by V8.
+        let rejected = match source.get_cached_data() {
+          Some(cached_data) => cached_data.rejected(),
+          _ => true,
+        };
+        (script, rejected)
+      })
+    })
+    .unwrap_or_else(|| {
+      (v8::Script::compile(tc_scope, source, Some(&origin)), true)
+    });
+
+  let script = match script {
     Some(s) => s,
     None => {
       assert!(tc_scope.has_caught());
@@ -267,6 +296,20 @@ pub fn op_eval_context<'a>(
       ));
     }
   };
+
+  if try_store_code_cache {
+    if let Some(eval_context_set_code_cache_cb) =
+      state.eval_context_set_code_cache_cb.as_ref()
+    {
+      let unbound_script = script.get_unbound_script(tc_scope);
+      let code_cache = unbound_script.create_code_cache().ok_or_else(|| {
+        type_error("Unable to get code cache from unbound module script")
+      })?;
+      eval_context_set_code_cache_cb(&specifier, &code_cache).map_err(
+        |_| type_error("Unable to store code cache from unbound module script"),
+      )?;
+    }
+  }
 
   match script.run(tc_scope) {
     Some(result) => Ok(EvalContextResult(Some(result.into()), None)),

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -298,16 +298,12 @@ pub fn op_eval_context<'a>(
   };
 
   if try_store_code_cache {
-    if let Some(eval_context_set_code_cache_cb) =
-      state.eval_context_set_code_cache_cb.as_ref()
-    {
+    if let Some(cb) = state.eval_context_code_cache_ready_cb.as_ref() {
       let unbound_script = script.get_unbound_script(tc_scope);
       let code_cache = unbound_script.create_code_cache().ok_or_else(|| {
         type_error("Unable to get code cache from unbound module script")
       })?;
-      eval_context_set_code_cache_cb(&specifier, &code_cache).map_err(
-        |_| type_error("Unable to store code cache from unbound module script"),
-      )?;
+      cb(&specifier, &code_cache);
     }
   }
 

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -349,7 +349,7 @@ impl JsRealm {
       let scope = &mut self.handle_scope(isolate);
       // true for main module
       module_map_rc
-        .new_es_module(scope, true, specifier.to_owned(), code, false)
+        .new_es_module(scope, true, specifier.to_owned(), code, false, None)
         .map_err(|e| e.into_any_error(scope, false, false))?;
     }
 
@@ -395,7 +395,7 @@ impl JsRealm {
       let scope = &mut self.handle_scope(isolate);
       // false for side module (not main module)
       module_map_rc
-        .new_es_module(scope, false, specifier, code, false)
+        .new_es_module(scope, false, specifier, code, false, None)
         .map_err(|e| e.into_any_error(scope, false, false))?;
     }
 
@@ -438,6 +438,7 @@ impl JsRealm {
       scope,
       module_specifier.as_str(),
       code,
+      None,
     )
   }
 }

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -26,8 +26,8 @@ use crate::inspector::JsRuntimeInspector;
 use crate::module_specifier::ModuleSpecifier;
 use crate::modules::default_import_meta_resolve_cb;
 use crate::modules::CustomModuleEvaluationCb;
+use crate::modules::EvalContextCodeCacheReadyCb;
 use crate::modules::EvalContextGetCodeCacheCb;
-use crate::modules::EvalContextStoreCodeCacheCb;
 use crate::modules::ExtModuleLoader;
 use crate::modules::ImportMetaResolveCallback;
 use crate::modules::IntoModuleCodeString;
@@ -415,8 +415,8 @@ pub struct JsRuntimeState {
   pub(crate) validate_import_attributes_cb: Option<ValidateImportAttributesCb>,
   pub(crate) custom_module_evaluation_cb: Option<CustomModuleEvaluationCb>,
   pub(crate) eval_context_get_code_cache_cb: Option<EvalContextGetCodeCacheCb>,
-  pub(crate) eval_context_set_code_cache_cb:
-    Option<EvalContextStoreCodeCacheCb>,
+  pub(crate) eval_context_code_cache_ready_cb:
+    Option<EvalContextCodeCacheReadyCb>,
   waker: Arc<AtomicWaker>,
   /// Accessed through [`JsRuntimeState::with_inspector`].
   inspector: RefCell<Option<Rc<RefCell<JsRuntimeInspector>>>>,
@@ -540,7 +540,7 @@ pub struct RuntimeOptions {
   /// Callbacks to retrieve and store code cache for scripts evaluated
   /// through evalContext.
   pub eval_context_code_cache_cbs:
-    Option<(EvalContextGetCodeCacheCb, EvalContextStoreCodeCacheCb)>,
+    Option<(EvalContextGetCodeCacheCb, EvalContextCodeCacheReadyCb)>,
 }
 
 impl RuntimeOptions {
@@ -689,7 +689,7 @@ impl JsRuntime {
       validate_import_attributes_cb: options.validate_import_attributes_cb,
       custom_module_evaluation_cb: options.custom_module_evaluation_cb,
       eval_context_get_code_cache_cb,
-      eval_context_set_code_cache_cb,
+      eval_context_code_cache_ready_cb: eval_context_set_code_cache_cb,
       waker,
       // Some fields are initialized later after isolate is created
       inspector: None.into(),

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -533,8 +533,8 @@ pub struct RuntimeOptions {
   pub custom_module_evaluation_cb: Option<CustomModuleEvaluationCb>,
 
   // Controls whether V8 code cache is enabled. Code cache can be applied
-  // to ES modules (loaded through ModuleLoader) and to scripts evaluated
-  // through evalContext.
+  // to ES modules (loaded through `ModuleLoader`) and to scripts evaluated
+  // through `Deno.core.evalContext`.
   pub enable_code_cache: bool,
 
   /// Callbacks to retrieve and store code cache for scripts evaluated

--- a/core/runtime/tests/misc.rs
+++ b/core/runtime/tests/misc.rs
@@ -1323,7 +1323,6 @@ fn eval_context_with_code_cache() {
       Box::new(move |specifier: &str, code_cache: &[u8]| {
         let mut c = updated_code_cache_clone.lock();
         c.insert(specifier.to_string(), code_cache.to_vec());
-        Ok(())
       });
 
     let mut runtime = JsRuntime::new(RuntimeOptions {
@@ -1363,7 +1362,6 @@ fn eval_context_with_code_cache() {
       Box::new(move |specifier: &str, code_cache: &[u8]| {
         let mut c = updated_code_cache_clone.lock();
         c.insert(specifier.to_string(), code_cache.to_vec());
-        Ok(())
       });
 
     let mut runtime = JsRuntime::new(RuntimeOptions {

--- a/testing/checkin/runner/ts_module_loader.rs
+++ b/testing/checkin/runner/ts_module_loader.rs
@@ -124,6 +124,7 @@ impl ModuleLoader for TypescriptModuleLoader {
         module_type,
         ModuleSourceCode::String(code.into()),
         module_specifier,
+        None,
       ))
     }
 


### PR DESCRIPTION
This PR adds V8 code cache support for ES modules loaded through `ModuleLoader`, and for scripts evaluated through `evalContext` (used by `require` in Deno). Embedders have full control over whether code caching is enabled, and how code cache is retrieved/stored.