### PR TITLE
feat: op2 codegen for object methods

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -117,6 +117,7 @@ pub use crate::modules::ResolutionKind;
 pub use crate::modules::StaticModuleLoader;
 pub use crate::modules::ValidateImportAttributesCb;
 pub use crate::normalize_path::normalize_path;
+pub use crate::ops::OpCtx;
 pub use crate::ops::OpId;
 pub use crate::ops::OpMetadata;
 pub use crate::ops::OpState;
@@ -149,7 +150,6 @@ pub use crate::source_map::SourceMapData;
 pub use crate::source_map::SourceMapGetter;
 pub use crate::tasks::V8CrossThreadTaskSpawner;
 pub use crate::tasks::V8TaskSpawner;
-pub use crate::ops::OpCtx;
 
 // Ensure we can use op2 in deno_core without any hackery.
 extern crate self as deno_core;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -149,6 +149,7 @@ pub use crate::source_map::SourceMapData;
 pub use crate::source_map::SourceMapGetter;
 pub use crate::tasks::V8CrossThreadTaskSpawner;
 pub use crate::tasks::V8TaskSpawner;
+pub use crate::ops::OpCtx;
 
 // Ensure we can use op2 in deno_core without any hackery.
 extern crate self as deno_core;
@@ -171,6 +172,7 @@ pub mod _ops {
   pub use super::ops_metrics::dispatch_metrics_fast;
   pub use super::ops_metrics::dispatch_metrics_slow;
   pub use super::ops_metrics::OpMetricsEvent;
+  pub use super::runtime::bindings::register_op_method;
   pub use super::runtime::ops::*;
   pub use super::runtime::ops_rust_to_v8::*;
   pub use super::runtime::V8_WRAPPER_OBJECT_INDEX;

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -154,6 +154,20 @@ impl OpCtx {
     }
   }
 
+  pub fn clone_for_method(&self, decl: OpDecl) -> Self {
+    // id and metrics_fn are not used in method ops
+    Self::new(
+      0,
+      self.isolate,
+      self.op_driver.clone(),
+      decl,
+      self.state.clone(),
+      self.runtime_state.clone(),
+      self.get_error_class_fn,
+      None,
+    )
+  }
+
   #[inline(always)]
   pub const fn decl(&self) -> &OpDecl {
     &self.decl

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -323,6 +323,17 @@ pub(crate) fn initialize_deno_core_ops_bindings<'s>(
   }
 }
 
+pub fn register_op_method(
+  scope: &mut v8::HandleScope,
+  op_ctx: OpCtx,
+  obj: v8::Local<v8::Object>,
+) {
+  let key = op_ctx.decl.name_fast.v8_string(scope);
+  let op_fn = op_ctx_function(scope, Box::leak(Box::new(op_ctx)));
+
+  obj.set(scope, key.into(), op_fn.into()).unwrap();
+}
+
 fn op_ctx_function<'s>(
   scope: &mut v8::HandleScope<'s>,
   op_ctx: &OpCtx,

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -183,8 +183,6 @@ impl InnerIsolateState {
     unsafe {
       ManuallyDrop::take(&mut self.main_realm).0.destroy();
     }
-
-    debug_assert_eq!(Rc::strong_count(&self.state), 1);
   }
 
   pub fn prepare_for_snapshot(mut self) -> v8::OwnedIsolate {

--- a/ops/op2/dispatch_async.rs
+++ b/ops/op2/dispatch_async.rs
@@ -10,6 +10,7 @@ use super::dispatch_slow::with_opctx;
 use super::dispatch_slow::with_opstate;
 use super::dispatch_slow::with_retval;
 use super::dispatch_slow::with_scope;
+use super::dispatch_slow::with_self;
 use super::generator_state::gs_quote;
 use super::generator_state::GeneratorState;
 use super::signature::ParsedSignature;
@@ -136,6 +137,12 @@ pub(crate) fn generate_dispatch_async(
     quote!()
   };
 
+  let with_self = if generator_state.needs_self {
+    with_self(generator_state)
+  } else {
+    quote!()
+  };
+
   Ok(
     gs_quote!(generator_state(info, slow_function, slow_function_metrics, opctx) => {
       #[inline(always)]
@@ -148,6 +155,7 @@ pub(crate) fn generate_dispatch_async(
         #with_args
         #with_opctx
         #with_opstate
+        #with_self
 
         #output
       }

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -641,6 +641,10 @@ fn map_v8_fastcall_arg_to_arg(
       *needs_js_runtime_state = true;
       quote!(let #arg_ident = &#js_runtime_state;)
     }
+    Arg::Ref(RefType::Ref, Special::OpCtx) => {
+      *needs_opctx = true;
+      quote!(let #arg_ident = #opctx;)
+    }
     Arg::State(RefType::Ref, state) => {
       *needs_opctx = true;
       let state =
@@ -800,6 +804,7 @@ fn map_arg_to_v8_fastcall_type(
     | Arg::Ref(_, Special::OpState)
     | Arg::Rc(Special::JsRuntimeState)
     | Arg::Ref(RefType::Ref, Special::JsRuntimeState)
+    | Arg::Ref(RefType::Ref, Special::OpCtx)
     | Arg::State(..)
     | Arg::Special(Special::Isolate)
     | Arg::OptionState(..)

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -439,6 +439,21 @@ pub(crate) fn generate_dispatch_fast(
     quote!()
   };
 
+  let with_self = if generator_state.needs_self {
+    gs_quote!(generator_state(self_ty) => {
+      let self_: &#self_ty = deno_core::cppgc::try_unwrap_cppgc_object(this.into()).unwrap();
+    })
+  } else {
+    quote!()
+  };
+
+  let name = &generator_state.name;
+  let call = if generator_state.needs_self {
+    quote!(self_. #name)
+  } else {
+    quote!(Self:: #name)
+  };
+
   let with_opctx = if generator_state.needs_fast_opctx {
     generator_state.needs_fast_api_callback_options = true;
     gs_quote!(generator_state(opctx, fast_api_callback_options) => {
@@ -503,7 +518,7 @@ pub(crate) fn generate_dispatch_fast(
 
     #[allow(clippy::too_many_arguments)]
     extern "C" fn #fast_function(
-      _: deno_core::v8::Local<deno_core::v8::Object>,
+      this: deno_core::v8::Local<deno_core::v8::Object>,
       #( #fastcall_names: #fastcall_types, )*
     ) -> #output_type {
       #[cfg(debug_assertions)]
@@ -512,9 +527,11 @@ pub(crate) fn generate_dispatch_fast(
       #with_fast_api_callback_options
       #with_opctx
       #with_js_runtime_state
+      #with_self
+
       let #result = {
         #(#call_args)*
-        Self::call(#(#call_names),*)
+        #call (#(#call_names),*)
       };
       #handle_error
       #handle_result

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -696,13 +696,14 @@ pub fn call(generator_state: &mut GeneratorState) -> TokenStream {
     tokens.extend(quote!( #arg , ));
   }
 
-  let self_ = if generator_state.needs_self {
-    quote!(self_.)
+  let name = &generator_state.name;
+  let call_ = if generator_state.needs_self {
+    quote!(self_. #name)
   } else {
-    quote!(Self::)
+    quote!(Self:: #name)
   };
 
-  quote!(#self_ call( #tokens ))
+  quote!(#call_ ( #tokens ))
 }
 
 pub fn return_value(

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -444,6 +444,10 @@ pub fn from_arg(
       *needs_js_runtime_state = true;
       quote!(let #arg_ident = &#js_runtime_state;)
     }
+    Arg::Ref(RefType::Ref, Special::OpCtx) => {
+      *needs_opctx = true;
+      quote!(let #arg_ident = #opctx;)
+    }
     Arg::State(RefType::Ref, state) => {
       *needs_opstate = true;
       let state =

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -243,9 +243,7 @@ pub(crate) fn with_js_runtime_state(
   )
 }
 
-pub(crate) fn with_self(
-  generator_state: &mut GeneratorState,
-) -> TokenStream {
+pub(crate) fn with_self(generator_state: &mut GeneratorState) -> TokenStream {
   generator_state.needs_opctx = true;
   gs_quote!(generator_state(fn_args, self_ty) =>
     (let self_: &#self_ty = unsafe { deno_core::cppgc::try_unwrap_cppgc_object(#fn_args.this().into()).unwrap() };)

--- a/ops/op2/generator_state.rs
+++ b/ops/op2/generator_state.rs
@@ -2,6 +2,7 @@
 use proc_macro2::Ident;
 
 pub struct GeneratorState {
+  pub name: Ident,
   /// Identifiers for each of the arguments of the original function
   pub args: Vec<Ident>,
   /// The result of the `call` function

--- a/ops/op2/generator_state.rs
+++ b/ops/op2/generator_state.rs
@@ -33,6 +33,8 @@ pub struct GeneratorState {
   pub fast_function_metrics: Ident,
   /// The async function promise ID argument
   pub promise_id: Ident,
+  /// Type of the self argument
+  pub self_ty: Ident,
 
   pub needs_args: bool,
   pub needs_retval: bool,
@@ -44,6 +46,7 @@ pub struct GeneratorState {
   pub needs_fast_opctx: bool,
   pub needs_fast_api_callback_options: bool,
   pub needs_fast_js_runtime_state: bool,
+  pub needs_self: bool,
 }
 
 /// Quotes a set of generator_state fields, along with variables captured from

--- a/ops/op2/mod.rs
+++ b/ops/op2/mod.rs
@@ -130,7 +130,7 @@ fn generate_op2(
     args.push(input);
     needs_args = true;
   }
-    
+
   let name = op_fn.sig.ident.clone();
   let retval = Ident::new("rv", Span::call_site());
   let result = Ident::new("result", Span::call_site());
@@ -149,9 +149,11 @@ fn generate_op2(
     Ident::new("v8_fn_ptr_fast_metrics", Span::call_site());
   let fast_api_callback_options =
     Ident::new("fast_api_callback_options", Span::call_site());
-  let self_ty = if let Some(ref ty) = config.method { 
-      format_ident!("{ty}")
-  } else { Ident::new("UNINIT", Span::call_site()) };
+  let self_ty = if let Some(ref ty) = config.method {
+    format_ident!("{ty}")
+  } else {
+    Ident::new("UNINIT", Span::call_site())
+  };
 
   let mut generator_state = GeneratorState {
     name,
@@ -306,15 +308,16 @@ fn generate_op2(
   };
 
   if *needs_self {
+    let register = format_ident!("register_{name}");
     return Ok(quote! {
-        pub fn register() {
+        pub fn #register() {
             #t
         }
 
         #[inline(always)]
         #(#attrs)*
         #op_fn
-    })
+    });
   }
 
   Ok(t)

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -989,7 +989,8 @@ pub fn parse_signature(
   let mut names = vec![];
   for input in signature.inputs {
     let name = match &input {
-      FnArg::Receiver(_) => "self".to_owned(),
+      // Skip reciever
+      FnArg::Receiver(_) => continue,
       FnArg::Typed(ty) => match &*ty.pat {
         Pat::Ident(ident) => ident.ident.to_string(),
         _ => "(complex)".to_owned(),

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -145,6 +145,7 @@ pub enum Special {
   HandleScope,
   OpState,
   JsRuntimeState,
+  OpCtx,
   FastApiCallbackOptions,
   Isolate,
 }
@@ -351,6 +352,7 @@ impl Arg {
         Special::FastApiCallbackOptions
         | Special::OpState
         | Special::JsRuntimeState
+        | Special::OpCtx
         | Special::HandleScope
         | Special::Isolate,
       ) => true,
@@ -359,6 +361,7 @@ impl Arg {
         Special::FastApiCallbackOptions
         | Special::OpState
         | Special::JsRuntimeState
+        | Special::OpCtx
         | Special::HandleScope,
       ) => true,
       Self::RcRefCell(
@@ -1346,6 +1349,7 @@ fn parse_type_path(
       }
       ( OpState ) => Ok(CBare(TSpecial(Special::OpState))),
       ( JsRuntimeState ) => Ok(CBare(TSpecial(Special::JsRuntimeState))),
+      ( OpCtx ) => Ok(CBare(TSpecial(Special::OpCtx))),
       ( v8 :: Isolate ) => Ok(CBare(TSpecial(Special::Isolate))),
       ( v8 :: HandleScope $( < $_scope:lifetime >)? ) => Ok(CBare(TSpecial(Special::HandleScope))),
       ( v8 :: FastApiCallbackOptions ) => Ok(CBare(TSpecial(Special::FastApiCallbackOptions))),
@@ -1385,7 +1389,9 @@ fn parse_type_path(
   // the easiest way to work with the 'rules!' macro above.
   match res {
     // OpState and JsRuntimeState appears in both ways
-    CBare(TSpecial(Special::OpState | Special::JsRuntimeState)) => {}
+    CBare(TSpecial(
+      Special::OpState | Special::JsRuntimeState | Special::OpCtx,
+    )) => {}
     CBare(
       TString(Strings::RefStr) | TSpecial(Special::HandleScope) | TV8(_),
     ) => {

--- a/ops/op2/test_cases/async/async_deferred.out
+++ b/ops/op2/test_cases/async/async_deferred.out
@@ -68,7 +68,7 @@ impl op_async_deferred {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         promise_id: i32,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {

--- a/ops/op2/test_cases/async/async_lazy.out
+++ b/ops/op2/test_cases/async/async_lazy.out
@@ -68,7 +68,7 @@ impl op_async_lazy {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         promise_id: i32,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -69,7 +69,7 @@ impl op_add {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: u32,
         arg1: u32,
     ) -> u32 {

--- a/ops/op2/test_cases/sync/bigint.out
+++ b/ops/op2/test_cases/sync/bigint.out
@@ -66,7 +66,9 @@ impl op_bigint {
         res
     }
     #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> u64 {
+    extern "C" fn v8_fn_ptr_fast(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+    ) -> u64 {
         #[cfg(debug_assertions)]
         let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
             &<Self as deno_core::_ops::Op>::DECL,

--- a/ops/op2/test_cases/sync/bool.out
+++ b/ops/op2/test_cases/sync/bool.out
@@ -68,7 +68,7 @@ impl op_bool {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: bool,
     ) -> bool {
         #[cfg(debug_assertions)]

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -68,7 +68,7 @@ impl op_bool {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: bool,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> bool {

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -84,7 +84,7 @@ impl op_buffers {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
         arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
         arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
@@ -351,7 +351,7 @@ impl op_buffers_32 {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
         arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
         arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -81,7 +81,7 @@ impl op_buffers {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
         arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
         arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
@@ -300,7 +300,7 @@ impl op_buffers_32 {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
         arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
     ) -> () {

--- a/ops/op2/test_cases/sync/cfg.out
+++ b/ops/op2/test_cases/sync/cfg.out
@@ -68,7 +68,9 @@ impl op_maybe_windows {
         res
     }
     #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
+    extern "C" fn v8_fn_ptr_fast(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+    ) -> () {
         #[cfg(debug_assertions)]
         let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
             &<Self as deno_core::_ops::Op>::DECL,
@@ -193,7 +195,9 @@ impl op_maybe_windows {
         res
     }
     #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
+    extern "C" fn v8_fn_ptr_fast(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+    ) -> () {
         #[cfg(debug_assertions)]
         let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
             &<Self as deno_core::_ops::Op>::DECL,

--- a/ops/op2/test_cases/sync/clippy_allow.out
+++ b/ops/op2/test_cases/sync/clippy_allow.out
@@ -68,7 +68,9 @@ impl op_extra_annotation {
         res
     }
     #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
+    extern "C" fn v8_fn_ptr_fast(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+    ) -> () {
         #[cfg(debug_assertions)]
         let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
             &<Self as deno_core::_ops::Op>::DECL,
@@ -191,7 +193,9 @@ impl op_clippy_internal {
         res
     }
     #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
+    extern "C" fn v8_fn_ptr_fast(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+    ) -> () {
         #[cfg(debug_assertions)]
         let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
             &<Self as deno_core::_ops::Op>::DECL,

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -68,7 +68,7 @@ impl op_file {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: deno_core::v8::Local<deno_core::v8::Value>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {

--- a/ops/op2/test_cases/sync/doc_comment.out
+++ b/ops/op2/test_cases/sync/doc_comment.out
@@ -67,7 +67,9 @@ impl op_has_doc_comment {
         res
     }
     #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
+    extern "C" fn v8_fn_ptr_fast(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+    ) -> () {
         #[cfg(debug_assertions)]
         let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
             &<Self as deno_core::_ops::Op>::DECL,

--- a/ops/op2/test_cases/sync/fast_alternative.out
+++ b/ops/op2/test_cases/sync/fast_alternative.out
@@ -177,7 +177,7 @@ impl op_fast {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: u32,
         arg1: u32,
     ) -> u32 {
@@ -451,7 +451,7 @@ impl<T: Trait> op_fast_generic<T> {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: u32,
         arg1: u32,
     ) -> u32 {

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -66,7 +66,9 @@ impl<T: Trait> op_generics<T> {
         res
     }
     #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
+    extern "C" fn v8_fn_ptr_fast(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+    ) -> () {
         #[cfg(debug_assertions)]
         let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
             &<Self as deno_core::_ops::Op>::DECL,
@@ -187,7 +189,9 @@ impl<T: Trait + 'static> op_generics_static<T> {
         res
     }
     #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
+    extern "C" fn v8_fn_ptr_fast(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+    ) -> () {
         #[cfg(debug_assertions)]
         let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
             &<Self as deno_core::_ops::Op>::DECL,
@@ -308,7 +312,9 @@ impl<T: Trait + 'static> op_generics_static_where<T> {
         res
     }
     #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
+    extern "C" fn v8_fn_ptr_fast(
+        this: deno_core::v8::Local<deno_core::v8::Object>,
+    ) -> () {
         #[cfg(debug_assertions)]
         let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
             &<Self as deno_core::_ops::Op>::DECL,

--- a/ops/op2/test_cases/sync/op_state_attr.out
+++ b/ops/op2/test_cases/sync/op_state_attr.out
@@ -67,7 +67,7 @@ impl op_state_rc {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         #[cfg(debug_assertions)]

--- a/ops/op2/test_cases/sync/op_state_rc.out
+++ b/ops/op2/test_cases/sync/op_state_rc.out
@@ -67,7 +67,7 @@ impl op_state_rc {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         #[cfg(debug_assertions)]

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -67,7 +67,7 @@ impl op_state_ref {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         #[cfg(debug_assertions)]
@@ -212,7 +212,7 @@ impl op_state_mut {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         #[cfg(debug_assertions)]
@@ -459,7 +459,7 @@ impl op_state_and_v8_local {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg1: deno_core::v8::Local<deno_core::v8::Value>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {

--- a/ops/op2/test_cases/sync/result_external.out
+++ b/ops/op2/test_cases/sync/result_external.out
@@ -67,7 +67,7 @@ impl op_external_with_result {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> *mut ::std::ffi::c_void {
         #[cfg(debug_assertions)]

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -67,7 +67,7 @@ impl op_u32_with_result {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> u32 {
         #[cfg(debug_assertions)]

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -67,7 +67,7 @@ impl op_void_with_result {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
     ) -> () {
         #[cfg(debug_assertions)]

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -78,7 +78,7 @@ impl op_smi_unsigned_return {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: i32,
         arg1: i32,
         arg2: i32,
@@ -291,7 +291,7 @@ impl op_smi_signed_return {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: i32,
         arg1: i32,
         arg2: i32,

--- a/ops/op2/test_cases/sync/string_cow.out
+++ b/ops/op2/test_cases/sync/string_cow.out
@@ -68,7 +68,7 @@ impl op_string_cow {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
     ) -> u32 {
         #[cfg(debug_assertions)]

--- a/ops/op2/test_cases/sync/string_onebyte.out
+++ b/ops/op2/test_cases/sync/string_onebyte.out
@@ -68,7 +68,7 @@ impl op_string_onebyte {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
     ) -> u32 {
         #[cfg(debug_assertions)]

--- a/ops/op2/test_cases/sync/string_owned.out
+++ b/ops/op2/test_cases/sync/string_owned.out
@@ -68,7 +68,7 @@ impl op_string_owned {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
     ) -> u32 {
         #[cfg(debug_assertions)]

--- a/ops/op2/test_cases/sync/string_ref.out
+++ b/ops/op2/test_cases/sync/string_ref.out
@@ -68,7 +68,7 @@ impl op_string_owned {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
     ) -> u32 {
         #[cfg(debug_assertions)]

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -69,7 +69,7 @@ impl op_v8_lifetime {
     }
     #[allow(clippy::too_many_arguments)]
     extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
+        this: deno_core::v8::Local<deno_core::v8::Object>,
         arg0: deno_core::v8::Local<deno_core::v8::Value>,
         arg1: deno_core::v8::Local<deno_core::v8::Value>,
         fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,

--- a/testing/checkin/runner/mod.rs
+++ b/testing/checkin/runner/mod.rs
@@ -46,6 +46,7 @@ deno_core::extension!(
     ops::op_stats_diff,
     ops::op_stats_dump,
     ops::op_stats_delete,
+    ops::op_stateful_new,
     ops_io::op_pipe_create,
     ops_io::op_file_open,
     ops_async::op_async_yield,

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -76,3 +76,15 @@ pub fn op_stats_delete(
 ) {
   test_data.take::<RuntimeActivityStats>(name);
 }
+
+struct Stateful {
+    name: String,
+}
+
+impl Stateful {
+    #[op2(method(Stateful))]
+    #[string]
+    fn get_name(&self) -> String {
+       self.name.clone()
+    }
+}

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -9,8 +9,8 @@ use deno_core::stats::RuntimeActivityStats;
 use deno_core::stats::RuntimeActivityStatsFactory;
 use deno_core::stats::RuntimeActivityStatsFilter;
 use deno_core::v8;
-use deno_core::OpState;
 use deno_core::OpCtx;
+use deno_core::OpState;
 
 use super::testing::Output;
 use super::testing::TestData;

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -10,6 +10,7 @@ use deno_core::stats::RuntimeActivityStatsFactory;
 use deno_core::stats::RuntimeActivityStatsFilter;
 use deno_core::v8;
 use deno_core::OpState;
+use deno_core::OpCtx;
 
 use super::testing::Output;
 use super::testing::TestData;
@@ -77,7 +78,7 @@ pub fn op_stats_delete(
   test_data.take::<RuntimeActivityStats>(name);
 }
 
-struct Stateful {
+pub struct Stateful {
   name: String,
 }
 
@@ -98,4 +99,17 @@ impl Stateful {
   async fn async_method(&self) -> String {
     self.name.clone()
   }
+}
+
+#[op2]
+pub fn op_stateful_new<'a>(
+  scope: &mut v8::HandleScope<'a>,
+  ctx: &OpCtx,
+  #[string] name: String,
+) -> v8::Local<'a, v8::Object> {
+  let obj = deno_core::cppgc::make_cppgc_object(scope, Stateful { name });
+  Stateful::register_get_name(scope, ctx, obj);
+  Stateful::register_print_name(scope, ctx, obj);
+  Stateful::register_async_method(scope, ctx, obj);
+  obj
 }

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -78,13 +78,24 @@ pub fn op_stats_delete(
 }
 
 struct Stateful {
-    name: String,
+  name: String,
 }
 
 impl Stateful {
-    #[op2(method(Stateful))]
-    #[string]
-    fn get_name(&self) -> String {
-       self.name.clone()
-    }
+  #[op2(method(Stateful))]
+  #[string]
+  fn get_name(&self) -> String {
+    self.name.clone()
+  }
+
+  #[op2(fast, method(Stateful))]
+  fn print_name(&self) {
+    println!("{}", self.name);
+  }
+
+  #[op2(async, method(Stateful))]
+  #[string]
+  async fn async_method(&self) -> String {
+    self.name.clone()
+  }
 }

--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -64,7 +64,7 @@ test(async function testCppgcAsync() {
   assertEquals(await op_async_get_cppgc_resource(resource), 42);
 });
 
-test(async function testCppgcObjectMethods() {
+test(function testCppgcObjectMethods() {
   const obj = op_stateful_new("A");
   const name = obj.get_name();
 

--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -6,6 +6,7 @@ const {
   op_file_open,
   op_async_make_cppgc_resource,
   op_async_get_cppgc_resource,
+  op_stateful_new,
 } = Deno.core.ops;
 
 test(async function testPipe() {
@@ -61,4 +62,12 @@ test(async function testFileIsNotTerminal() {
 test(async function testCppgcAsync() {
   const resource = await op_async_make_cppgc_resource();
   assertEquals(await op_async_get_cppgc_resource(resource), 42);
+});
+
+test(async function testCppgcObjectMethods() {
+  const obj = op_stateful_new("A");
+  const name = obj.get_name();
+
+  assertEquals(name, "A");
+  obj.print_name();
 });


### PR DESCRIPTION
Introducing op2++ (a.k.a `op2` for object methods). 

op2++ is to op2 as C++ is to C.

This patch introduces a small extension on top of the existing op2 codegen infrastructure to enable writing cppgc object methods in Rust:

```rust
pub struct City {
  name: String,
}

impl City {
  #[op2(method(City))]
  #[string]
  fn get_name(&self) -> String {
    self.name.clone()
  }

  #[op2(fast, method(City))]
  fn print_name(&self) {
    println!("{}", self.name);
  }
}

#[op2]
pub fn op_city_new<'a>(
  scope: &mut v8::HandleScope<'a>,
  ctx: &OpCtx,
  #[string] name: String,
) -> v8::Local<'a, v8::Object> {
  let obj = deno_core::cppgc::make_cppgc_object(scope, City { name });
  City::register_get_name(scope, ctx, obj);
  City::register_print_name(scope, ctx, obj);
  obj
}
```

```ts
import { op_city_new } from "ext:core/ops";

const city = op_city_new("Pune");
city.print_name();

const name = city.get_name();
```

Notable changes:
- Added `&OpCtx` as argument, required for registration of methods.
- New attribute `method(Type)` where Type is the `type` of the reciever `self`. Due to the independent nature of op2 codegen we need to know the concrete type. 
- Generate registration methods `Type::register_op` that can be called to register the method onto a Cppgc object.

Future work could make these constructors transparent by processing `impl`s.