### PR TITLE
Allow relative imports in extension JS/TS code

### DIFF
--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -1849,3 +1849,23 @@ fn test_load_with_code_cache() {
     assert_eq!(keys, vec!["file:///a.js", "file:///b.js",]);
   }
 }
+
+#[test]
+fn ext_module_loader_relative() {
+  let loader = ExtModuleLoader::new(vec![]).unwrap();
+  let cases = [
+    (
+      ("../../foo.js", "ext:test/nested/mod/bar.js"),
+      "ext:test/foo.js",
+    ),
+    (("./foo.js", "ext:test/bar.js"), "ext:test/foo.js"),
+    ((".././foo.js", "ext:test/bar.js"), "ext:foo.js"),
+    (("./foo.js", "ext:bar.js"), "ext:foo.js"),
+  ];
+  for ((specifier, referrer), expected) in cases {
+    let result = loader
+      .resolve(specifier, referrer, ResolutionKind::Import)
+      .unwrap();
+    assert_eq!(result.as_str(), expected);
+  }
+}

--- a/testing/checkin/runtime/__init.js
+++ b/testing/checkin/runtime/__init.js
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import "ext:checkin_runtime/__bootstrap.js";
+import "./__bootstrap.js";
 import * as async from "checkin:async";
 import * as testing from "checkin:testing";
 import * as console from "checkin:console";


### PR DESCRIPTION
Before

```ts
// In `ext/node/polyfills/foo.ts`
import * as errors from "ext:deno_node/internal/errors.ts";
```

Now

```ts
// In `ext/node/polyfills/foo.ts`
import * as errors from "./internal/errors.ts";
```

It's pretty ugly because the `url` crate restricts you from directly modifying "bases" or "hosts" of URLs that aren't valid bases, but this avoids having to reimplement a worse version of `Url::join`