### PR TITLE
feat(op2): Allow attaching static metadata to ops in #[op2]

### DIFF
--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 use crate::modules::IntoModuleCodeString;
 use crate::modules::ModuleCodeString;
+use crate::ops::OpMetadata;
 use crate::runtime::bindings;
 use crate::FastStaticString;
 use crate::OpState;
@@ -182,6 +183,8 @@ pub struct OpDecl {
   pub(crate) fast_fn: Option<FastFunction>,
   /// The fast dispatch call with metrics enabled. If metrics are enabled, the `v8::Function`'s fastcall is created with this callback.
   pub(crate) fast_fn_with_metrics: Option<FastFunction>,
+  /// Any metadata associated with this op.
+  pub metadata: OpMetadata,
 }
 
 impl OpDecl {
@@ -197,6 +200,7 @@ impl OpDecl {
     slow_fn_with_metrics: OpFnRef,
     fast_fn: Option<FastFunction>,
     fast_fn_with_metrics: Option<FastFunction>,
+    metadata: OpMetadata,
   ) -> Self {
     #[allow(deprecated)]
     Self {
@@ -209,6 +213,7 @@ impl OpDecl {
       slow_fn_with_metrics,
       fast_fn,
       fast_fn_with_metrics,
+      metadata,
     }
   }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -118,6 +118,7 @@ pub use crate::modules::StaticModuleLoader;
 pub use crate::modules::ValidateImportAttributesCb;
 pub use crate::normalize_path::normalize_path;
 pub use crate::ops::OpId;
+pub use crate::ops::OpMetadata;
 pub use crate::ops::OpState;
 pub use crate::ops::PromiseId;
 pub use crate::ops_builtin::op_close;

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -55,6 +55,23 @@ pub fn reentrancy_check(decl: &'static OpDecl) -> Option<ReentrancyGuard> {
   Some(ReentrancyGuard {})
 }
 
+#[derive(Clone, Copy)]
+pub struct OpMetadata {
+  /// A description of the op for use in sanitizer output.
+  pub sanitizer_details: Option<&'static str>,
+  /// The fix for the issue described in `sanitizer_details`.
+  pub sanitizer_fix: Option<&'static str>,
+}
+
+impl OpMetadata {
+  pub const fn default() -> Self {
+    Self {
+      sanitizer_details: None,
+      sanitizer_fix: None,
+    }
+  }
+}
+
 /// Per-op context.
 ///
 // Note: We don't worry too much about the size of this struct because it's allocated once per realm, and is

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -247,6 +247,10 @@ impl OpCtx {
   pub(crate) fn runtime_state(&self) -> &JsRuntimeState {
     &self.runtime_state
   }
+
+  pub fn metadata(&self) -> OpMetadata {
+    self.decl.metadata
+  }
 }
 
 /// Maintains the resources and ops inside a JS runtime.

--- a/ops/op2/mod.rs
+++ b/ops/op2/mod.rs
@@ -263,7 +263,7 @@ fn generate_op2(
         /*fast_fn*/ #fast_definition,
         /*fast_fn_metrics*/ #fast_definition_metrics,
         /*metadata*/ ::deno_core::OpMetadata {
-          #(#meta_key: #meta_value,)*
+          #(#meta_key: Some(#meta_value),)*
           ..::deno_core::OpMetadata::default()
         },
       );

--- a/ops/op2/mod.rs
+++ b/ops/op2/mod.rs
@@ -240,6 +240,9 @@ fn generate_op2(
     .map(|p| parse_str::<Type>(p).expect("Failed to reparse type bounds"))
     .collect::<Vec<_>>();
 
+  let meta_key = signature.metadata.keys().collect::<Vec<_>>();
+  let meta_value = signature.metadata.values().collect::<Vec<_>>();
+
   Ok(quote! {
     #[allow(non_camel_case_types)]
     #(#attrs)*
@@ -259,6 +262,10 @@ fn generate_op2(
         /*slow_fn_metrics*/ Self::#slow_function_metrics as _,
         /*fast_fn*/ #fast_definition,
         /*fast_fn_metrics*/ #fast_definition_metrics,
+        /*metadata*/ ::deno_core::OpMetadata {
+          #(#meta_key: #meta_value),*
+          ..::deno_core::OpMetadata::default()
+        },
       );
     }
 

--- a/ops/op2/mod.rs
+++ b/ops/op2/mod.rs
@@ -263,7 +263,7 @@ fn generate_op2(
         /*fast_fn*/ #fast_definition,
         /*fast_fn_metrics*/ #fast_definition_metrics,
         /*metadata*/ ::deno_core::OpMetadata {
-          #(#meta_key: #meta_value),*
+          #(#meta_key: #meta_value,)*
           ..::deno_core::OpMetadata::default()
         },
       );

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -1214,6 +1214,10 @@ fn parse_attributes(
 /// Is this a special attribute that we understand?
 pub fn is_attribute_special(attr: &Attribute) -> bool {
   parse_attribute(attr).unwrap_or_default().is_some()
+    // this is kind of ugly, but #[meta(..)] is the only
+    // attribute that we want to omit from the generated code 
+    // that doesn't have a semantic meaning
+    || attr.path().is_ident("meta")
 }
 
 /// Parses an attribute, returning None if this is an attribute we support but is

--- a/ops/op2/test_cases/async/async_arg_return.out
+++ b/ops/op2/test_cases/async/async_arg_return.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_async {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_async {

--- a/ops/op2/test_cases/async/async_arg_return_result.out
+++ b/ops/op2/test_cases/async/async_arg_return_result.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_async {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_async {

--- a/ops/op2/test_cases/async/async_deferred.out
+++ b/ops/op2/test_cases/async/async_deferred.out
@@ -29,6 +29,9 @@ impl ::deno_core::_ops::Op for op_async_deferred {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_async_deferred {

--- a/ops/op2/test_cases/async/async_jsbuffer.out
+++ b/ops/op2/test_cases/async/async_jsbuffer.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_async_v8_buffer {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_async_v8_buffer {

--- a/ops/op2/test_cases/async/async_lazy.out
+++ b/ops/op2/test_cases/async/async_lazy.out
@@ -29,6 +29,9 @@ impl ::deno_core::_ops::Op for op_async_lazy {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_async_lazy {

--- a/ops/op2/test_cases/async/async_op_metadata.out
+++ b/ops/op2/test_cases/async/async_op_metadata.out
@@ -1,0 +1,191 @@
+#[allow(non_camel_case_types)]
+struct op_blob_read_part {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
+impl ::deno_core::_ops::Op for op_blob_read_part {
+    const NAME: &'static str = stringify!(op_blob_read_part);
+    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+        ::deno_core::__op_name_fast!(op_blob_read_part),
+        true,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
+        None,
+        ::deno_core::OpMetadata {
+            sanitizer_details: Some("read from a Blob or File"),
+            sanitizer_fix: Some("awaiting the result of a Blob or File read"),
+            ..::deno_core::OpMetadata::default()
+        },
+    );
+}
+impl op_blob_read_part {
+    pub const fn name() -> &'static str {
+        stringify!(op_blob_read_part)
+    }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
+    }
+    #[inline(always)]
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        #[cfg(debug_assertions)]
+        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+            &<Self as deno_core::_ops::Op>::DECL,
+        );
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+            &*info
+        });
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        let result = { Self::call() };
+        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+            .unwrap_or_default();
+        if let Some(result) = deno_core::_ops::map_async_op_infallible(
+            opctx,
+            false,
+            false,
+            promise_id,
+            result,
+            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+        ) {
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        return 2;
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::slow_function_impl(info);
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_async(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
+        );
+        let res = Self::slow_function_impl(info);
+        if res == 0 {
+            deno_core::_ops::dispatch_metrics_async(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Completed,
+            );
+        } else if res == 1 {
+            deno_core::_ops::dispatch_metrics_async(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Error,
+            );
+        }
+    }
+    #[inline(always)]
+    async fn call() {
+        return;
+    }
+}
+
+#[allow(non_camel_case_types)]
+struct op_broadcast_recv {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
+impl ::deno_core::_ops::Op for op_broadcast_recv {
+    const NAME: &'static str = stringify!(op_broadcast_recv);
+    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+        ::deno_core::__op_name_fast!(op_broadcast_recv),
+        true,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
+        None,
+        ::deno_core::OpMetadata {
+            sanitizer_details: Some("receive a message from a BroadcastChannel"),
+            sanitizer_fix: Some("closing the BroadcastChannel"),
+            ..::deno_core::OpMetadata::default()
+        },
+    );
+}
+impl op_broadcast_recv {
+    pub const fn name() -> &'static str {
+        stringify!(op_broadcast_recv)
+    }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
+    }
+    #[inline(always)]
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        #[cfg(debug_assertions)]
+        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+            &<Self as deno_core::_ops::Op>::DECL,
+        );
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+            &*info
+        });
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        let result = { Self::call() };
+        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+            .unwrap_or_default();
+        if let Some(result) = deno_core::_ops::map_async_op_infallible(
+            opctx,
+            false,
+            false,
+            promise_id,
+            result,
+            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+        ) {
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        return 2;
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::slow_function_impl(info);
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_async(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
+        );
+        let res = Self::slow_function_impl(info);
+        if res == 0 {
+            deno_core::_ops::dispatch_metrics_async(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Completed,
+            );
+        } else if res == 1 {
+            deno_core::_ops::dispatch_metrics_async(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Error,
+            );
+        }
+    }
+    #[inline(always)]
+    async fn call() {
+        return;
+    }
+}

--- a/ops/op2/test_cases/async/async_op_metadata.rs
+++ b/ops/op2/test_cases/async/async_op_metadata.rs
@@ -1,0 +1,19 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+#![deny(warnings)]
+deno_ops_compile_test_runner::prelude!();
+
+#[op2(async)]
+#[meta(sanitizer_details = "read from a Blob or File")]
+#[meta(sanitizer_fix = "awaiting the result of a Blob or File read")]
+async fn op_blob_read_part() {
+  return;
+}
+
+#[op2(async)]
+#[meta(
+  sanitizer_details = "receive a message from a BroadcastChannel",
+  sanitizer_fix = "closing the BroadcastChannel"
+)]
+async fn op_broadcast_recv() {
+  return;
+}

--- a/ops/op2/test_cases/async/async_opstate.out
+++ b/ops/op2/test_cases/async/async_opstate.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_async_opstate {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_async_opstate {

--- a/ops/op2/test_cases/async/async_result.out
+++ b/ops/op2/test_cases/async/async_result.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_async {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_async {

--- a/ops/op2/test_cases/async/async_result_impl.out
+++ b/ops/op2/test_cases/async/async_result_impl.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_async_result_impl {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_async_result_impl {

--- a/ops/op2/test_cases/async/async_result_smi.out
+++ b/ops/op2/test_cases/async/async_result_smi.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_async {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_async {

--- a/ops/op2/test_cases/async/async_v8_global.out
+++ b/ops/op2/test_cases/async/async_v8_global.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_async_v8_global {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_async_v8_global {

--- a/ops/op2/test_cases/async/async_void.out
+++ b/ops/op2/test_cases/async/async_void.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_async {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_async {

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -29,6 +29,9 @@ impl ::deno_core::_ops::Op for op_add {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_add {

--- a/ops/op2/test_cases/sync/add_options.out
+++ b/ops/op2/test_cases/sync/add_options.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_test_add_option {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_test_add_option {

--- a/ops/op2/test_cases/sync/bigint.out
+++ b/ops/op2/test_cases/sync/bigint.out
@@ -29,6 +29,9 @@ impl ::deno_core::_ops::Op for op_bigint {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_bigint {

--- a/ops/op2/test_cases/sync/bool.out
+++ b/ops/op2/test_cases/sync/bool.out
@@ -29,6 +29,9 @@ impl ::deno_core::_ops::Op for op_bool {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_bool {

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -29,6 +29,9 @@ impl ::deno_core::_ops::Op for op_bool {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_bool {

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -42,6 +42,9 @@ impl ::deno_core::_ops::Op for op_buffers {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_buffers {
@@ -306,6 +309,9 @@ impl ::deno_core::_ops::Op for op_buffers_32 {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_buffers_32 {
@@ -541,6 +547,9 @@ impl ::deno_core::_ops::Op for op_buffers_option {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_buffers_option {

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -40,6 +40,9 @@ impl ::deno_core::_ops::Op for op_buffers {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_buffers {
@@ -257,6 +260,9 @@ impl ::deno_core::_ops::Op for op_buffers_32 {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_buffers_32 {

--- a/ops/op2/test_cases/sync/buffers_out.out
+++ b/ops/op2/test_cases/sync/buffers_out.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_buffers {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_buffers {
@@ -121,6 +124,9 @@ impl ::deno_core::_ops::Op for op_buffers_option {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_buffers_option {
@@ -236,6 +242,9 @@ impl ::deno_core::_ops::Op for op_arraybuffers {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_arraybuffers {

--- a/ops/op2/test_cases/sync/cfg.out
+++ b/ops/op2/test_cases/sync/cfg.out
@@ -31,6 +31,9 @@ impl ::deno_core::_ops::Op for op_maybe_windows {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_maybe_windows {
@@ -153,6 +156,9 @@ impl ::deno_core::_ops::Op for op_maybe_windows {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_maybe_windows {

--- a/ops/op2/test_cases/sync/clippy_allow.out
+++ b/ops/op2/test_cases/sync/clippy_allow.out
@@ -31,6 +31,9 @@ impl ::deno_core::_ops::Op for op_extra_annotation {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_extra_annotation {
@@ -151,6 +154,9 @@ impl ::deno_core::_ops::Op for op_clippy_internal {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_clippy_internal {

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -29,6 +29,9 @@ impl ::deno_core::_ops::Op for op_file {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_file {

--- a/ops/op2/test_cases/sync/doc_comment.out
+++ b/ops/op2/test_cases/sync/doc_comment.out
@@ -30,6 +30,9 @@ impl ::deno_core::_ops::Op for op_has_doc_comment {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_has_doc_comment {

--- a/ops/op2/test_cases/sync/fast_alternative.out
+++ b/ops/op2/test_cases/sync/fast_alternative.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_slow {
         Self::v8_fn_ptr_metrics as _,
         Some({ op_fast::DECL.fast_fn() }),
         Some({ op_fast::DECL.fast_fn_with_metrics() }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_slow {
@@ -134,6 +137,9 @@ impl ::deno_core::_ops::Op for op_fast {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_fast {
@@ -281,6 +287,9 @@ impl<T: Trait> ::deno_core::_ops::Op for op_slow_generic<T> {
         Self::v8_fn_ptr_metrics as _,
         Some({ op_fast_generic::<T>::DECL.fast_fn() }),
         Some({ op_fast_generic::<T>::DECL.fast_fn_with_metrics() }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl<T: Trait> op_slow_generic<T> {
@@ -402,6 +411,9 @@ impl<T: Trait> ::deno_core::_ops::Op for op_fast_generic<T> {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl<T: Trait> op_fast_generic<T> {

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -29,6 +29,9 @@ impl<T: Trait> ::deno_core::_ops::Op for op_generics<T> {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl<T: Trait> op_generics<T> {
@@ -147,6 +150,9 @@ impl<T: Trait + 'static> ::deno_core::_ops::Op for op_generics_static<T> {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl<T: Trait + 'static> op_generics_static<T> {
@@ -265,6 +271,9 @@ impl<T: Trait + 'static> ::deno_core::_ops::Op for op_generics_static_where<T> {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl<T: Trait + 'static> op_generics_static_where<T> {

--- a/ops/op2/test_cases/sync/nofast.out
+++ b/ops/op2/test_cases/sync/nofast.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_nofast {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_nofast {

--- a/ops/op2/test_cases/sync/op_state_attr.out
+++ b/ops/op2/test_cases/sync/op_state_attr.out
@@ -29,6 +29,9 @@ impl ::deno_core::_ops::Op for op_state_rc {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_state_rc {

--- a/ops/op2/test_cases/sync/op_state_rc.out
+++ b/ops/op2/test_cases/sync/op_state_rc.out
@@ -29,6 +29,9 @@ impl ::deno_core::_ops::Op for op_state_rc {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_state_rc {

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -29,6 +29,9 @@ impl ::deno_core::_ops::Op for op_state_ref {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_state_ref {
@@ -171,6 +174,9 @@ impl ::deno_core::_ops::Op for op_state_mut {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_state_mut {
@@ -297,6 +303,9 @@ impl ::deno_core::_ops::Op for op_state_and_v8 {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_state_and_v8 {
@@ -411,6 +420,9 @@ impl ::deno_core::_ops::Op for op_state_and_v8_local {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_state_and_v8_local {

--- a/ops/op2/test_cases/sync/result_external.out
+++ b/ops/op2/test_cases/sync/result_external.out
@@ -29,6 +29,9 @@ impl ::deno_core::_ops::Op for op_external_with_result {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_external_with_result {

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -29,6 +29,9 @@ impl ::deno_core::_ops::Op for op_u32_with_result {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_u32_with_result {

--- a/ops/op2/test_cases/sync/result_scope.out
+++ b/ops/op2/test_cases/sync/result_scope.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_void_with_result {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_void_with_result {

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -29,6 +29,9 @@ impl ::deno_core::_ops::Op for op_void_with_result {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_void_with_result {

--- a/ops/op2/test_cases/sync/serde_v8.out
+++ b/ops/op2/test_cases/sync/serde_v8.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_serde_v8 {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_serde_v8 {

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -36,6 +36,9 @@ impl ::deno_core::_ops::Op for op_smi_unsigned_return {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_smi_unsigned_return {
@@ -246,6 +249,9 @@ impl ::deno_core::_ops::Op for op_smi_signed_return {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_smi_signed_return {
@@ -433,6 +439,9 @@ impl ::deno_core::_ops::Op for op_smi_option {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_smi_option {

--- a/ops/op2/test_cases/sync/string_cow.out
+++ b/ops/op2/test_cases/sync/string_cow.out
@@ -29,6 +29,9 @@ impl ::deno_core::_ops::Op for op_string_cow {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_string_cow {

--- a/ops/op2/test_cases/sync/string_onebyte.out
+++ b/ops/op2/test_cases/sync/string_onebyte.out
@@ -29,6 +29,9 @@ impl ::deno_core::_ops::Op for op_string_onebyte {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_string_onebyte {

--- a/ops/op2/test_cases/sync/string_option_return.out
+++ b/ops/op2/test_cases/sync/string_option_return.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_string_return {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_string_return {

--- a/ops/op2/test_cases/sync/string_owned.out
+++ b/ops/op2/test_cases/sync/string_owned.out
@@ -29,6 +29,9 @@ impl ::deno_core::_ops::Op for op_string_owned {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_string_owned {

--- a/ops/op2/test_cases/sync/string_ref.out
+++ b/ops/op2/test_cases/sync/string_ref.out
@@ -29,6 +29,9 @@ impl ::deno_core::_ops::Op for op_string_owned {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_string_owned {

--- a/ops/op2/test_cases/sync/string_return.out
+++ b/ops/op2/test_cases/sync/string_return.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_string_return {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_string_return {
@@ -98,6 +101,9 @@ impl ::deno_core::_ops::Op for op_string_return_ref {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_string_return_ref {
@@ -183,6 +189,9 @@ impl ::deno_core::_ops::Op for op_string_return_cow {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_string_return_cow {

--- a/ops/op2/test_cases/sync/v8_global.out
+++ b/ops/op2/test_cases/sync/v8_global.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_global {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_global {

--- a/ops/op2/test_cases/sync/v8_handlescope.out
+++ b/ops/op2/test_cases/sync/v8_handlescope.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_handlescope {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_handlescope {

--- a/ops/op2/test_cases/sync/v8_lifetime.out
+++ b/ops/op2/test_cases/sync/v8_lifetime.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_v8_lifetime {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_v8_lifetime {

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -29,6 +29,9 @@ impl ::deno_core::_ops::Op for op_v8_lifetime {
                 Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
             )
         }),
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_v8_lifetime {

--- a/ops/op2/test_cases/sync/v8_string.out
+++ b/ops/op2/test_cases/sync/v8_string.out
@@ -13,6 +13,9 @@ impl ::deno_core::_ops::Op for op_v8_string {
         Self::v8_fn_ptr_metrics as _,
         None,
         None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
     );
 }
 impl op_v8_string {


### PR DESCRIPTION
Currently, only `sanitizer_details` and `sanitizer_fix` (to replace [this map](https://github.com/denoland/deno/blob/2ce645137a6539411dad8d9fe359bc651b215ba5/cli/tools/test/fmt.rs#L293-L294)), but adding more metadata fields shouldn't require any updates to the macro code.

Now you can write

```rust
#[op2(async)]
#[serde]
#[meta(
  sanitizer_details = "receive a message from a BroadcastChannel",
  sanitizer_fix = "closing the BroadcastChannel"
)]
pub async fn op_broadcast_recv(..) {
 ..
}
```

This expands to setting values in the `OpMetadata` struct, which is attached to `OpDecl` and publically accessible via the `metadata` method on `OpCtx`

Closes https://github.com/denoland/deno_core/issues/467