### PR TITLE
feat(op2): support cppgc in async ops

### DIFF
--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -597,9 +597,7 @@ mod tests {
       op_buffer_any_length,
       op_arraybuffer_slice,
       op_test_get_cppgc_resource,
-      op_test_get_cppgc_resource_async,
       op_test_make_cppgc_resource,
-      op_test_make_cppgc_resource_async,
       op_external_make,
       op_external_process,
       op_external_make_ptr,
@@ -1867,20 +1865,6 @@ mod tests {
     resource.value
   }
 
-  #[op2(async)]
-  #[cppgc]
-  pub async fn op_test_make_cppgc_resource_async() -> TestResource {
-    TestResource { value: 42 }
-  }
-
-  #[op2(async)]
-  #[smi]
-  pub async fn op_test_get_cppgc_resource_async(
-    #[cppgc] resource: &TestResource,
-  ) -> u32 {
-    resource.value
-  }
-
   #[test]
   pub fn test_op_cppgc_object() -> Result<(), Box<dyn std::error::Error>> {
     run_test2(
@@ -1890,20 +1874,6 @@ mod tests {
       const resource = op_test_make_cppgc_resource();
       assert(op_test_get_cppgc_resource(resource) == 42);",
     )?;
-    Ok(())
-  }
-
-  #[tokio::test]
-  pub async fn test_op_cppgc_object_async(
-  ) -> Result<(), Box<dyn std::error::Error>> {
-    run_async_test(
-      10,
-      "op_test_make_cppgc_resource_async, op_test_get_cppgc_resource, op_test_get_cppgc_resource_async",
-      r"
-      const resource = await op_test_make_cppgc_resource_async();
-      assert(op_test_get_cppgc_resource(resource) == 42);
-      assert(await op_test_get_cppgc_resource_async(resource) == 42);",
-    ).await?;
     Ok(())
   }
 

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -597,7 +597,9 @@ mod tests {
       op_buffer_any_length,
       op_arraybuffer_slice,
       op_test_get_cppgc_resource,
+      op_test_get_cppgc_resource_async,
       op_test_make_cppgc_resource,
+      op_test_make_cppgc_resource_async,
       op_external_make,
       op_external_process,
       op_external_make_ptr,
@@ -1865,6 +1867,20 @@ mod tests {
     resource.value
   }
 
+  #[op2(async)]
+  #[cppgc]
+  pub async fn op_test_make_cppgc_resource_async() -> TestResource {
+    TestResource { value: 42 }
+  }
+
+  #[op2(async)]
+  #[smi]
+  pub async fn op_test_get_cppgc_resource_async(
+    #[cppgc] resource: &TestResource,
+  ) -> u32 {
+    resource.value
+  }
+
   #[test]
   pub fn test_op_cppgc_object() -> Result<(), Box<dyn std::error::Error>> {
     run_test2(
@@ -1874,6 +1890,20 @@ mod tests {
       const resource = op_test_make_cppgc_resource();
       assert(op_test_get_cppgc_resource(resource) == 42);",
     )?;
+    Ok(())
+  }
+
+  #[tokio::test]
+  pub async fn test_op_cppgc_object_async(
+  ) -> Result<(), Box<dyn std::error::Error>> {
+    run_async_test(
+      10,
+      "op_test_make_cppgc_resource_async, op_test_get_cppgc_resource, op_test_get_cppgc_resource_async",
+      r"
+      const resource = await op_test_make_cppgc_resource_async();
+      assert(op_test_get_cppgc_resource(resource) == 42);
+      assert(await op_test_get_cppgc_resource_async(resource) == 42);",
+    ).await?;
     Ok(())
   }
 

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -782,7 +782,7 @@ pub fn return_value_v8_value(
       quote!(deno_core::_ops::RustToV8Marker::<deno_core::_ops::NumberMarker, _>::from(#result))
     }
     ArgMarker::Cppgc => {
-      quote!(deno_core::cppgc::make_cppgc_object(&mut #scope, #result))
+      quote!(deno_core::cppgc::make_cppgc_object(#scope, #result))
     }
     ArgMarker::None => quote!(#result),
   };

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -234,3 +234,110 @@ impl op_make_cppgc_object {
         Wrap
     }
 }
+
+#[allow(non_camel_case_types)]
+struct op_make_cppgc_object_async {
+    _unconstructable: ::std::marker::PhantomData<()>,
+}
+impl ::deno_core::_ops::Op for op_make_cppgc_object_async {
+    const NAME: &'static str = stringify!(op_make_cppgc_object_async);
+    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+        ::deno_core::__op_name_fast!(op_make_cppgc_object_async),
+        true,
+        false,
+        1usize as u8,
+        Self::v8_fn_ptr as _,
+        Self::v8_fn_ptr_metrics as _,
+        None,
+        None,
+        ::deno_core::OpMetadata {
+            ..::deno_core::OpMetadata::default()
+        },
+    );
+}
+impl op_make_cppgc_object_async {
+    pub const fn name() -> &'static str {
+        stringify!(op_make_cppgc_object_async)
+    }
+    #[deprecated(note = "Use the const op::DECL instead")]
+    pub const fn decl() -> deno_core::_ops::OpDecl {
+        <Self as deno_core::_ops::Op>::DECL
+    }
+    #[inline(always)]
+    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+        #[cfg(debug_assertions)]
+        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+            &<Self as deno_core::_ops::Op>::DECL,
+        );
+        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+            &*info
+        });
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        let result = { Self::call() };
+        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+            .unwrap_or_default();
+        if let Some(result) = deno_core::_ops::map_async_op_infallible(
+            opctx,
+            false,
+            false,
+            promise_id,
+            result,
+            |scope, result| {
+                Ok(
+                    deno_core::_ops::RustToV8NoScope::to_v8(
+                        deno_core::cppgc::make_cppgc_object(scope, result),
+                    ),
+                )
+            },
+        ) {
+            rv.set(
+                deno_core::_ops::RustToV8NoScope::to_v8(
+                    deno_core::v8::Local::<
+                        deno_core::v8::Value,
+                    >::from(deno_core::cppgc::make_cppgc_object(&mut scope, result)),
+                ),
+            );
+            return 0;
+        }
+        return 2;
+    }
+    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        Self::slow_function_impl(info);
+    }
+    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+            &*info
+        });
+        let opctx = unsafe {
+            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
+                as *const deno_core::_ops::OpCtx)
+        };
+        deno_core::_ops::dispatch_metrics_async(
+            &opctx,
+            deno_core::_ops::OpMetricsEvent::Dispatched,
+        );
+        let res = Self::slow_function_impl(info);
+        if res == 0 {
+            deno_core::_ops::dispatch_metrics_async(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Completed,
+            );
+        } else if res == 1 {
+            deno_core::_ops::dispatch_metrics_async(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Error,
+            );
+        }
+    }
+    #[inline(always)]
+    async fn call() -> Wrap {
+        Wrap
+    }
+}

--- a/ops/op2/test_cases/sync/cppgc_resource.rs
+++ b/ops/op2/test_cases/sync/cppgc_resource.rs
@@ -12,3 +12,9 @@ struct Wrap;
 fn op_make_cppgc_object() -> Wrap {
     Wrap
 }
+
+#[op2(async)]
+#[cppgc]
+async fn op_make_cppgc_object_async() -> Wrap {
+    Wrap
+}

--- a/testing/checkin/runner/mod.rs
+++ b/testing/checkin/runner/mod.rs
@@ -52,6 +52,8 @@ deno_core::extension!(
     ops_async::op_async_barrier_create,
     ops_async::op_async_barrier_await,
     ops_async::op_async_spin_on_state,
+    ops_async::op_async_make_cppgc_resource,
+    ops_async::op_async_get_cppgc_resource,
     ops_error::op_async_throw_error_eager,
     ops_error::op_async_throw_error_lazy,
     ops_error::op_async_throw_error_deferred,

--- a/testing/checkin/runner/ops_async.rs
+++ b/testing/checkin/runner/ops_async.rs
@@ -46,3 +46,21 @@ pub async fn op_async_spin_on_state(state: Rc<RefCell<OpState>>) {
   })
   .await
 }
+
+pub struct TestResource {
+  value: u32,
+}
+
+#[op2(async)]
+#[cppgc]
+pub async fn op_async_make_cppgc_resource() -> TestResource {
+  TestResource { value: 42 }
+}
+
+#[op2(async)]
+#[smi]
+pub async fn op_async_get_cppgc_resource(
+  #[cppgc] resource: &TestResource,
+) -> u32 {
+  resource.value
+}

--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assert, assertArrayEquals, assertEquals, test } from "checkin:testing";
 
-const { op_pipe_create, op_file_open } = Deno.core.ops;
+const { op_pipe_create, op_file_open, op_async_make_cppgc_resource, op_async_get_cppgc_resource } = Deno.core.ops;
 
 test(async function testPipe() {
   const [p1, p2] = op_pipe_create();
@@ -52,3 +52,9 @@ test(async function testFileIsNotTerminal() {
   const file = await op_file_open("./README.md");
   assert(!Deno.core.isTerminal(file));
 });
+
+test(async function testCppgcAsync() {
+  const resource = await op_async_make_cppgc_resource();
+  assertEquals(await op_async_get_cppgc_resource(resource), 42);
+});
+

--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -1,7 +1,12 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assert, assertArrayEquals, assertEquals, test } from "checkin:testing";
 
-const { op_pipe_create, op_file_open, op_async_make_cppgc_resource, op_async_get_cppgc_resource } = Deno.core.ops;
+const {
+  op_pipe_create,
+  op_file_open,
+  op_async_make_cppgc_resource,
+  op_async_get_cppgc_resource,
+} = Deno.core.ops;
 
 test(async function testPipe() {
   const [p1, p2] = op_pipe_create();
@@ -57,4 +62,3 @@ test(async function testCppgcAsync() {
   const resource = await op_async_make_cppgc_resource();
   assertEquals(await op_async_get_cppgc_resource(resource), 42);
 });
-


### PR DESCRIPTION
`#[cppgc]` return values were added in https://github.com/denoland/deno_core/commit/a736d868d091406ee20c3fda44bde56def2e73f3 which made 
creation of cppgc backed objects possible without direct access to V8 APIs. 

This patch builds on top of that and adds `#[cppgc]` support for async ops.