### PR TITLE
refactor: remove log crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,6 @@ dependencies = [
  "fastrand",
  "futures",
  "libc",
- "log",
  "memoffset",
  "parking_lot",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ cooked-waker = "5"
 fastrand = "2"
 futures = "0.3.21"
 libc = "0.2.126"
-log = "0.4.17"
 memoffset = ">=0.9"
 num-bigint = { version = "0.4", features = ["rand"] }
 parking_lot = "0.12.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -34,7 +34,6 @@ deno_ops.workspace = true
 deno_unsync.workspace = true
 futures.workspace = true
 libc.workspace = true
-log.workspace = true
 memoffset.workspace = true
 parking_lot.workspace = true
 pin-project.workspace = true

--- a/core/gotham_state.rs
+++ b/core/gotham_state.rs
@@ -3,7 +3,6 @@
 // https://github.com/gotham-rs/gotham/blob/bcbbf8923789e341b7a0e62c59909428ca4e22e2/gotham/src/state/mod.rs
 // Copyright 2017 Gotham Project Developers. MIT license.
 
-use log::trace;
 use std::any::type_name;
 use std::any::Any;
 use std::any::TypeId;
@@ -20,7 +19,6 @@ impl GothamState {
   /// type.
   pub fn put<T: 'static>(&mut self, t: T) {
     let type_id = TypeId::of::<T>();
-    trace!(" inserting record to state for type_id `{:?}`", type_id);
     self.data.insert(type_id, Box::new(t));
   }
 
@@ -33,7 +31,6 @@ impl GothamState {
   /// Tries to borrow a value from the `GothamState` storage.
   pub fn try_borrow<T: 'static>(&self) -> Option<&T> {
     let type_id = TypeId::of::<T>();
-    trace!(" borrowing state data for type_id `{:?}`", type_id);
     self.data.get(&type_id).and_then(|b| b.downcast_ref())
   }
 
@@ -45,7 +42,6 @@ impl GothamState {
   /// Tries to mutably borrow a value from the `GothamState` storage.
   pub fn try_borrow_mut<T: 'static>(&mut self) -> Option<&mut T> {
     let type_id = TypeId::of::<T>();
-    trace!(" mutably borrowing state data for type_id `{:?}`", type_id);
     self.data.get_mut(&type_id).and_then(|b| b.downcast_mut())
   }
 
@@ -57,10 +53,6 @@ impl GothamState {
   /// Tries to move a value out of the `GothamState` storage and return ownership.
   pub fn try_take<T: 'static>(&mut self) -> Option<T> {
     let type_id = TypeId::of::<T>();
-    trace!(
-      " taking ownership from state data for type_id `{:?}`",
-      type_id
-    );
     self
       .data
       .remove(&type_id)

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -41,7 +41,6 @@ use futures::task::noop_waker_ref;
 use futures::task::AtomicWaker;
 use futures::Future;
 use futures::StreamExt;
-use log::debug;
 use v8::Function;
 use v8::PromiseState;
 
@@ -338,10 +337,6 @@ impl ModuleMap {
     let maybe_module_id = self.get_id(&module_url_found, requested_module_type);
 
     if let Some(module_id) = maybe_module_id {
-      debug!(
-        "Already-registered module fetched again: {:?}",
-        module_url_found
-      );
       return Ok(module_id);
     }
 

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 use anyhow::Context;
-use log::debug;
 use std::mem::MaybeUninit;
 use std::os::raw::c_void;
 use std::path::PathBuf;
@@ -429,10 +428,6 @@ pub fn host_import_module_dynamically_callback<'s>(
     let state = JsRuntime::state_from(scope);
     let module_map_rc = JsRealm::module_map_from(scope);
 
-    debug!(
-      "dyn_import specifier {} referrer {} ",
-      specifier_str, referrer_name_str
-    );
     ModuleMap::load_dynamic_import(
       module_map_rc,
       &specifier_str,

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -9,7 +9,6 @@ use crate::*;
 use anyhow::bail;
 use anyhow::Error;
 use futures::Future;
-use log::debug;
 use pretty_assertions::assert_eq;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -515,7 +514,6 @@ await op_void_async_deferred();
     biased;
 
     maybe_result = &mut rx => {
-      debug!("received module evaluate {:#?}", maybe_result);
       maybe_result
     }
 


### PR DESCRIPTION
We have not used these logs in the past 2-3 years, it's questionable to keep them around.