### PR TITLE
refactor: Remove Deno.core.ensureFastOps

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -13,7 +13,6 @@
     ObjectFromEntries,
     ObjectKeys,
     ObjectHasOwn,
-    Proxy,
     setQueueMicrotask,
     SafeMap,
     Set,
@@ -55,7 +54,6 @@
     op_lazy_load_esm,
     op_memory_usage,
     op_op_names,
-    op_panic,
     op_print,
     op_queue_microtask,
     op_ref_op,
@@ -109,7 +107,7 @@
     op_is_typed_array,
     op_is_weak_map,
     op_is_weak_set,
-  } = ensureFastOps();
+  } = ops;
 
   // core/infra collaborative code
   delete window.__infra;
@@ -402,21 +400,6 @@
     );
   }
 
-  function ensureFastOps(keep = false) {
-    return new Proxy({}, {
-      get(_target, opName) {
-        const op = ops[opName];
-        if (ops[opName] === undefined) {
-          op_panic(`Unknown or disabled op '${opName}'`);
-        }
-        if (keep !== true) {
-          delete ops[opName];
-        }
-        return op;
-      },
-    });
-  }
-
   const {
     op_close: close,
     op_try_close: tryClose,
@@ -429,7 +412,7 @@
     op_write_sync: writeSync,
     op_shutdown: shutdown,
     op_is_terminal: isTerminal,
-  } = ensureFastOps(true);
+  } = ops;
 
   const callSiteRetBuf = new Uint32Array(2);
   const callSiteRetBufU8 = new Uint8Array(callSiteRetBuf.buffer);
@@ -619,7 +602,6 @@
   // Extra Deno.core.* exports
   const core = ObjectAssign(globalThis.Deno.core, {
     internalRidSymbol: Symbol("Deno.internal.rid"),
-    ensureFastOps,
     resources,
     metrics,
     eventLoopTick,

--- a/core/benches/ops/async_harness.js
+++ b/core/benches/ops/async_harness.js
@@ -9,8 +9,8 @@ async function run() {
   const LARGE_STRING_UTF8_1000 = "\u1000".repeat(1000);
   const BUFFER = new Uint8Array(1024);
   const ARRAYBUFFER = new ArrayBuffer(1024);
-  const { __OP__: op } = Deno.core.ensureFastOps();
-  const { op_make_external } = Deno.core.ensureFastOps();
+  const { __OP__: op } = Deno.core.ops;
+  const { op_make_external } = Deno.core.ops;
   const EXTERNAL = op_make_external();
 
   // TODO(mmastrac): Because of current v8 limitations, these ops are not always fast unless we do this.

--- a/core/benches/ops/sync_harness.js
+++ b/core/benches/ops/sync_harness.js
@@ -8,8 +8,8 @@ const LARGE_STRING_UTF8_1000000 = "\u1000".repeat(1000000);
 const LARGE_STRING_UTF8_1000 = "\u1000".repeat(1000);
 const BUFFER = new Uint8Array(1024);
 const ARRAYBUFFER = new ArrayBuffer(1024);
-const { __OP__: op } = Deno.core.ensureFastOps();
-const { op_make_external } = Deno.core.ensureFastOps();
+const { __OP__: op } = Deno.core.ops;
+const { op_make_external } = Deno.core.ops;
 const EXTERNAL = op_make_external();
 
 // TODO(mmastrac): Because of current v8 limitations, these ops are not always fast unless we do this.

--- a/core/lib.deno_core.d.ts
+++ b/core/lib.deno_core.d.ts
@@ -7,9 +7,6 @@
 
 declare namespace Deno {
   namespace core {
-    /** Returns a proxy that generates the fast versions of sync and async ops. */
-    function ensureFastOps(keep?: boolean): any;
-
     /** Mark following promise as "ref", ie. event loop won't exit
      * until all "ref" promises are resolved. All async ops are "ref" by default. */
     function refOpPromise<T>(promise: Promise<T>): void;

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -658,8 +658,9 @@ mod tests {
     runtime
       .execute_script(
         "",
-        format!(r"
-          const {{ op_test_fail, op_test_print_debug, {op} }} = Deno.core.ensureFastOps();
+        format!(
+          r"
+          const {{ op_test_fail, op_test_print_debug, {op} }} = Deno.core.ops;
           function assert(b) {{
             if (!b) {{
               op_test_fail();
@@ -671,7 +672,8 @@ mod tests {
           function log(s) {{
             op_test_print_debug(String(s))
           }}
-        ")
+        "
+        ),
       )
       .map_err(err_mapper)?;
     FAIL.with(|b| b.set(false));
@@ -707,8 +709,9 @@ mod tests {
     runtime
       .execute_script(
         "",
-        format!(r"
-          const {{ op_test_fail, op_test_print_debug, {op} }} = Deno.core.ensureFastOps();
+        format!(
+          r"
+          const {{ op_test_fail, op_test_print_debug, {op} }} = Deno.core.ops;
           function assert(b) {{
             if (!b) {{
               op_test_fail();
@@ -720,7 +723,8 @@ mod tests {
           function log(s) {{
             op_test_print_debug(String(s))
           }}
-        ")
+        "
+        ),
       )
       .map_err(err_mapper)?;
     FAIL.with(|b| b.set(false));

--- a/core/runtime/tests/jsrealm.rs
+++ b/core/runtime/tests/jsrealm.rs
@@ -94,7 +94,7 @@ async fn js_realm_ref_unref_ops() {
         runtime.v8_isolate(),
         "",
         r#"
-        const { op_pending } = Deno.core.ensureFastOps();
+        const { op_pending } = Deno.core.ops;
         var promise = op_pending();
         "#,
       )

--- a/core/runtime/tests/misc.rs
+++ b/core/runtime/tests/misc.rs
@@ -121,7 +121,7 @@ async fn test_wakers_for_async_ops() {
     .execute_script(
       "",
       ascii_str!(
-        "const { op_async_sleep } = Deno.core.ensureFastOps(); (async () => { await op_async_sleep(); })()"
+        "const { op_async_sleep } = Deno.core.ops; (async () => { await op_async_sleep(); })()"
       ),
     )
     .unwrap();
@@ -660,7 +660,7 @@ async fn test_set_macrotask_callback_set_next_tick_callback() {
     .execute_script(
       "macrotasks_and_nextticks.js",
       r#"
-      const { op_async_sleep } = Deno.core.ensureFastOps();
+      const { op_async_sleep } = Deno.core.ops;
       (async function () {
         const results = [];
         Deno.core.setMacrotaskCallback(() => {
@@ -824,7 +824,7 @@ async fn test_promise_rejection_handler_generic(
     function throwError() {
       throw new Error("boom");
     }
-    const { op_void_async, op_void_async_deferred } = Deno.core.ensureFastOps();
+    const { op_void_async, op_void_async_deferred } = Deno.core.ops;
     if (test != "no_handler") {
       Deno.core.setUnhandledPromiseRejectionHandler((promise, rejection) => {
         if (test.startsWith("exception_")) {
@@ -970,11 +970,11 @@ async fn test_dynamic_import_module_error_stack() {
   let loader = StaticModuleLoader::new([
     (
       Url::parse("file:///main.js").unwrap(),
-      "await import(\"file:///import.js\");"
+      "await import(\"file:///import.js\");",
     ),
     (
       Url::parse("file:///import.js").unwrap(),
-      "const { op_async_error } = Deno.core.ensureFastOps(); await op_async_error();",
+      "const { op_async_error } = Deno.core.ops; await op_async_error();",
     ),
   ]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
@@ -998,7 +998,7 @@ async fn test_dynamic_import_module_error_stack() {
   assert_eq!(
     js_error.to_string(),
     "Error: foo
-    at async file:///import.js:1:55"
+    at async file:///import.js:1:43"
   );
 }
 
@@ -1024,7 +1024,7 @@ async fn tla_in_esm_extensions_panics() {
       "mod:test" = { source = "import 'mod:tla';" },
       "mod:tla" = {
         source = r#"
-          const { op_wait } = Deno.core.ensureFastOps();
+          const { op_wait } = Deno.core.ops;
           await op_wait(0);
           export const TEST = "foo";
       "#
@@ -1195,7 +1195,7 @@ async fn terminate_execution_run_event_loop_js() {
     .execute_script(
       "sleep_code.js",
       r#"
-              const { op_async_sleep } = Deno.core.ensureFastOps(); 
+              const { op_async_sleep } = Deno.core.ops; 
               async function sleep() {
                 await op_async_sleep();
               }

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -51,7 +51,7 @@ async fn test_async_opstate_borrow() {
   runtime
     .execute_script(
       "op_async_borrow.js",
-      "const { op_async_borrow } = Deno.core.ensureFastOps(); op_async_borrow();",
+      "const { op_async_borrow } = Deno.core.ops; op_async_borrow();",
     )
     .unwrap();
   runtime.run_event_loop(Default::default()).await.unwrap();
@@ -125,7 +125,7 @@ async fn test_async_op_serialize_object_with_numbers_as_keys() {
     .execute_script(
       "op_async_serialize_object_with_numbers_as_keys.js",
       r#"
-        const { op_async_serialize_object_with_numbers_as_keys } = Deno.core.ensureFastOps();
+        const { op_async_serialize_object_with_numbers_as_keys } = Deno.core.ops;
         op_async_serialize_object_with_numbers_as_keys({
           lines: {
             100: {
@@ -344,7 +344,7 @@ fn ops_in_js_have_proper_names() {
     throw new Error();
   }
 
-  const { op_test_async } = Deno.core.ensureFastOps();
+  const { op_test_async } = Deno.core.ops;
   if (op_test_async.name !== "op_test_async") {
     throw new Error();
   }
@@ -359,7 +359,7 @@ async fn test_ref_unref_ops() {
     .execute_script(
       "filename.js",
       r#"
-      const { op_test } = Deno.core.ensureFastOps();
+      const { op_test } = Deno.core.ops;
       var p1 = op_test(42);
       var p2 = op_test(42);
       "#,
@@ -408,7 +408,7 @@ fn test_dispatch() {
       "filename.js",
       r#"
       let control = 42;
-      const { op_test } = Deno.core.ensureFastOps();
+      const { op_test } = Deno.core.ops;
       op_test(control);
       async function main() {
         op_test(control);
@@ -427,7 +427,7 @@ fn test_dispatch_no_zero_copy_buf() {
     .execute_script(
       "filename.js",
       r#"
-      const { op_test } = Deno.core.ensureFastOps();
+      const { op_test } = Deno.core.ops;
       op_test(0);
       "#,
     )
@@ -442,7 +442,7 @@ fn test_dispatch_stack_zero_copy_bufs() {
     .execute_script(
       "filename.js",
       r#"
-      const { op_test } = Deno.core.ensureFastOps();
+      const { op_test } = Deno.core.ops;
       let zero_copy_a = new Uint8Array([0]);
       op_test(0, zero_copy_a);
       "#,
@@ -483,7 +483,7 @@ pub async fn test_top_level_await() {
     (
       Url::parse("http://x/main.js").unwrap(),
       r#"
-const { op_sleep_forever } = Deno.core.ensureFastOps();
+const { op_sleep_forever } = Deno.core.ops;
 (async () => await op_sleep_forever())();
 await import('./mod.js');
     "#,
@@ -491,7 +491,7 @@ await import('./mod.js');
     (
       Url::parse("http://x/mod.js").unwrap(),
       r#"
-const { op_void_async_deferred } = Deno.core.ensureFastOps();
+const { op_void_async_deferred } = Deno.core.ops;
 await op_void_async_deferred();
     "#,
     ),
@@ -633,7 +633,7 @@ pub async fn test_op_metrics() {
   .execute_script(
     "filename.js",
     r#"
-    const { op_sync, op_sync_error, op_async, op_async_error, op_async_yield, op_async_yield_error, op_async_deferred, op_async_lazy, op_async_impl_future_error, op_sync_arg_error, op_async_arg_error } = Deno.core.ensureFastOps();
+    const { op_sync, op_sync_error, op_async, op_async_error, op_async_yield, op_async_yield_error, op_async_deferred, op_async_lazy, op_async_impl_future_error, op_sync_arg_error, op_async_arg_error } = Deno.core.ops;
     async function go() {
       op_sync();
       try { op_sync_error(); } catch {}
@@ -705,7 +705,7 @@ pub async fn test_op_metrics_summary_tracker() {
   .execute_script(
     "filename.js",
     r#"
-    const { op_sync, op_sync_error, op_async, op_async_error, op_async_yield, op_async_yield_error, op_async_deferred, op_async_lazy, op_async_impl_future_error, op_sync_arg_error, op_async_arg_error } = Deno.core.ensureFastOps();
+    const { op_sync, op_sync_error, op_async, op_async_error, op_async_yield, op_async_yield_error, op_async_deferred, op_async_lazy, op_async_impl_future_error, op_sync_arg_error, op_async_arg_error } = Deno.core.ops;
     async function go() {
       op_sync();
       try { op_sync_error(); } catch {}

--- a/testing/checkin/runtime/async.ts
+++ b/testing/checkin/runtime/async.ts
@@ -10,7 +10,7 @@ const {
   op_stats_delete,
 } = Deno
   .core
-  .ensureFastOps();
+  .ops;
 
 export function barrierCreate(name: string, count: number) {
   op_async_barrier_create(name, count);

--- a/testing/unit/ops_buffer_test.ts
+++ b/testing/unit/ops_buffer_test.ts
@@ -3,7 +3,7 @@ import { assertArrayEquals, test } from "checkin:testing";
 const {
   op_v8slice_store,
   op_v8slice_clone,
-} = Deno.core.ensureFastOps(true);
+} = Deno.core.ops;
 
 // Cloning a buffer should result in the same buffer being returned
 test(function testBufferStore() {

--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assert, assertArrayEquals, assertEquals, test } from "checkin:testing";
 
-const { op_pipe_create, op_file_open } = Deno.core.ensureFastOps();
+const { op_pipe_create, op_file_open } = Deno.core.ops;
 
 test(async function testPipe() {
   const [p1, p2] = op_pipe_create();

--- a/testing/unit/stats_test.ts
+++ b/testing/unit/stats_test.ts
@@ -12,7 +12,7 @@ import {
   test,
 } from "checkin:testing";
 
-const { op_pipe_create } = Deno.core.ensureFastOps();
+const { op_pipe_create } = Deno.core.ops;
 
 test(async function testStatsOps() {
   using statsBefore = StatsFactory.capture();


### PR DESCRIPTION
Instead embedders should tear off appropriate ops
directly from `Deno.core.ops` object.

This API just added another layer of indirection for no obvious
reason.

Ref https://github.com/denoland/deno_core/issues/521