### PR TITLE
Use `const fn` for op declaration

### DIFF
--- a/core/examples/hello_world.rs
+++ b/core/examples/hello_world.rs
@@ -16,9 +16,10 @@ fn op_sum(#[serde] nums: Vec<f64>) -> Result<f64, deno_core::error::AnyError> {
 
 fn main() {
   // Build a deno_core::Extension providing custom ops
+  const DECL: OpDecl = op_sum();
   let ext = Extension {
     name: "my_ext",
-    ops: std::borrow::Cow::Borrowed(&[op_sum::DECL]),
+    ops: std::borrow::Cow::Borrowed(&[DECL]),
     ..Default::default()
   };
 

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -322,7 +322,7 @@ macro_rules! ops {
       vec![
       $(
         $( #[ $m ] )*
-        $( $op )::+ :: decl $( :: <$op_param> )? () ,
+        $( $op )+ $( :: <$op_param> )? () ,
       )+
       ]
     }
@@ -331,7 +331,7 @@ macro_rules! ops {
     pub(crate) fn $name() -> ::std::Vec<$crate::OpDecl> {
       use $crate::Op;
       vec![
-        $( $( #[ $m ] )* $( $op )::+ :: DECL, )+
+        $( $( #[ $m ] )* $( $op )+() , )+
       ]
     }
   }
@@ -450,10 +450,11 @@ macro_rules! extension {
             const V: ::std::option::Option<&'static ::std::primitive::str> = $crate::or!($(::std::option::Option::Some($esm_entry_point))?, ::std::option::Option::None);
             V
           },
-          ops: ::std::borrow::Cow::Borrowed(&[$($(
+          ops: ::std::borrow::Cow::Borrowed(&[$($({
             $( #[ $m ] )*
-            $( $op )::+ $( :: < $($op_param),* > )? :: DECL
-          ),+)?]),
+            const DECL: $crate::OpDecl =  $( $op )::+ $( :: < $($op_param),* > )? ();
+            DECL
+          }),+)?]),
           external_references: ::std::borrow::Cow::Borrowed(&[ $( $external_reference ),* ]),
           global_template_middleware: ::std::option::Option::None,
           global_object_middleware: ::std::option::Option::None,

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -10,7 +10,6 @@ use crate::ops_builtin_types;
 use crate::ops_builtin_v8;
 use crate::CancelHandle;
 use crate::JsBuffer;
-use crate::Op;
 use crate::OpDecl;
 use crate::OpState;
 use crate::Resource;
@@ -26,7 +25,7 @@ use std::rc::Rc;
 macro_rules! builtin_ops {
   ( $($op:ident $(:: $sub:ident)*),* ) => {
     pub const BUILTIN_OPS: &'static [OpDecl] = &[
-      $( $op $(:: $sub)*::DECL, )*
+      $( $op $(:: $sub) * () ),*
     ];
   }
 }

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 use crate::error::AnyError;
-use crate::extensions::Op;
 use crate::extensions::OpDecl;
 use crate::modules::StaticModuleLoader;
 use crate::runtime::tests::setup;
@@ -196,7 +195,7 @@ fn test_op_disabled() {
   }
 
   fn ops() -> Vec<OpDecl> {
-    vec![op_foo::DECL.disable()]
+    vec![op_foo().disable()]
   }
 
   deno_core::extension!(test_ext, ops_fn = ops);

--- a/core/runtime/tests/snapshot.rs
+++ b/core/runtime/tests/snapshot.rs
@@ -1,5 +1,4 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-use crate::extensions::Op;
 use crate::modules::ModuleInfo;
 use crate::modules::RequestedModuleType;
 use crate::runtime::NO_OF_BUILTIN_MODULES;
@@ -236,11 +235,10 @@ fn es_snapshot() {
   fn op_test() -> Result<String, Error> {
     Ok(String::from("test"))
   }
-
   let mut runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
     extensions: vec![Extension {
       name: "test_ext",
-      ops: Cow::Borrowed(&[op_test::DECL]),
+      ops: Cow::Borrowed(&[DECL]),
       ..Default::default()
     }],
     ..Default::default()
@@ -278,7 +276,7 @@ fn es_snapshot() {
     startup_snapshot: Some(snapshot),
     extensions: vec![Extension {
       name: "test_ext",
-      ops: Cow::Borrowed(&[op_test::DECL]),
+      ops: Cow::Borrowed(&[DECL]),
       ..Default::default()
     }],
     ..Default::default()
@@ -294,11 +292,12 @@ fn es_snapshot() {
   let snapshot2 = runtime2.snapshot();
   let snapshot2 = Box::leak(snapshot2);
 
+  const DECL: OpDecl = op_test();
   let mut runtime3 = JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(snapshot2),
     extensions: vec![Extension {
       name: "test_ext",
-      ops: Cow::Borrowed(&[op_test::DECL]),
+      ops: Cow::Borrowed(&[DECL]),
       ..Default::default()
     }],
     ..Default::default()

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -375,8 +375,8 @@ pub(crate) fn generate_dispatch_fast(
     let alternative =
       syn::parse_str::<Type>(alternative).expect("Failed to reparse type");
     return Ok(Some((
-      quote!(#alternative::DECL.fast_fn()),
-      quote!(#alternative::DECL.fast_fn_with_metrics()),
+      quote!(#alternative().fast_fn()),
+      quote!(#alternative().fast_fn_with_metrics()),
       quote!(),
     )));
   }

--- a/ops/op2/mod.rs
+++ b/ops/op2/mod.rs
@@ -244,46 +244,51 @@ fn generate_op2(
 
   Ok(quote! {
     #[allow(non_camel_case_types)]
-    #(#attrs)*
-    #vis struct #name <#(#generic),*> {
-      // We need to mark these type parameters as used, so we use a PhantomData
-      _unconstructable: ::std::marker::PhantomData<(#(#generic),*)>
-    }
-
-    impl <#(#generic : #bound),*> ::deno_core::_ops::Op for #name <#(#generic),*> {
-      const NAME: &'static str = stringify!(#name);
-      const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        /*name*/ ::deno_core::__op_name_fast!(#name),
-        /*is_async*/ #is_async,
-        /*is_reentrant*/ #is_reentrant,
-        /*arg_count*/ #arg_count as u8,
-        /*slow_fn*/ Self::#slow_function as _,
-        /*slow_fn_metrics*/ Self::#slow_function_metrics as _,
-        /*fast_fn*/ #fast_definition,
-        /*fast_fn_metrics*/ #fast_definition_metrics,
-        /*metadata*/ ::deno_core::OpMetadata {
-          #(#meta_key: Some(#meta_value),)*
-          ..::deno_core::OpMetadata::default()
-        },
-      );
-    }
-
-    impl <#(#generic : #bound),*> #name <#(#generic),*> {
-      pub const fn name() -> &'static str {
-        stringify!(#name)
-      }
-
-      #[deprecated(note = "Use the const op::DECL instead")]
-      pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-      }
-
-      #fast_fn
-      #slow_fn
-
-      #[inline(always)]
+    #vis const fn #name <#(#generic : #bound),*> () -> ::deno_core::_ops::OpDecl {
+      #[allow(non_camel_case_types)]
       #(#attrs)*
-      #op_fn
+      #vis struct #name <#(#generic),*> {
+        // We need to mark these type parameters as used, so we use a PhantomData
+        _unconstructable: ::std::marker::PhantomData<(#(#generic),*)>
+      }
+
+      impl <#(#generic : #bound),*> ::deno_core::_ops::Op for #name <#(#generic),*> {
+        const NAME: &'static str = stringify!(#name);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+          /*name*/ ::deno_core::__op_name_fast!(#name),
+          /*is_async*/ #is_async,
+          /*is_reentrant*/ #is_reentrant,
+          /*arg_count*/ #arg_count as u8,
+          /*slow_fn*/ Self::#slow_function as _,
+          /*slow_fn_metrics*/ Self::#slow_function_metrics as _,
+          /*fast_fn*/ #fast_definition,
+          /*fast_fn_metrics*/ #fast_definition_metrics,
+          /*metadata*/ ::deno_core::OpMetadata {
+            #(#meta_key: Some(#meta_value),)*
+            ..::deno_core::OpMetadata::default()
+          },
+        );
+      }
+
+      impl <#(#generic : #bound),*> #name <#(#generic),*> {
+        pub const fn name() -> &'static str {
+          stringify!(#name)
+        }
+
+       #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+          <Self as deno_core::_ops::Op>::DECL
+        }
+
+        #fast_fn
+        #slow_fn
+
+        #[inline(always)]
+        #(#attrs)*
+        #op_fn
+      }
+
+      <#name <#(#generic),*>  as ::deno_core::_ops::Op>::DECL
     }
   })
 }

--- a/ops/op2/mod.rs
+++ b/ops/op2/mod.rs
@@ -275,11 +275,6 @@ fn generate_op2(
           stringify!(#name)
         }
 
-       #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-          <Self as deno_core::_ops::Op>::DECL
-        }
-
         #fast_fn
         #slow_fn
 

--- a/ops/op2/test_cases/async/async_arg_return.out
+++ b/ops/op2/test_cases/async/async_arg_return.out
@@ -24,10 +24,6 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_async)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,

--- a/ops/op2/test_cases/async/async_arg_return.out
+++ b/ops/op2/test_cases/async/async_arg_return.out
@@ -1,109 +1,117 @@
 #[allow(non_camel_case_types)]
-pub struct op_async {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_async {
-    const NAME: &'static str = stringify!(op_async);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_async),
-        true,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_async {
-    pub const fn name() -> &'static str {
-        stringify!(op_async)
+pub const fn op_async() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_async {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_async {
+        const NAME: &'static str = stringify!(op_async);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_async),
+            true,
+            false,
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let result = {
-            let arg0 = args.get(1usize as i32);
-            let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected i32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
+    }
+    impl op_async {
+        pub const fn name() -> &'static str {
+            stringify!(op_async)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
             };
-            let arg0 = arg0 as _;
-            Self::call(arg0)
-        };
-        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
-            .unwrap_or_default();
-        if let Some(result) = deno_core::_ops::map_async_op_infallible(
-            opctx,
-            false,
-            false,
-            promise_id,
-            result,
-            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            let result = {
+                let arg0 = args.get(1usize as i32);
+                let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected i32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg0 = arg0 as _;
+                Self::call(arg0)
+            };
+            let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+                .unwrap_or_default();
+            if let Some(result) = deno_core::_ops::map_async_op_infallible(
+                opctx,
+                false,
+                false,
+                promise_id,
+                result,
+                |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            ) {
+                deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+                return 0;
+            }
+            return 2;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-            return 0;
-        }
-        return 2;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_async(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else if res == 1 {
-            deno_core::_ops::dispatch_metrics_async(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else if res == 1 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub async fn call(x: i32) -> i32 {
+            x
         }
     }
-    #[inline(always)]
-    pub async fn call(x: i32) -> i32 {
-        x
-    }
+    <op_async as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/async/async_arg_return_result.out
+++ b/ops/op2/test_cases/async/async_arg_return_result.out
@@ -24,10 +24,6 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_async)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,

--- a/ops/op2/test_cases/async/async_arg_return_result.out
+++ b/ops/op2/test_cases/async/async_arg_return_result.out
@@ -1,122 +1,134 @@
 #[allow(non_camel_case_types)]
-pub struct op_async {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_async {
-    const NAME: &'static str = stringify!(op_async);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_async),
-        true,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_async {
-    pub const fn name() -> &'static str {
-        stringify!(op_async)
+pub const fn op_async() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_async {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_async {
+        const NAME: &'static str = stringify!(op_async);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_async),
+            true,
+            false,
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let result = {
-            let arg0 = args.get(1usize as i32);
-            let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected i32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
+    }
+    impl op_async {
+        pub const fn name() -> &'static str {
+            stringify!(op_async)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
             };
-            let arg0 = arg0 as _;
-            Self::call(arg0)
-        };
-        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
-            .unwrap_or_default();
-        if let Some(result) = deno_core::_ops::map_async_op_fallible(
-            opctx,
-            false,
-            false,
-            promise_id,
-            result,
-            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
-        ) {
-            match result {
-                Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
-                Err(err) => {
+            let result = {
+                let arg0 = args.get(1usize as i32);
+                let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let err = err.into();
-                    let exception = deno_core::error::to_v8_error(
-                        &mut scope,
-                        opctx.get_error_class_fn,
-                        &err,
-                    );
-                    scope.throw_exception(exception);
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected i32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
                     return 1;
-                }
+                };
+                let arg0 = arg0 as _;
+                Self::call(arg0)
             };
-            return 0;
+            let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+                .unwrap_or_default();
+            if let Some(result) = deno_core::_ops::map_async_op_fallible(
+                opctx,
+                false,
+                false,
+                promise_id,
+                result,
+                |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            ) {
+                match result {
+                    Ok(result) => {
+                        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+                    }
+                    Err(err) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let err = err.into();
+                        let exception = deno_core::error::to_v8_error(
+                            &mut scope,
+                            opctx.get_error_class_fn,
+                            &err,
+                        );
+                        scope.throw_exception(exception);
+                        return 1;
+                    }
+                };
+                return 0;
+            }
+            return 2;
         }
-        return 2;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_async(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else if res == 1 {
-            deno_core::_ops::dispatch_metrics_async(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else if res == 1 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub async fn call(x: i32) -> std::io::Result<i32> {
+            Ok(x)
         }
     }
-    #[inline(always)]
-    pub async fn call(x: i32) -> std::io::Result<i32> {
-        Ok(x)
-    }
+    <op_async as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/async/async_deferred.out
+++ b/ops/op2/test_cases/async/async_deferred.out
@@ -1,157 +1,165 @@
 #[allow(non_camel_case_types)]
-pub struct op_async_deferred {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_async_deferred {
-    const NAME: &'static str = stringify!(op_async_deferred);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_async_deferred),
-        true,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::Int32, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::Int32, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_async_deferred {
-    pub const fn name() -> &'static str {
-        stringify!(op_async_deferred)
+pub const fn op_async_deferred() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_async_deferred {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        promise_id: i32,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, promise_id, fast_api_callback_options);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        promise_id: i32,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        let result = { Self::call() };
-        deno_core::_ops::map_async_op_fallible(
-            opctx,
-            false,
+    impl ::deno_core::_ops::Op for op_async_deferred {
+        const NAME: &'static str = stringify!(op_async_deferred);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_async_deferred),
             true,
-            promise_id,
-            result,
-            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
-        );
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let result = { Self::call() };
-        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
-            .unwrap_or_default();
-        deno_core::_ops::map_async_op_fallible(
-            opctx,
             false,
-            true,
-            promise_id,
-            result,
-            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::Int32, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::Int32, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        return 2;
     }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_async(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_async(
+    impl op_async_deferred {
+        pub const fn name() -> &'static str {
+            stringify!(op_async_deferred)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            promise_id: i32,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, promise_id, fast_api_callback_options);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else if res == 1 {
-            deno_core::_ops::dispatch_metrics_async(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            promise_id: i32,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = { Self::call() };
+            deno_core::_ops::map_async_op_fallible(
+                opctx,
+                false,
+                true,
+                promise_id,
+                result,
+                |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
             );
         }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = { Self::call() };
+            let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+                .unwrap_or_default();
+            deno_core::_ops::map_async_op_fallible(
+                opctx,
+                false,
+                true,
+                promise_id,
+                result,
+                |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            );
+            return 2;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_async(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else if res == 1 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub async fn call() -> std::io::Result<i32> {
+            Ok(0)
+        }
     }
-    #[inline(always)]
-    pub async fn call() -> std::io::Result<i32> {
-        Ok(0)
-    }
+    <op_async_deferred as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/async/async_deferred.out
+++ b/ops/op2/test_cases/async/async_deferred.out
@@ -40,10 +40,6 @@ pub const fn op_async_deferred() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_async_deferred)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/async/async_jsbuffer.out
+++ b/ops/op2/test_cases/async/async_jsbuffer.out
@@ -1,128 +1,141 @@
 #[allow(non_camel_case_types)]
-pub struct op_async_v8_buffer {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_async_v8_buffer {
-    const NAME: &'static str = stringify!(op_async_v8_buffer);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_async_v8_buffer),
-        true,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_async_v8_buffer {
-    pub const fn name() -> &'static str {
-        stringify!(op_async_v8_buffer)
+pub const fn op_async_v8_buffer() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_async_v8_buffer {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let result = {
-            let arg0 = args.get(1usize as i32);
-            let mut arg0_temp;
-            arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
-                Ok(arg0) => arg0,
-                Err(arg0_err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            arg0_err.as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
-                    return 1;
-                }
-            };
-            let arg0 = deno_core::serde_v8::JsBuffer::from_parts(arg0_temp);
-            Self::call(arg0)
-        };
-        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
-            .unwrap_or_default();
-        if let Some(result) = deno_core::_ops::map_async_op_infallible(
-            opctx,
+    impl ::deno_core::_ops::Op for op_async_v8_buffer {
+        const NAME: &'static str = stringify!(op_async_v8_buffer);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_async_v8_buffer),
+            true,
             false,
-            false,
-            promise_id,
-            result,
-            |scope, result| {
-                deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, scope)
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
             },
-        ) {
-            match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
-                Ok(v) => rv.set(v),
-                Err(rv_err) => {
-                    let msg = deno_core::v8::String::new(
-                            &mut scope,
-                            &format!("{}", deno_core::anyhow::Error::from(rv_err)),
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
-                    return 1;
-                }
-            };
-            return 0;
-        }
-        return 2;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_async(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+    }
+    impl op_async_v8_buffer {
+        pub const fn name() -> &'static str {
+            stringify!(op_async_v8_buffer)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = {
+                let arg0 = args.get(1usize as i32);
+                let mut arg0_temp;
+                arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
+                    Ok(arg0) => arg0,
+                    Err(arg0_err) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let msg = deno_core::v8::String::new_from_one_byte(
+                                &mut scope,
+                                arg0_err.as_bytes(),
+                                deno_core::v8::NewStringType::Normal,
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    }
+                };
+                let arg0 = deno_core::serde_v8::JsBuffer::from_parts(arg0_temp);
+                Self::call(arg0)
+            };
+            let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+                .unwrap_or_default();
+            if let Some(result) = deno_core::_ops::map_async_op_infallible(
+                opctx,
+                false,
+                false,
+                promise_id,
+                result,
+                |scope, result| {
+                    deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, scope)
+                },
+            ) {
+                match deno_core::_ops::RustToV8Fallible::to_v8_fallible(
+                    result,
+                    &mut scope,
+                ) {
+                    Ok(v) => rv.set(v),
+                    Err(rv_err) => {
+                        let msg = deno_core::v8::String::new(
+                                &mut scope,
+                                &format!("{}", deno_core::anyhow::Error::from(rv_err)),
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    }
+                };
+                return 0;
+            }
+            return 2;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else if res == 1 {
-            deno_core::_ops::dispatch_metrics_async(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else if res == 1 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub async fn call(buf: JsBuffer) -> JsBuffer {
+            buf
         }
     }
-    #[inline(always)]
-    pub async fn call(buf: JsBuffer) -> JsBuffer {
-        buf
-    }
+    <op_async_v8_buffer as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/async/async_jsbuffer.out
+++ b/ops/op2/test_cases/async/async_jsbuffer.out
@@ -24,10 +24,6 @@ pub const fn op_async_v8_buffer() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_async_v8_buffer)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,

--- a/ops/op2/test_cases/async/async_lazy.out
+++ b/ops/op2/test_cases/async/async_lazy.out
@@ -1,157 +1,165 @@
 #[allow(non_camel_case_types)]
-pub struct op_async_lazy {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_async_lazy {
-    const NAME: &'static str = stringify!(op_async_lazy);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_async_lazy),
-        true,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::Int32, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::Int32, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_async_lazy {
-    pub const fn name() -> &'static str {
-        stringify!(op_async_lazy)
+pub const fn op_async_lazy() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_async_lazy {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        promise_id: i32,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, promise_id, fast_api_callback_options);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        promise_id: i32,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        let result = { Self::call() };
-        deno_core::_ops::map_async_op_fallible(
-            opctx,
+    impl ::deno_core::_ops::Op for op_async_lazy {
+        const NAME: &'static str = stringify!(op_async_lazy);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_async_lazy),
             true,
             false,
-            promise_id,
-            result,
-            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::Int32, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::Int32, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
     }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let result = { Self::call() };
-        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
-            .unwrap_or_default();
-        deno_core::_ops::map_async_op_fallible(
-            opctx,
-            true,
-            false,
-            promise_id,
-            result,
-            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
-        );
-        return 2;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_async(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_async(
+    impl op_async_lazy {
+        pub const fn name() -> &'static str {
+            stringify!(op_async_lazy)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            promise_id: i32,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, promise_id, fast_api_callback_options);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else if res == 1 {
-            deno_core::_ops::dispatch_metrics_async(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            promise_id: i32,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = { Self::call() };
+            deno_core::_ops::map_async_op_fallible(
+                opctx,
+                true,
+                false,
+                promise_id,
+                result,
+                |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
             );
         }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = { Self::call() };
+            let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+                .unwrap_or_default();
+            deno_core::_ops::map_async_op_fallible(
+                opctx,
+                true,
+                false,
+                promise_id,
+                result,
+                |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            );
+            return 2;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_async(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else if res == 1 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub async fn call() -> std::io::Result<i32> {
+            Ok(0)
+        }
     }
-    #[inline(always)]
-    pub async fn call() -> std::io::Result<i32> {
-        Ok(0)
-    }
+    <op_async_lazy as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/async/async_lazy.out
+++ b/ops/op2/test_cases/async/async_lazy.out
@@ -40,10 +40,6 @@ pub const fn op_async_lazy() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_async_lazy)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/async/async_op_metadata.out
+++ b/ops/op2/test_cases/async/async_op_metadata.out
@@ -1,191 +1,207 @@
 #[allow(non_camel_case_types)]
-struct op_blob_read_part {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_blob_read_part {
-    const NAME: &'static str = stringify!(op_blob_read_part);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_blob_read_part),
-        true,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            sanitizer_details: Some("read from a Blob or File"),
-            sanitizer_fix: Some("awaiting the result of a Blob or File read"),
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_blob_read_part {
-    pub const fn name() -> &'static str {
-        stringify!(op_blob_read_part)
+const fn op_blob_read_part() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_blob_read_part {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_blob_read_part {
+        const NAME: &'static str = stringify!(op_blob_read_part);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_blob_read_part),
+            true,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                sanitizer_details: Some("read from a Blob or File"),
+                sanitizer_fix: Some("awaiting the result of a Blob or File read"),
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let result = { Self::call() };
-        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
-            .unwrap_or_default();
-        if let Some(result) = deno_core::_ops::map_async_op_infallible(
-            opctx,
-            false,
-            false,
-            promise_id,
-            result,
-            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+    }
+    impl op_blob_read_part {
+        pub const fn name() -> &'static str {
+            stringify!(op_blob_read_part)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = { Self::call() };
+            let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+                .unwrap_or_default();
+            if let Some(result) = deno_core::_ops::map_async_op_infallible(
+                opctx,
+                false,
+                false,
+                promise_id,
+                result,
+                |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            ) {
+                deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+                return 0;
+            }
+            return 2;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-            return 0;
-        }
-        return 2;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_async(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else if res == 1 {
-            deno_core::_ops::dispatch_metrics_async(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else if res == 1 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        async fn call() {
+            return;
         }
     }
-    #[inline(always)]
-    async fn call() {
-        return;
-    }
+    <op_blob_read_part as ::deno_core::_ops::Op>::DECL
 }
 
 #[allow(non_camel_case_types)]
-struct op_broadcast_recv {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_broadcast_recv {
-    const NAME: &'static str = stringify!(op_broadcast_recv);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_broadcast_recv),
-        true,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            sanitizer_details: Some("receive a message from a BroadcastChannel"),
-            sanitizer_fix: Some("closing the BroadcastChannel"),
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_broadcast_recv {
-    pub const fn name() -> &'static str {
-        stringify!(op_broadcast_recv)
+const fn op_broadcast_recv() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_broadcast_recv {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_broadcast_recv {
+        const NAME: &'static str = stringify!(op_broadcast_recv);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_broadcast_recv),
+            true,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                sanitizer_details: Some("receive a message from a BroadcastChannel"),
+                sanitizer_fix: Some("closing the BroadcastChannel"),
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let result = { Self::call() };
-        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
-            .unwrap_or_default();
-        if let Some(result) = deno_core::_ops::map_async_op_infallible(
-            opctx,
-            false,
-            false,
-            promise_id,
-            result,
-            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+    }
+    impl op_broadcast_recv {
+        pub const fn name() -> &'static str {
+            stringify!(op_broadcast_recv)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = { Self::call() };
+            let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+                .unwrap_or_default();
+            if let Some(result) = deno_core::_ops::map_async_op_infallible(
+                opctx,
+                false,
+                false,
+                promise_id,
+                result,
+                |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            ) {
+                deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+                return 0;
+            }
+            return 2;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-            return 0;
-        }
-        return 2;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_async(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else if res == 1 {
-            deno_core::_ops::dispatch_metrics_async(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else if res == 1 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        async fn call() {
+            return;
         }
     }
-    #[inline(always)]
-    async fn call() {
-        return;
-    }
+    <op_broadcast_recv as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/async/async_op_metadata.out
+++ b/ops/op2/test_cases/async/async_op_metadata.out
@@ -26,10 +26,6 @@ const fn op_blob_read_part() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_blob_read_part)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,
@@ -129,10 +125,6 @@ const fn op_broadcast_recv() -> ::deno_core::_ops::OpDecl {
     impl op_broadcast_recv {
         pub const fn name() -> &'static str {
             stringify!(op_broadcast_recv)
-        }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
         }
         #[inline(always)]
         fn slow_function_impl(

--- a/ops/op2/test_cases/async/async_opstate.out
+++ b/ops/op2/test_cases/async/async_opstate.out
@@ -24,10 +24,6 @@ pub const fn op_async_opstate() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_async_opstate)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,

--- a/ops/op2/test_cases/async/async_opstate.out
+++ b/ops/op2/test_cases/async/async_opstate.out
@@ -1,110 +1,122 @@
 #[allow(non_camel_case_types)]
-pub struct op_async_opstate {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_async_opstate {
-    const NAME: &'static str = stringify!(op_async_opstate);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_async_opstate),
-        true,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_async_opstate {
-    pub const fn name() -> &'static str {
-        stringify!(op_async_opstate)
+pub const fn op_async_opstate() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_async_opstate {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_async_opstate {
+        const NAME: &'static str = stringify!(op_async_opstate);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_async_opstate),
+            true,
+            false,
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let opstate = &opctx.state;
-        let result = {
-            let arg0 = opstate.clone();
-            Self::call(arg0)
-        };
-        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
-            .unwrap_or_default();
-        if let Some(result) = deno_core::_ops::map_async_op_fallible(
-            opctx,
-            false,
-            false,
-            promise_id,
-            result,
-            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
-        ) {
-            match result {
-                Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
-                Err(err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let err = err.into();
-                    let exception = deno_core::error::to_v8_error(
-                        &mut scope,
-                        opctx.get_error_class_fn,
-                        &err,
-                    );
-                    scope.throw_exception(exception);
-                    return 1;
-                }
+    }
+    impl op_async_opstate {
+        pub const fn name() -> &'static str {
+            stringify!(op_async_opstate)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
             };
-            return 0;
+            let opstate = &opctx.state;
+            let result = {
+                let arg0 = opstate.clone();
+                Self::call(arg0)
+            };
+            let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+                .unwrap_or_default();
+            if let Some(result) = deno_core::_ops::map_async_op_fallible(
+                opctx,
+                false,
+                false,
+                promise_id,
+                result,
+                |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            ) {
+                match result {
+                    Ok(result) => {
+                        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+                    }
+                    Err(err) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let err = err.into();
+                        let exception = deno_core::error::to_v8_error(
+                            &mut scope,
+                            opctx.get_error_class_fn,
+                            &err,
+                        );
+                        scope.throw_exception(exception);
+                        return 1;
+                    }
+                };
+                return 0;
+            }
+            return 2;
         }
-        return 2;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_async(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else if res == 1 {
-            deno_core::_ops::dispatch_metrics_async(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else if res == 1 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub async fn call(state: Rc<RefCell<OpState>>) -> std::io::Result<i32> {
+            Ok(*state.borrow().borrow::<i32>())
         }
     }
-    #[inline(always)]
-    pub async fn call(state: Rc<RefCell<OpState>>) -> std::io::Result<i32> {
-        Ok(*state.borrow().borrow::<i32>())
-    }
+    <op_async_opstate as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/async/async_result.out
+++ b/ops/op2/test_cases/async/async_result.out
@@ -1,106 +1,118 @@
 #[allow(non_camel_case_types)]
-pub struct op_async {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_async {
-    const NAME: &'static str = stringify!(op_async);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_async),
-        true,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_async {
-    pub const fn name() -> &'static str {
-        stringify!(op_async)
+pub const fn op_async() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_async {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_async {
+        const NAME: &'static str = stringify!(op_async);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_async),
+            true,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let result = { Self::call() };
-        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
-            .unwrap_or_default();
-        if let Some(result) = deno_core::_ops::map_async_op_fallible(
-            opctx,
-            false,
-            false,
-            promise_id,
-            result,
-            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
-        ) {
-            match result {
-                Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
-                Err(err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let err = err.into();
-                    let exception = deno_core::error::to_v8_error(
-                        &mut scope,
-                        opctx.get_error_class_fn,
-                        &err,
-                    );
-                    scope.throw_exception(exception);
-                    return 1;
-                }
+    }
+    impl op_async {
+        pub const fn name() -> &'static str {
+            stringify!(op_async)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
             };
-            return 0;
+            let result = { Self::call() };
+            let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+                .unwrap_or_default();
+            if let Some(result) = deno_core::_ops::map_async_op_fallible(
+                opctx,
+                false,
+                false,
+                promise_id,
+                result,
+                |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            ) {
+                match result {
+                    Ok(result) => {
+                        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+                    }
+                    Err(err) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let err = err.into();
+                        let exception = deno_core::error::to_v8_error(
+                            &mut scope,
+                            opctx.get_error_class_fn,
+                            &err,
+                        );
+                        scope.throw_exception(exception);
+                        return 1;
+                    }
+                };
+                return 0;
+            }
+            return 2;
         }
-        return 2;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_async(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else if res == 1 {
-            deno_core::_ops::dispatch_metrics_async(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else if res == 1 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub async fn call() -> std::io::Result<i32> {
+            Ok(0)
         }
     }
-    #[inline(always)]
-    pub async fn call() -> std::io::Result<i32> {
-        Ok(0)
-    }
+    <op_async as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/async/async_result.out
+++ b/ops/op2/test_cases/async/async_result.out
@@ -24,10 +24,6 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_async)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,

--- a/ops/op2/test_cases/async/async_result_impl.out
+++ b/ops/op2/test_cases/async/async_result_impl.out
@@ -1,90 +1,70 @@
 #[allow(non_camel_case_types)]
-pub struct op_async_result_impl {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_async_result_impl {
-    const NAME: &'static str = stringify!(op_async_result_impl);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_async_result_impl),
-        true,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_async_result_impl {
-    pub const fn name() -> &'static str {
-        stringify!(op_async_result_impl)
+pub const fn op_async_result_impl() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_async_result_impl {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_async_result_impl {
+        const NAME: &'static str = stringify!(op_async_result_impl);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_async_result_impl),
+            true,
+            false,
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let result = {
-            let arg0 = args.get(1usize as i32);
-            let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected i32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
+    }
+    impl op_async_result_impl {
+        pub const fn name() -> &'static str {
+            stringify!(op_async_result_impl)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
             };
-            let arg0 = arg0 as _;
-            Self::call(arg0)
-        };
-        let result = match result {
-            Ok(result) => result,
-            Err(err) => {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let err = err.into();
-                let exception = deno_core::error::to_v8_error(
-                    &mut scope,
-                    opctx.get_error_class_fn,
-                    &err,
-                );
-                scope.throw_exception(exception);
-                return 1;
-            }
-        };
-        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
-            .unwrap_or_default();
-        if let Some(result) = deno_core::_ops::map_async_op_fallible(
-            opctx,
-            false,
-            false,
-            promise_id,
-            result,
-            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
-        ) {
-            match result {
-                Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
+            let result = {
+                let arg0 = args.get(1usize as i32);
+                let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected i32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg0 = arg0 as _;
+                Self::call(arg0)
+            };
+            let result = match result {
+                Ok(result) => result,
                 Err(err) => {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                     let err = err.into();
@@ -97,40 +77,74 @@ impl op_async_result_impl {
                     return 1;
                 }
             };
-            return 0;
+            let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+                .unwrap_or_default();
+            if let Some(result) = deno_core::_ops::map_async_op_fallible(
+                opctx,
+                false,
+                false,
+                promise_id,
+                result,
+                |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            ) {
+                match result {
+                    Ok(result) => {
+                        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv)
+                    }
+                    Err(err) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let err = err.into();
+                        let exception = deno_core::error::to_v8_error(
+                            &mut scope,
+                            opctx.get_error_class_fn,
+                            &err,
+                        );
+                        scope.throw_exception(exception);
+                        return 1;
+                    }
+                };
+                return 0;
+            }
+            return 2;
         }
-        return 2;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_async(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else if res == 1 {
-            deno_core::_ops::dispatch_metrics_async(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else if res == 1 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub fn call(
+            x: i32,
+        ) -> Result<impl Future<Output = std::io::Result<i32>>, AnyError> {
+            Ok(async move { Ok(x) })
         }
     }
-    #[inline(always)]
-    pub fn call(x: i32) -> Result<impl Future<Output = std::io::Result<i32>>, AnyError> {
-        Ok(async move { Ok(x) })
-    }
+    <op_async_result_impl as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/async/async_result_impl.out
+++ b/ops/op2/test_cases/async/async_result_impl.out
@@ -24,10 +24,6 @@ pub const fn op_async_result_impl() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_async_result_impl)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,

--- a/ops/op2/test_cases/async/async_result_smi.out
+++ b/ops/op2/test_cases/async/async_result_smi.out
@@ -24,10 +24,6 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_async)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,

--- a/ops/op2/test_cases/async/async_result_smi.out
+++ b/ops/op2/test_cases/async/async_result_smi.out
@@ -1,140 +1,150 @@
 #[allow(non_camel_case_types)]
-pub struct op_async {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_async {
-    const NAME: &'static str = stringify!(op_async);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_async),
-        true,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_async {
-    pub const fn name() -> &'static str {
-        stringify!(op_async)
+pub const fn op_async() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_async {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let result = {
-            let arg0 = args.get(1usize as i32);
-            let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected i32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg0 = arg0 as _;
-            Self::call(arg0)
-        };
-        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
-            .unwrap_or_default();
-        if let Some(result) = deno_core::_ops::map_async_op_fallible(
-            opctx,
+    impl ::deno_core::_ops::Op for op_async {
+        const NAME: &'static str = stringify!(op_async);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_async),
+            true,
             false,
-            false,
-            promise_id,
-            result,
-            |scope, result| {
-                Ok(
-                    deno_core::_ops::RustToV8::to_v8(
-                        deno_core::_ops::RustToV8Marker::<
-                            deno_core::_ops::SmiMarker,
-                            _,
-                        >::from(result),
-                        scope,
-                    ),
-                )
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
             },
-        ) {
-            match result {
-                Ok(result) => {
-                    deno_core::_ops::RustToV8RetVal::to_v8_rv(
-                        deno_core::_ops::RustToV8Marker::<
-                            deno_core::_ops::SmiMarker,
-                            _,
-                        >::from(result),
-                        &mut rv,
-                    )
-                }
-                Err(err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let err = err.into();
-                    let exception = deno_core::error::to_v8_error(
-                        &mut scope,
-                        opctx.get_error_class_fn,
-                        &err,
-                    );
-                    scope.throw_exception(exception);
-                    return 1;
-                }
-            };
-            return 0;
-        }
-        return 2;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_async(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
         );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+    }
+    impl op_async {
+        pub const fn name() -> &'static str {
+            stringify!(op_async)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = {
+                let arg0 = args.get(1usize as i32);
+                let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected i32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg0 = arg0 as _;
+                Self::call(arg0)
+            };
+            let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+                .unwrap_or_default();
+            if let Some(result) = deno_core::_ops::map_async_op_fallible(
+                opctx,
+                false,
+                false,
+                promise_id,
+                result,
+                |scope, result| {
+                    Ok(
+                        deno_core::_ops::RustToV8::to_v8(
+                            deno_core::_ops::RustToV8Marker::<
+                                deno_core::_ops::SmiMarker,
+                                _,
+                            >::from(result),
+                            scope,
+                        ),
+                    )
+                },
+            ) {
+                match result {
+                    Ok(result) => {
+                        deno_core::_ops::RustToV8RetVal::to_v8_rv(
+                            deno_core::_ops::RustToV8Marker::<
+                                deno_core::_ops::SmiMarker,
+                                _,
+                            >::from(result),
+                            &mut rv,
+                        )
+                    }
+                    Err(err) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let err = err.into();
+                        let exception = deno_core::error::to_v8_error(
+                            &mut scope,
+                            opctx.get_error_class_fn,
+                            &err,
+                        );
+                        scope.throw_exception(exception);
+                        return 1;
+                    }
+                };
+                return 0;
+            }
+            return 2;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else if res == 1 {
-            deno_core::_ops::dispatch_metrics_async(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else if res == 1 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub async fn call(rid: ResourceId) -> std::io::Result<ResourceId> {
+            Ok(rid as _)
         }
     }
-    #[inline(always)]
-    pub async fn call(rid: ResourceId) -> std::io::Result<ResourceId> {
-        Ok(rid as _)
-    }
+    <op_async as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/async/async_v8_global.out
+++ b/ops/op2/test_cases/async/async_v8_global.out
@@ -1,110 +1,118 @@
 #[allow(non_camel_case_types)]
-pub struct op_async_v8_global {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_async_v8_global {
-    const NAME: &'static str = stringify!(op_async_v8_global);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_async_v8_global),
-        true,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_async_v8_global {
-    pub const fn name() -> &'static str {
-        stringify!(op_async_v8_global)
+pub const fn op_async_v8_global() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_async_v8_global {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_async_v8_global {
+        const NAME: &'static str = stringify!(op_async_v8_global);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_async_v8_global),
+            true,
+            false,
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let result = {
-            let arg0 = args.get(1usize as i32);
-            let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
-                deno_core::v8::String,
-            >(arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected String".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
+    }
+    impl op_async_v8_global {
+        pub const fn name() -> &'static str {
+            stringify!(op_async_v8_global)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
             };
-            let arg0 = deno_core::v8::Global::new(&mut scope, arg0);
-            Self::call(arg0)
-        };
-        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
-            .unwrap_or_default();
-        if let Some(result) = deno_core::_ops::map_async_op_infallible(
-            opctx,
-            false,
-            false,
-            promise_id,
-            result,
-            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            let result = {
+                let arg0 = args.get(1usize as i32);
+                let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
+                    deno_core::v8::String,
+                >(arg0) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected String".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg0 = deno_core::v8::Global::new(&mut scope, arg0);
+                Self::call(arg0)
+            };
+            let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+                .unwrap_or_default();
+            if let Some(result) = deno_core::_ops::map_async_op_infallible(
+                opctx,
+                false,
+                false,
+                promise_id,
+                result,
+                |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            ) {
+                deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+                return 0;
+            }
+            return 2;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-            return 0;
-        }
-        return 2;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_async(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else if res == 1 {
-            deno_core::_ops::dispatch_metrics_async(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else if res == 1 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
         }
+        #[inline(always)]
+        pub async fn call(_s: v8::Global<v8::String>) {}
     }
-    #[inline(always)]
-    pub async fn call(_s: v8::Global<v8::String>) {}
+    <op_async_v8_global as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/async/async_v8_global.out
+++ b/ops/op2/test_cases/async/async_v8_global.out
@@ -24,10 +24,6 @@ pub const fn op_async_v8_global() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_async_v8_global)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,

--- a/ops/op2/test_cases/async/async_void.out
+++ b/ops/op2/test_cases/async/async_void.out
@@ -24,10 +24,6 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_async)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,

--- a/ops/op2/test_cases/async/async_void.out
+++ b/ops/op2/test_cases/async/async_void.out
@@ -1,91 +1,99 @@
 #[allow(non_camel_case_types)]
-pub struct op_async {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_async {
-    const NAME: &'static str = stringify!(op_async);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_async),
-        true,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_async {
-    pub const fn name() -> &'static str {
-        stringify!(op_async)
+pub const fn op_async() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_async {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_async {
+        const NAME: &'static str = stringify!(op_async);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_async),
+            true,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let result = { Self::call() };
-        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
-            .unwrap_or_default();
-        if let Some(result) = deno_core::_ops::map_async_op_infallible(
-            opctx,
-            false,
-            false,
-            promise_id,
-            result,
-            |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+    }
+    impl op_async {
+        pub const fn name() -> &'static str {
+            stringify!(op_async)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = { Self::call() };
+            let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+                .unwrap_or_default();
+            if let Some(result) = deno_core::_ops::map_async_op_infallible(
+                opctx,
+                false,
+                false,
+                promise_id,
+                result,
+                |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            ) {
+                deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+                return 0;
+            }
+            return 2;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-            return 0;
-        }
-        return 2;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_async(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_async(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else if res == 1 {
-            deno_core::_ops::dispatch_metrics_async(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else if res == 1 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
         }
+        #[inline(always)]
+        pub async fn call() {}
     }
-    #[inline(always)]
-    pub async fn call() {}
+    <op_async as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -40,10 +40,6 @@ const fn op_add() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_add)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -1,165 +1,173 @@
 #[allow(non_camel_case_types)]
-struct op_add {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_add {
-    const NAME: &'static str = stringify!(op_add);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_add),
-        false,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::Uint32, Type::Uint32],
-                CType::Uint32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::Uint32, Type::Uint32, Type::CallbackOptions],
-                CType::Uint32,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_add {
-    pub const fn name() -> &'static str {
-        stringify!(op_add)
+const fn op_add() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_add {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
+    impl ::deno_core::_ops::Op for op_add {
+        const NAME: &'static str = stringify!(op_add);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_add),
+            false,
+            false,
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::Uint32, Type::Uint32],
+                    CType::Uint32,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::Uint32, Type::Uint32, Type::CallbackOptions],
+                    CType::Uint32,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: u32,
-        arg1: u32,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> u32 {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: u32,
-        arg1: u32,
-    ) -> u32 {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = {
-            let arg0 = arg0 as _;
-            let arg1 = arg1 as _;
-            Self::call(arg0, arg1)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected u32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
+    impl op_add {
+        pub const fn name() -> &'static str {
+            stringify!(op_add)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: u32,
+            arg1: u32,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> u32 {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
             };
-            let arg0 = arg0 as _;
-            let arg1 = args.get(1usize as i32);
-            let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected u32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg1 = arg1 as _;
-            Self::call(arg0, arg1)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: u32,
+            arg1: u32,
+        ) -> u32 {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = {
+                let arg0 = arg0 as _;
+                let arg1 = arg1 as _;
+                Self::call(arg0, arg1)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected u32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg0 = arg0 as _;
+                let arg1 = args.get(1usize as i32);
+                let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected u32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg1 = arg1 as _;
+                Self::call(arg0, arg1)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(a: u32, b: u32) -> u32 {
+            a + b
         }
     }
-    #[inline(always)]
-    fn call(a: u32, b: u32) -> u32 {
-        a + b
-    }
+    <op_add as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/add_options.out
+++ b/ops/op2/test_cases/sync/add_options.out
@@ -1,63 +1,50 @@
 #[allow(non_camel_case_types)]
-pub struct op_test_add_option {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_test_add_option {
-    const NAME: &'static str = stringify!(op_test_add_option);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_test_add_option),
-        false,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_test_add_option {
-    pub const fn name() -> &'static str {
-        stringify!(op_test_add_option)
+pub const fn op_test_add_option() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_test_add_option {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_test_add_option {
+        const NAME: &'static str = stringify!(op_test_add_option);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_test_add_option),
+            false,
+            false,
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected u32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg0 = arg0 as _;
-            let arg1 = args.get(1usize as i32);
-            let arg1 = if arg1.is_null_or_undefined() {
-                None
-            } else {
-                let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+    }
+    impl op_test_add_option {
+        pub const fn name() -> &'static str {
+            stringify!(op_test_add_option)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
@@ -69,44 +56,67 @@ impl op_test_add_option {
                     scope.throw_exception(exc);
                     return 1;
                 };
-                let arg1 = arg1 as _;
-                Some(arg1)
+                let arg0 = arg0 as _;
+                let arg1 = args.get(1usize as i32);
+                let arg1 = if arg1.is_null_or_undefined() {
+                    None
+                } else {
+                    let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let msg = deno_core::v8::String::new_from_one_byte(
+                                &mut scope,
+                                "expected u32".as_bytes(),
+                                deno_core::v8::NewStringType::Normal,
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    };
+                    let arg1 = arg1 as _;
+                    Some(arg1)
+                };
+                Self::call(arg0, arg1)
             };
-            Self::call(arg0, arg1)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub fn call(a: u32, b: Option<u32>) -> u32 {
+            a + b.unwrap_or(100)
         }
     }
-    #[inline(always)]
-    pub fn call(a: u32, b: Option<u32>) -> u32 {
-        a + b.unwrap_or(100)
-    }
+    <op_test_add_option as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/add_options.out
+++ b/ops/op2/test_cases/sync/add_options.out
@@ -24,10 +24,6 @@ pub const fn op_test_add_option() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_test_add_option)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,

--- a/ops/op2/test_cases/sync/bigint.out
+++ b/ops/op2/test_cases/sync/bigint.out
@@ -1,123 +1,133 @@
 #[allow(non_camel_case_types)]
-pub struct op_bigint {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_bigint {
-    const NAME: &'static str = stringify!(op_bigint);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_bigint),
-        false,
-        false,
-        0usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value],
-                CType::Uint64,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Uint64,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_bigint {
-    pub const fn name() -> &'static str {
-        stringify!(op_bigint)
+pub const fn op_bigint() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_bigint {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> u64 {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
+    impl ::deno_core::_ops::Op for op_bigint {
+        const NAME: &'static str = stringify!(op_bigint);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_bigint),
+            false,
+            false,
+            0usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value],
+                    CType::Uint64,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Uint64,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let res = Self::v8_fn_ptr_fast(this);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> u64 {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = { Self::call() };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = { Self::call() };
-        rv.set(deno_core::_ops::RustToV8::to_v8(result, &mut scope));
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+    impl op_bigint {
+        pub const fn name() -> &'static str {
+            stringify!(op_bigint)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> u64 {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+        ) -> u64 {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = { Self::call() };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = { Self::call() };
+            rv.set(deno_core::_ops::RustToV8::to_v8(result, &mut scope));
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub fn call() -> u64 {
+            0
         }
     }
-    #[inline(always)]
-    pub fn call() -> u64 {
-        0
-    }
+    <op_bigint as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/bigint.out
+++ b/ops/op2/test_cases/sync/bigint.out
@@ -40,10 +40,6 @@ pub const fn op_bigint() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_bigint)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/bool.out
+++ b/ops/op2/test_cases/sync/bool.out
@@ -40,10 +40,6 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_bool)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/bool.out
+++ b/ops/op2/test_cases/sync/bool.out
@@ -1,136 +1,144 @@
 #[allow(non_camel_case_types)]
-pub struct op_bool {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_bool {
-    const NAME: &'static str = stringify!(op_bool);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_bool),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::Bool],
-                CType::Bool,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::Bool, Type::CallbackOptions],
-                CType::Bool,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_bool {
-    pub const fn name() -> &'static str {
-        stringify!(op_bool)
+pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_bool {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: bool,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> bool {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
+    impl ::deno_core::_ops::Op for op_bool {
+        const NAME: &'static str = stringify!(op_bool);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_bool),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::Bool],
+                    CType::Bool,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::Bool, Type::CallbackOptions],
+                    CType::Bool,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let res = Self::v8_fn_ptr_fast(this, arg0);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: bool,
-    ) -> bool {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = {
-            let arg0 = arg0 as _;
-            Self::call(arg0)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let arg0 = arg0.is_true();
-            Self::call(arg0)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+    impl op_bool {
+        pub const fn name() -> &'static str {
+            stringify!(op_bool)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: bool,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> bool {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, arg0);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: bool,
+        ) -> bool {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = {
+                let arg0 = arg0 as _;
+                Self::call(arg0)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let arg0 = arg0.is_true();
+                Self::call(arg0)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub fn call(arg: bool) -> bool {
+            arg
         }
     }
-    #[inline(always)]
-    pub fn call(arg: bool) -> bool {
-        arg
-    }
+    <op_bool as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -40,10 +40,6 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_bool)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -1,140 +1,126 @@
 #[allow(non_camel_case_types)]
-pub struct op_bool {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_bool {
-    const NAME: &'static str = stringify!(op_bool);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_bool),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::Bool, Type::CallbackOptions],
-                CType::Bool,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::Bool, Type::CallbackOptions],
-                CType::Bool,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_bool {
-    pub const fn name() -> &'static str {
-        stringify!(op_bool)
+pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_bool {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
+    impl ::deno_core::_ops::Op for op_bool {
+        const NAME: &'static str = stringify!(op_bool);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_bool),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::Bool, Type::CallbackOptions],
+                    CType::Bool,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::Bool, Type::CallbackOptions],
+                    CType::Bool,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: bool,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> bool {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: bool,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> bool {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        let result = {
-            let arg0 = arg0 as _;
-            Self::call(arg0)
-        };
-        let result = match result {
-            Ok(result) => result,
-            Err(err) => {
-                let err = err.into();
-                unsafe {
-                    opctx.unsafely_set_last_error_for_ops_only(err);
-                }
-                fast_api_callback_options.fallback = true;
-                return unsafe { std::mem::zeroed() };
-            }
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        if let Some(err) = unsafe { opctx.unsafely_take_last_error_for_ops_only() } {
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let err = err.into();
-            let exception = deno_core::error::to_v8_error(
-                &mut scope,
-                opctx.get_error_class_fn,
-                &err,
-            );
-            scope.throw_exception(exception);
-            return 1;
+    impl op_bool {
+        pub const fn name() -> &'static str {
+            stringify!(op_bool)
         }
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let arg0 = arg0.is_true();
-            Self::call(arg0)
-        };
-        match result {
-            Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
-            Err(err) => {
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: bool,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> bool {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Completed,
+            );
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: bool,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> bool {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = {
+                let arg0 = arg0 as _;
+                Self::call(arg0)
+            };
+            let result = match result {
+                Ok(result) => result,
+                Err(err) => {
+                    let err = err.into();
+                    unsafe {
+                        opctx.unsafely_set_last_error_for_ops_only(err);
+                    }
+                    fast_api_callback_options.fallback = true;
+                    return unsafe { std::mem::zeroed() };
+                }
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            if let Some(err) = unsafe { opctx.unsafely_take_last_error_for_ops_only() } {
                 let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                 let err = err.into();
                 let exception = deno_core::error::to_v8_error(
@@ -145,39 +131,61 @@ impl op_bool {
                 scope.throw_exception(exception);
                 return 1;
             }
-        };
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let arg0 = arg0.is_true();
+                Self::call(arg0)
+            };
+            match result {
+                Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
+                Err(err) => {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let err = err.into();
+                    let exception = deno_core::error::to_v8_error(
+                        &mut scope,
+                        opctx.get_error_class_fn,
+                        &err,
+                    );
+                    scope.throw_exception(exception);
+                    return 1;
+                }
+            };
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub fn call(arg: bool) -> Result<bool, AnyError> {
+            Ok(arg)
         }
     }
-    #[inline(always)]
-    pub fn call(arg: bool) -> Result<bool, AnyError> {
-        Ok(arg)
-    }
+    <op_bool as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -53,10 +53,6 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_buffers)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,
@@ -336,10 +332,6 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_buffers_32)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,
@@ -589,10 +581,6 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
     impl op_buffers_option {
         pub const fn name() -> &'static str {
             stringify!(op_buffers_option)
-        }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
         }
         #[inline(always)]
         fn slow_function_impl(

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -1,583 +1,159 @@
 #[allow(non_camel_case_types)]
-struct op_buffers {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_buffers {
-    const NAME: &'static str = stringify!(op_buffers);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_buffers),
-        false,
-        false,
-        4usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[
-                    Type::V8Value,
-                    Type::TypedArray(CType::Uint8),
-                    Type::TypedArray(CType::Uint8),
-                    Type::TypedArray(CType::Uint8),
-                    Type::TypedArray(CType::Uint8),
-                ],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[
-                    Type::V8Value,
-                    Type::TypedArray(CType::Uint8),
-                    Type::TypedArray(CType::Uint8),
-                    Type::TypedArray(CType::Uint8),
-                    Type::TypedArray(CType::Uint8),
-                    Type::CallbackOptions,
-                ],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_buffers {
-    pub const fn name() -> &'static str {
-        stringify!(op_buffers)
+const fn op_buffers() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_buffers {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-    ) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = {
-            let arg0 = unsafe {
-                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
-                    arg0,
+    impl ::deno_core::_ops::Op for op_buffers {
+        const NAME: &'static str = stringify!(op_buffers);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_buffers),
+            false,
+            false,
+            4usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[
+                        Type::V8Value,
+                        Type::TypedArray(CType::Uint8),
+                        Type::TypedArray(CType::Uint8),
+                        Type::TypedArray(CType::Uint8),
+                        Type::TypedArray(CType::Uint8),
+                    ],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
                 )
-            }
-                .expect("Invalid buffer");
-            let arg0 = arg0;
-            let arg1 = unsafe {
-                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
-                    arg1,
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[
+                        Type::V8Value,
+                        Type::TypedArray(CType::Uint8),
+                        Type::TypedArray(CType::Uint8),
+                        Type::TypedArray(CType::Uint8),
+                        Type::TypedArray(CType::Uint8),
+                        Type::CallbackOptions,
+                    ],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
                 )
-            }
-                .expect("Invalid buffer");
-            let arg1 = arg1;
-            let arg2 = unsafe {
-                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
-                    arg2,
-                )
-            }
-                .expect("Invalid buffer");
-            let arg2 = if arg2.len() == 0 {
-                ::std::ptr::null_mut()
-            } else {
-                arg2.as_mut_ptr() as _
-            };
-            let arg3 = unsafe {
-                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
-                    arg3,
-                )
-            }
-                .expect("Invalid buffer");
-            let arg3 = if arg3.len() == 0 {
-                ::std::ptr::null_mut()
-            } else {
-                arg3.as_mut_ptr() as _
-            };
-            Self::call(arg0, arg1, arg2, arg3)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let mut arg0_temp;
-            arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
-                Ok(arg0) => arg0,
-                Err(arg0_err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            arg0_err.as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
-                    return 1;
-                }
-            };
-            let arg0 = arg0_temp.as_ref();
-            let arg1 = args.get(1usize as i32);
-            let mut arg1_temp;
-            arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg1) } {
-                Ok(arg1) => arg1,
-                Err(arg1_err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            arg1_err.as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
-                    return 1;
-                }
-            };
-            let arg1 = arg1_temp.as_mut();
-            let arg2 = args.get(2usize as i32);
-            let mut arg2_temp;
-            arg2_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg2) } {
-                Ok(arg2) => arg2,
-                Err(arg2_err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            arg2_err.as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
-                    return 1;
-                }
-            };
-            let arg2 = if arg2_temp.len() == 0 {
-                std::ptr::null()
-            } else {
-                arg2_temp.as_ref().as_ptr()
-            };
-            let arg3 = args.get(3usize as i32);
-            let mut arg3_temp;
-            arg3_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg3) } {
-                Ok(arg3) => arg3,
-                Err(arg3_err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            arg3_err.as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
-                    return 1;
-                }
-            };
-            let arg3 = if arg3_temp.len() == 0 {
-                std::ptr::null_mut()
-            } else {
-                arg3_temp.as_mut().as_mut_ptr()
-            };
-            Self::call(arg0, arg1, arg2, arg3)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+    impl op_buffers {
+        pub const fn name() -> &'static str {
+            stringify!(op_buffers)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+            arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+            arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+            arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            res
         }
-    }
-    #[inline(always)]
-    fn call(_a: &[u8], _b: &mut [u8], _c: *const u8, _d: *mut u8) {}
-}
-
-#[allow(non_camel_case_types)]
-struct op_buffers_32 {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_buffers_32 {
-    const NAME: &'static str = stringify!(op_buffers_32);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_buffers_32),
-        false,
-        false,
-        4usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[
-                    Type::V8Value,
-                    Type::TypedArray(CType::Uint32),
-                    Type::TypedArray(CType::Uint32),
-                    Type::TypedArray(CType::Uint32),
-                    Type::TypedArray(CType::Uint32),
-                ],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[
-                    Type::V8Value,
-                    Type::TypedArray(CType::Uint32),
-                    Type::TypedArray(CType::Uint32),
-                    Type::TypedArray(CType::Uint32),
-                    Type::TypedArray(CType::Uint32),
-                    Type::CallbackOptions,
-                ],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_buffers_32 {
-    pub const fn name() -> &'static str {
-        stringify!(op_buffers_32)
-    }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-    ) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = {
-            let arg0 = unsafe {
-                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
-                    arg0,
-                )
-            }
-                .expect("Invalid buffer");
-            let arg0 = arg0;
-            let arg1 = unsafe {
-                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
-                    arg1,
-                )
-            }
-                .expect("Invalid buffer");
-            let arg1 = arg1;
-            let arg2 = unsafe {
-                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
-                    arg2,
-                )
-            }
-                .expect("Invalid buffer");
-            let arg2 = if arg2.len() == 0 {
-                ::std::ptr::null_mut()
-            } else {
-                arg2.as_mut_ptr() as _
-            };
-            let arg3 = unsafe {
-                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
-                    arg3,
-                )
-            }
-                .expect("Invalid buffer");
-            let arg3 = if arg3.len() == 0 {
-                ::std::ptr::null_mut()
-            } else {
-                arg3.as_mut_ptr() as _
-            };
-            Self::call(arg0, arg1, arg2, arg3)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let mut arg0_temp;
-            arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg0) } {
-                Ok(arg0) => arg0,
-                Err(arg0_err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            arg0_err.as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
-                    return 1;
-                }
-            };
-            let arg0 = arg0_temp.as_ref();
-            let arg1 = args.get(1usize as i32);
-            let mut arg1_temp;
-            arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg1) } {
-                Ok(arg1) => arg1,
-                Err(arg1_err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            arg1_err.as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
-                    return 1;
-                }
-            };
-            let arg1 = arg1_temp.as_mut();
-            let arg2 = args.get(2usize as i32);
-            let mut arg2_temp;
-            arg2_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg2) } {
-                Ok(arg2) => arg2,
-                Err(arg2_err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            arg2_err.as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
-                    return 1;
-                }
-            };
-            let arg2 = if arg2_temp.len() == 0 {
-                std::ptr::null()
-            } else {
-                arg2_temp.as_ref().as_ptr()
-            };
-            let arg3 = args.get(3usize as i32);
-            let mut arg3_temp;
-            arg3_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg3) } {
-                Ok(arg3) => arg3,
-                Err(arg3_err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            arg3_err.as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
-                    return 1;
-                }
-            };
-            let arg3 = if arg3_temp.len() == 0 {
-                std::ptr::null_mut()
-            } else {
-                arg3_temp.as_mut().as_mut_ptr()
-            };
-            Self::call(arg0, arg1, arg2, arg3)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+            arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+            arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+            arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
             );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let result = {
+                let arg0 = unsafe {
+                    deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                        arg0,
+                    )
+                }
+                    .expect("Invalid buffer");
+                let arg0 = arg0;
+                let arg1 = unsafe {
+                    deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                        arg1,
+                    )
+                }
+                    .expect("Invalid buffer");
+                let arg1 = arg1;
+                let arg2 = unsafe {
+                    deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                        arg2,
+                    )
+                }
+                    .expect("Invalid buffer");
+                let arg2 = if arg2.len() == 0 {
+                    ::std::ptr::null_mut()
+                } else {
+                    arg2.as_mut_ptr() as _
+                };
+                let arg3 = unsafe {
+                    deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                        arg3,
+                    )
+                }
+                    .expect("Invalid buffer");
+                let arg3 = if arg3.len() == 0 {
+                    ::std::ptr::null_mut()
+                } else {
+                    arg3.as_mut_ptr() as _
+                };
+                Self::call(arg0, arg1, arg2, arg3)
+            };
+            result as _
         }
-    }
-    #[inline(always)]
-    fn call(_a: &[u32], _b: &mut [u32], _c: *const u32, _d: *mut u32) {}
-}
-
-#[allow(non_camel_case_types)]
-struct op_buffers_option {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_buffers_option {
-    const NAME: &'static str = stringify!(op_buffers_option);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_buffers_option),
-        false,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_buffers_option {
-    pub const fn name() -> &'static str {
-        stringify!(op_buffers_option)
-    }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let mut arg0_temp;
-            let arg0 = if arg0.is_null_or_undefined() {
-                None
-            } else {
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let mut arg0_temp;
                 arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
@@ -596,13 +172,8 @@ impl op_buffers_option {
                     }
                 };
                 let arg0 = arg0_temp.as_ref();
-                Some(arg0)
-            };
-            let arg1 = args.get(1usize as i32);
-            let mut arg1_temp;
-            let arg1 = if arg1.is_null_or_undefined() {
-                None
-            } else {
+                let arg1 = args.get(1usize as i32);
+                let mut arg1_temp;
                 arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg1) } {
                     Ok(arg1) => arg1,
                     Err(arg1_err) => {
@@ -620,42 +191,521 @@ impl op_buffers_option {
                         return 1;
                     }
                 };
-                let arg1 = deno_core::serde_v8::JsBuffer::from_parts(arg1_temp);
-                Some(arg1)
+                let arg1 = arg1_temp.as_mut();
+                let arg2 = args.get(2usize as i32);
+                let mut arg2_temp;
+                arg2_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg2) } {
+                    Ok(arg2) => arg2,
+                    Err(arg2_err) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let msg = deno_core::v8::String::new_from_one_byte(
+                                &mut scope,
+                                arg2_err.as_bytes(),
+                                deno_core::v8::NewStringType::Normal,
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    }
+                };
+                let arg2 = if arg2_temp.len() == 0 {
+                    std::ptr::null()
+                } else {
+                    arg2_temp.as_ref().as_ptr()
+                };
+                let arg3 = args.get(3usize as i32);
+                let mut arg3_temp;
+                arg3_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg3) } {
+                    Ok(arg3) => arg3,
+                    Err(arg3_err) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let msg = deno_core::v8::String::new_from_one_byte(
+                                &mut scope,
+                                arg3_err.as_bytes(),
+                                deno_core::v8::NewStringType::Normal,
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    }
+                };
+                let arg3 = if arg3_temp.len() == 0 {
+                    std::ptr::null_mut()
+                } else {
+                    arg3_temp.as_mut().as_mut_ptr()
+                };
+                Self::call(arg0, arg1, arg2, arg3)
             };
-            Self::call(arg0, arg1)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(_a: &[u8], _b: &mut [u8], _c: *const u8, _d: *mut u8) {}
+    }
+    <op_buffers as ::deno_core::_ops::Op>::DECL
+}
+
+#[allow(non_camel_case_types)]
+const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_buffers_32 {
+        _unconstructable: ::std::marker::PhantomData<()>,
+    }
+    impl ::deno_core::_ops::Op for op_buffers_32 {
+        const NAME: &'static str = stringify!(op_buffers_32);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_buffers_32),
+            false,
+            false,
+            4usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[
+                        Type::V8Value,
+                        Type::TypedArray(CType::Uint32),
+                        Type::TypedArray(CType::Uint32),
+                        Type::TypedArray(CType::Uint32),
+                        Type::TypedArray(CType::Uint32),
+                    ],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[
+                        Type::V8Value,
+                        Type::TypedArray(CType::Uint32),
+                        Type::TypedArray(CType::Uint32),
+                        Type::TypedArray(CType::Uint32),
+                        Type::TypedArray(CType::Uint32),
+                        Type::CallbackOptions,
+                    ],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
+    }
+    impl op_buffers_32 {
+        pub const fn name() -> &'static str {
+            stringify!(op_buffers_32)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+            arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+            arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+            arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+            arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+            arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+            arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = {
+                let arg0 = unsafe {
+                    deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                        arg0,
+                    )
+                }
+                    .expect("Invalid buffer");
+                let arg0 = arg0;
+                let arg1 = unsafe {
+                    deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                        arg1,
+                    )
+                }
+                    .expect("Invalid buffer");
+                let arg1 = arg1;
+                let arg2 = unsafe {
+                    deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                        arg2,
+                    )
+                }
+                    .expect("Invalid buffer");
+                let arg2 = if arg2.len() == 0 {
+                    ::std::ptr::null_mut()
+                } else {
+                    arg2.as_mut_ptr() as _
+                };
+                let arg3 = unsafe {
+                    deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                        arg3,
+                    )
+                }
+                    .expect("Invalid buffer");
+                let arg3 = if arg3.len() == 0 {
+                    ::std::ptr::null_mut()
+                } else {
+                    arg3.as_mut_ptr() as _
+                };
+                Self::call(arg0, arg1, arg2, arg3)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let mut arg0_temp;
+                arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg0) } {
+                    Ok(arg0) => arg0,
+                    Err(arg0_err) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let msg = deno_core::v8::String::new_from_one_byte(
+                                &mut scope,
+                                arg0_err.as_bytes(),
+                                deno_core::v8::NewStringType::Normal,
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    }
+                };
+                let arg0 = arg0_temp.as_ref();
+                let arg1 = args.get(1usize as i32);
+                let mut arg1_temp;
+                arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg1) } {
+                    Ok(arg1) => arg1,
+                    Err(arg1_err) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let msg = deno_core::v8::String::new_from_one_byte(
+                                &mut scope,
+                                arg1_err.as_bytes(),
+                                deno_core::v8::NewStringType::Normal,
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    }
+                };
+                let arg1 = arg1_temp.as_mut();
+                let arg2 = args.get(2usize as i32);
+                let mut arg2_temp;
+                arg2_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg2) } {
+                    Ok(arg2) => arg2,
+                    Err(arg2_err) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let msg = deno_core::v8::String::new_from_one_byte(
+                                &mut scope,
+                                arg2_err.as_bytes(),
+                                deno_core::v8::NewStringType::Normal,
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    }
+                };
+                let arg2 = if arg2_temp.len() == 0 {
+                    std::ptr::null()
+                } else {
+                    arg2_temp.as_ref().as_ptr()
+                };
+                let arg3 = args.get(3usize as i32);
+                let mut arg3_temp;
+                arg3_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg3) } {
+                    Ok(arg3) => arg3,
+                    Err(arg3_err) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let msg = deno_core::v8::String::new_from_one_byte(
+                                &mut scope,
+                                arg3_err.as_bytes(),
+                                deno_core::v8::NewStringType::Normal,
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    }
+                };
+                let arg3 = if arg3_temp.len() == 0 {
+                    std::ptr::null_mut()
+                } else {
+                    arg3_temp.as_mut().as_mut_ptr()
+                };
+                Self::call(arg0, arg1, arg2, arg3)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
         }
+        #[inline(always)]
+        fn call(_a: &[u32], _b: &mut [u32], _c: *const u32, _d: *mut u32) {}
     }
-    #[inline(always)]
-    fn call(_a: Option<&[u8]>, _b: Option<JsBuffer>) {}
+    <op_buffers_32 as ::deno_core::_ops::Op>::DECL
+}
+
+#[allow(non_camel_case_types)]
+const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_buffers_option {
+        _unconstructable: ::std::marker::PhantomData<()>,
+    }
+    impl ::deno_core::_ops::Op for op_buffers_option {
+        const NAME: &'static str = stringify!(op_buffers_option);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_buffers_option),
+            false,
+            false,
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
+    }
+    impl op_buffers_option {
+        pub const fn name() -> &'static str {
+            stringify!(op_buffers_option)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let mut arg0_temp;
+                let arg0 = if arg0.is_null_or_undefined() {
+                    None
+                } else {
+                    arg0_temp = match unsafe {
+                        deno_core::_ops::to_v8_slice::<u8>(arg0)
+                    } {
+                        Ok(arg0) => arg0,
+                        Err(arg0_err) => {
+                            let mut scope = unsafe {
+                                deno_core::v8::CallbackScope::new(&*info)
+                            };
+                            let msg = deno_core::v8::String::new_from_one_byte(
+                                    &mut scope,
+                                    arg0_err.as_bytes(),
+                                    deno_core::v8::NewStringType::Normal,
+                                )
+                                .unwrap();
+                            let exc = deno_core::v8::Exception::type_error(
+                                &mut scope,
+                                msg,
+                            );
+                            scope.throw_exception(exc);
+                            return 1;
+                        }
+                    };
+                    let arg0 = arg0_temp.as_ref();
+                    Some(arg0)
+                };
+                let arg1 = args.get(1usize as i32);
+                let mut arg1_temp;
+                let arg1 = if arg1.is_null_or_undefined() {
+                    None
+                } else {
+                    arg1_temp = match unsafe {
+                        deno_core::_ops::to_v8_slice::<u8>(arg1)
+                    } {
+                        Ok(arg1) => arg1,
+                        Err(arg1_err) => {
+                            let mut scope = unsafe {
+                                deno_core::v8::CallbackScope::new(&*info)
+                            };
+                            let msg = deno_core::v8::String::new_from_one_byte(
+                                    &mut scope,
+                                    arg1_err.as_bytes(),
+                                    deno_core::v8::NewStringType::Normal,
+                                )
+                                .unwrap();
+                            let exc = deno_core::v8::Exception::type_error(
+                                &mut scope,
+                                msg,
+                            );
+                            scope.throw_exception(exc);
+                            return 1;
+                        }
+                    };
+                    let arg1 = deno_core::serde_v8::JsBuffer::from_parts(arg1_temp);
+                    Some(arg1)
+                };
+                Self::call(arg0, arg1)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_slow(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(_a: Option<&[u8]>, _b: Option<JsBuffer>) {}
+    }
+    <op_buffers_option as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -1,414 +1,440 @@
 #[allow(non_camel_case_types)]
-struct op_buffers {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_buffers {
-    const NAME: &'static str = stringify!(op_buffers);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_buffers),
-        false,
-        false,
-        3usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[
-                    Type::V8Value,
-                    Type::TypedArray(CType::Uint8),
-                    Type::TypedArray(CType::Uint8),
-                    Type::TypedArray(CType::Uint8),
-                ],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[
-                    Type::V8Value,
-                    Type::TypedArray(CType::Uint8),
-                    Type::TypedArray(CType::Uint8),
-                    Type::TypedArray(CType::Uint8),
-                    Type::CallbackOptions,
-                ],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_buffers {
-    pub const fn name() -> &'static str {
-        stringify!(op_buffers)
+const fn op_buffers() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_buffers {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-        arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-    ) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = {
-            let arg0 = unsafe {
-                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
-                    arg0,
+    impl ::deno_core::_ops::Op for op_buffers {
+        const NAME: &'static str = stringify!(op_buffers);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_buffers),
+            false,
+            false,
+            3usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[
+                        Type::V8Value,
+                        Type::TypedArray(CType::Uint8),
+                        Type::TypedArray(CType::Uint8),
+                        Type::TypedArray(CType::Uint8),
+                    ],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
                 )
-            }
-                .expect("Invalid buffer");
-            let arg0 = arg0.to_vec();
-            let arg1 = unsafe {
-                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
-                    arg1,
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[
+                        Type::V8Value,
+                        Type::TypedArray(CType::Uint8),
+                        Type::TypedArray(CType::Uint8),
+                        Type::TypedArray(CType::Uint8),
+                        Type::CallbackOptions,
+                    ],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
                 )
-            }
-                .expect("Invalid buffer");
-            let arg1 = arg1.to_vec().into_boxed_slice();
-            let arg2 = unsafe {
-                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
-                    arg2,
-                )
-            }
-                .expect("Invalid buffer");
-            let arg2 = arg2.to_vec().into();
-            Self::call(arg0, arg1, arg2)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let mut arg0_temp;
-            arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
-                Ok(arg0) => arg0,
-                Err(arg0_err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            arg0_err.as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
-                    return 1;
-                }
-            };
-            let arg0 = arg0_temp.to_vec();
-            let arg1 = args.get(1usize as i32);
-            let mut arg1_temp;
-            arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg1) } {
-                Ok(arg1) => arg1,
-                Err(arg1_err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            arg1_err.as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
-                    return 1;
-                }
-            };
-            let arg1 = arg1_temp.to_boxed_slice();
-            let arg2 = args.get(2usize as i32);
-            let mut arg2_temp;
-            arg2_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg2) } {
-                Ok(arg2) => arg2,
-                Err(arg2_err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            arg2_err.as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
-                    return 1;
-                }
-            };
-            let arg2 = arg2_temp.to_vec().into();
-            Self::call(arg0, arg1, arg2)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+    impl op_buffers {
+        pub const fn name() -> &'static str {
+            stringify!(op_buffers)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+            arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+            arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+            arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+            arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = {
+                let arg0 = unsafe {
+                    deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                        arg0,
+                    )
+                }
+                    .expect("Invalid buffer");
+                let arg0 = arg0.to_vec();
+                let arg1 = unsafe {
+                    deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                        arg1,
+                    )
+                }
+                    .expect("Invalid buffer");
+                let arg1 = arg1.to_vec().into_boxed_slice();
+                let arg2 = unsafe {
+                    deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                        arg2,
+                    )
+                }
+                    .expect("Invalid buffer");
+                let arg2 = arg2.to_vec().into();
+                Self::call(arg0, arg1, arg2)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let mut arg0_temp;
+                arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
+                    Ok(arg0) => arg0,
+                    Err(arg0_err) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let msg = deno_core::v8::String::new_from_one_byte(
+                                &mut scope,
+                                arg0_err.as_bytes(),
+                                deno_core::v8::NewStringType::Normal,
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    }
+                };
+                let arg0 = arg0_temp.to_vec();
+                let arg1 = args.get(1usize as i32);
+                let mut arg1_temp;
+                arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg1) } {
+                    Ok(arg1) => arg1,
+                    Err(arg1_err) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let msg = deno_core::v8::String::new_from_one_byte(
+                                &mut scope,
+                                arg1_err.as_bytes(),
+                                deno_core::v8::NewStringType::Normal,
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    }
+                };
+                let arg1 = arg1_temp.to_boxed_slice();
+                let arg2 = args.get(2usize as i32);
+                let mut arg2_temp;
+                arg2_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg2) } {
+                    Ok(arg2) => arg2,
+                    Err(arg2_err) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let msg = deno_core::v8::String::new_from_one_byte(
+                                &mut scope,
+                                arg2_err.as_bytes(),
+                                deno_core::v8::NewStringType::Normal,
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    }
+                };
+                let arg2 = arg2_temp.to_vec().into();
+                Self::call(arg0, arg1, arg2)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
         }
+        #[inline(always)]
+        fn call(_a: Vec<u8>, _b: Box<[u8]>, _c: bytes::Bytes) {}
     }
-    #[inline(always)]
-    fn call(_a: Vec<u8>, _b: Box<[u8]>, _c: bytes::Bytes) {}
+    <op_buffers as ::deno_core::_ops::Op>::DECL
 }
 
 #[allow(non_camel_case_types)]
-struct op_buffers_32 {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_buffers_32 {
-    const NAME: &'static str = stringify!(op_buffers_32);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_buffers_32),
-        false,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[
-                    Type::V8Value,
-                    Type::TypedArray(CType::Uint32),
-                    Type::TypedArray(CType::Uint32),
-                ],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[
-                    Type::V8Value,
-                    Type::TypedArray(CType::Uint32),
-                    Type::TypedArray(CType::Uint32),
-                    Type::CallbackOptions,
-                ],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_buffers_32 {
-    pub const fn name() -> &'static str {
-        stringify!(op_buffers_32)
+const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_buffers_32 {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-        arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-    ) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = {
-            let arg0 = unsafe {
-                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
-                    arg0,
+    impl ::deno_core::_ops::Op for op_buffers_32 {
+        const NAME: &'static str = stringify!(op_buffers_32);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_buffers_32),
+            false,
+            false,
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[
+                        Type::V8Value,
+                        Type::TypedArray(CType::Uint32),
+                        Type::TypedArray(CType::Uint32),
+                    ],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
                 )
-            }
-                .expect("Invalid buffer");
-            let arg0 = arg0.to_vec();
-            let arg1 = unsafe {
-                deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
-                    arg1,
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[
+                        Type::V8Value,
+                        Type::TypedArray(CType::Uint32),
+                        Type::TypedArray(CType::Uint32),
+                        Type::CallbackOptions,
+                    ],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
                 )
-            }
-                .expect("Invalid buffer");
-            let arg1 = arg1.to_vec().into_boxed_slice();
-            Self::call(arg0, arg1)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let mut arg0_temp;
-            arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg0) } {
-                Ok(arg0) => arg0,
-                Err(arg0_err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            arg0_err.as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
-                    return 1;
-                }
-            };
-            let arg0 = arg0_temp.to_vec();
-            let arg1 = args.get(1usize as i32);
-            let mut arg1_temp;
-            arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg1) } {
-                Ok(arg1) => arg1,
-                Err(arg1_err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            arg1_err.as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
-                    return 1;
-                }
-            };
-            let arg1 = arg1_temp.to_boxed_slice();
-            Self::call(arg0, arg1)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+    impl op_buffers_32 {
+        pub const fn name() -> &'static str {
+            stringify!(op_buffers_32)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+            arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+            arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = {
+                let arg0 = unsafe {
+                    deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                        arg0,
+                    )
+                }
+                    .expect("Invalid buffer");
+                let arg0 = arg0.to_vec();
+                let arg1 = unsafe {
+                    deno_core::v8::fast_api::FastApiTypedArray::get_storage_from_pointer_if_aligned(
+                        arg1,
+                    )
+                }
+                    .expect("Invalid buffer");
+                let arg1 = arg1.to_vec().into_boxed_slice();
+                Self::call(arg0, arg1)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let mut arg0_temp;
+                arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg0) } {
+                    Ok(arg0) => arg0,
+                    Err(arg0_err) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let msg = deno_core::v8::String::new_from_one_byte(
+                                &mut scope,
+                                arg0_err.as_bytes(),
+                                deno_core::v8::NewStringType::Normal,
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    }
+                };
+                let arg0 = arg0_temp.to_vec();
+                let arg1 = args.get(1usize as i32);
+                let mut arg1_temp;
+                arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg1) } {
+                    Ok(arg1) => arg1,
+                    Err(arg1_err) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let msg = deno_core::v8::String::new_from_one_byte(
+                                &mut scope,
+                                arg1_err.as_bytes(),
+                                deno_core::v8::NewStringType::Normal,
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    }
+                };
+                let arg1 = arg1_temp.to_boxed_slice();
+                Self::call(arg0, arg1)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
         }
+        #[inline(always)]
+        fn call(_a: Vec<u32>, _b: Box<[u32]>) {}
     }
-    #[inline(always)]
-    fn call(_a: Vec<u32>, _b: Box<[u32]>) {}
+    <op_buffers_32 as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -51,10 +51,6 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_buffers)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,
@@ -284,10 +280,6 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
     impl op_buffers_32 {
         pub const fn name() -> &'static str {
             stringify!(op_buffers_32)
-        }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(

--- a/ops/op2/test_cases/sync/buffers_out.out
+++ b/ops/op2/test_cases/sync/buffers_out.out
@@ -1,161 +1,51 @@
 #[allow(non_camel_case_types)]
-struct op_buffers {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_buffers {
-    const NAME: &'static str = stringify!(op_buffers);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_buffers),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_buffers {
-    pub const fn name() -> &'static str {
-        stringify!(op_buffers)
+const fn op_buffers() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_buffers {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_buffers {
+        const NAME: &'static str = stringify!(op_buffers);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_buffers),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let mut arg0_temp;
-            arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
-                Ok(arg0) => arg0,
-                Err(arg0_err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            arg0_err.as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
-                    return 1;
-                }
-            };
-            let arg0 = deno_core::serde_v8::JsBuffer::from_parts(arg0_temp);
-            Self::call(arg0)
-        };
-        match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
-            Ok(v) => rv.set(v),
-            Err(rv_err) => {
-                let msg = deno_core::v8::String::new(
-                        &mut scope,
-                        &format!("{}", deno_core::anyhow::Error::from(rv_err)),
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            }
-        };
-        return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+    impl op_buffers {
+        pub const fn name() -> &'static str {
+            stringify!(op_buffers)
         }
-    }
-    #[inline(always)]
-    fn call(buffer: JsBuffer) -> JsBuffer {
-        buffer
-    }
-}
-
-#[allow(non_camel_case_types)]
-struct op_buffers_option {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_buffers_option {
-    const NAME: &'static str = stringify!(op_buffers_option);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_buffers_option),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_buffers_option {
-    pub const fn name() -> &'static str {
-        stringify!(op_buffers_option)
-    }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let mut arg0_temp;
-            let arg0 = if arg0.is_null_or_undefined() {
-                None
-            } else {
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let mut arg0_temp;
                 arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
@@ -174,111 +64,14 @@ impl op_buffers_option {
                     }
                 };
                 let arg0 = deno_core::serde_v8::JsBuffer::from_parts(arg0_temp);
-                Some(arg0)
+                Self::call(arg0)
             };
-            Self::call(arg0)
-        };
-        match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
-            Ok(v) => rv.set(v),
-            Err(rv_err) => {
-                let msg = deno_core::v8::String::new(
-                        &mut scope,
-                        &format!("{}", deno_core::anyhow::Error::from(rv_err)),
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            }
-        };
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
-        }
-    }
-    #[inline(always)]
-    fn call(buffer: Option<JsBuffer>) -> Option<JsBuffer> {
-        buffer
-    }
-}
-
-#[allow(non_camel_case_types)]
-struct op_arraybuffers {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_arraybuffers {
-    const NAME: &'static str = stringify!(op_arraybuffers);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_arraybuffers),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_arraybuffers {
-    pub const fn name() -> &'static str {
-        stringify!(op_arraybuffers)
-    }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let mut arg0_temp;
-            arg0_temp = match unsafe { deno_core::_ops::to_v8_slice_buffer(arg0) } {
-                Ok(arg0) => arg0,
-                Err(arg0_err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
+            match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
+                Ok(v) => rv.set(v),
+                Err(rv_err) => {
+                    let msg = deno_core::v8::String::new(
                             &mut scope,
-                            arg0_err.as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
+                            &format!("{}", deno_core::anyhow::Error::from(rv_err)),
                         )
                         .unwrap();
                     let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
@@ -286,50 +79,290 @@ impl op_arraybuffers {
                     return 1;
                 }
             };
-            let arg0 = deno_core::serde_v8::JsBuffer::from_parts(arg0_temp);
-            Self::call(arg0)
-        };
-        rv.set(
-            deno_core::_ops::RustToV8::to_v8(
-                deno_core::_ops::RustToV8Marker::<
-                    deno_core::_ops::ArrayBufferMarker,
-                    _,
-                >::from(result),
-                &mut scope,
-            ),
-        );
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(buffer: JsBuffer) -> JsBuffer {
+            buffer
         }
     }
-    #[inline(always)]
-    fn call(buffer: JsBuffer) -> JsBuffer {
-        buffer
+    <op_buffers as ::deno_core::_ops::Op>::DECL
+}
+
+#[allow(non_camel_case_types)]
+const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_buffers_option {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
+    impl ::deno_core::_ops::Op for op_buffers_option {
+        const NAME: &'static str = stringify!(op_buffers_option);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_buffers_option),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
+    }
+    impl op_buffers_option {
+        pub const fn name() -> &'static str {
+            stringify!(op_buffers_option)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let mut arg0_temp;
+                let arg0 = if arg0.is_null_or_undefined() {
+                    None
+                } else {
+                    arg0_temp = match unsafe {
+                        deno_core::_ops::to_v8_slice::<u8>(arg0)
+                    } {
+                        Ok(arg0) => arg0,
+                        Err(arg0_err) => {
+                            let mut scope = unsafe {
+                                deno_core::v8::CallbackScope::new(&*info)
+                            };
+                            let msg = deno_core::v8::String::new_from_one_byte(
+                                    &mut scope,
+                                    arg0_err.as_bytes(),
+                                    deno_core::v8::NewStringType::Normal,
+                                )
+                                .unwrap();
+                            let exc = deno_core::v8::Exception::type_error(
+                                &mut scope,
+                                msg,
+                            );
+                            scope.throw_exception(exc);
+                            return 1;
+                        }
+                    };
+                    let arg0 = deno_core::serde_v8::JsBuffer::from_parts(arg0_temp);
+                    Some(arg0)
+                };
+                Self::call(arg0)
+            };
+            match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
+                Ok(v) => rv.set(v),
+                Err(rv_err) => {
+                    let msg = deno_core::v8::String::new(
+                            &mut scope,
+                            &format!("{}", deno_core::anyhow::Error::from(rv_err)),
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                }
+            };
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_slow(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(buffer: Option<JsBuffer>) -> Option<JsBuffer> {
+            buffer
+        }
+    }
+    <op_buffers_option as ::deno_core::_ops::Op>::DECL
+}
+
+#[allow(non_camel_case_types)]
+const fn op_arraybuffers() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_arraybuffers {
+        _unconstructable: ::std::marker::PhantomData<()>,
+    }
+    impl ::deno_core::_ops::Op for op_arraybuffers {
+        const NAME: &'static str = stringify!(op_arraybuffers);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_arraybuffers),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
+    }
+    impl op_arraybuffers {
+        pub const fn name() -> &'static str {
+            stringify!(op_arraybuffers)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let mut arg0_temp;
+                arg0_temp = match unsafe { deno_core::_ops::to_v8_slice_buffer(arg0) } {
+                    Ok(arg0) => arg0,
+                    Err(arg0_err) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let msg = deno_core::v8::String::new_from_one_byte(
+                                &mut scope,
+                                arg0_err.as_bytes(),
+                                deno_core::v8::NewStringType::Normal,
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    }
+                };
+                let arg0 = deno_core::serde_v8::JsBuffer::from_parts(arg0_temp);
+                Self::call(arg0)
+            };
+            rv.set(
+                deno_core::_ops::RustToV8::to_v8(
+                    deno_core::_ops::RustToV8Marker::<
+                        deno_core::_ops::ArrayBufferMarker,
+                        _,
+                    >::from(result),
+                    &mut scope,
+                ),
+            );
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_slow(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(buffer: JsBuffer) -> JsBuffer {
+            buffer
+        }
+    }
+    <op_arraybuffers as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/buffers_out.out
+++ b/ops/op2/test_cases/sync/buffers_out.out
@@ -24,10 +24,6 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_buffers)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,
@@ -144,10 +140,6 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
     impl op_buffers_option {
         pub const fn name() -> &'static str {
             stringify!(op_buffers_option)
-        }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
         }
         #[inline(always)]
         fn slow_function_impl(
@@ -275,10 +267,6 @@ const fn op_arraybuffers() -> ::deno_core::_ops::OpDecl {
     impl op_arraybuffers {
         pub const fn name() -> &'static str {
             stringify!(op_arraybuffers)
-        }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
         }
         #[inline(always)]
         fn slow_function_impl(

--- a/ops/op2/test_cases/sync/cfg.out
+++ b/ops/op2/test_cases/sync/cfg.out
@@ -1,249 +1,269 @@
 #[allow(non_camel_case_types)]
-/// This is a doc comment.
-#[cfg(windows)]
-pub struct op_maybe_windows {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_maybe_windows {
-    const NAME: &'static str = stringify!(op_maybe_windows);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_maybe_windows),
-        false,
-        false,
-        0usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_maybe_windows {
-    pub const fn name() -> &'static str {
-        stringify!(op_maybe_windows)
+pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    /// This is a doc comment.
+    #[cfg(windows)]
+    pub struct op_maybe_windows {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
+    impl ::deno_core::_ops::Op for op_maybe_windows {
+        const NAME: &'static str = stringify!(op_maybe_windows);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_maybe_windows),
+            false,
+            false,
+            0usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let res = Self::v8_fn_ptr_fast(this);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = { Self::call() };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = { Self::call() };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+    impl op_maybe_windows {
+        pub const fn name() -> &'static str {
+            stringify!(op_maybe_windows)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = { Self::call() };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = { Self::call() };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
         }
+        #[inline(always)]
+        /// This is a doc comment.
+        #[cfg(windows)]
+        pub fn call() -> () {}
     }
-    #[inline(always)]
-    /// This is a doc comment.
-    #[cfg(windows)]
-    pub fn call() -> () {}
+    <op_maybe_windows as ::deno_core::_ops::Op>::DECL
 }
 
 #[allow(non_camel_case_types)]
-/// This is a doc comment.
-#[cfg(not(windows))]
-pub struct op_maybe_windows {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_maybe_windows {
-    const NAME: &'static str = stringify!(op_maybe_windows);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_maybe_windows),
-        false,
-        false,
-        0usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_maybe_windows {
-    pub const fn name() -> &'static str {
-        stringify!(op_maybe_windows)
+pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    /// This is a doc comment.
+    #[cfg(not(windows))]
+    pub struct op_maybe_windows {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
+    impl ::deno_core::_ops::Op for op_maybe_windows {
+        const NAME: &'static str = stringify!(op_maybe_windows);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_maybe_windows),
+            false,
+            false,
+            0usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let res = Self::v8_fn_ptr_fast(this);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = { Self::call() };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = { Self::call() };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+    impl op_maybe_windows {
+        pub const fn name() -> &'static str {
+            stringify!(op_maybe_windows)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = { Self::call() };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = { Self::call() };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
         }
+        #[inline(always)]
+        /// This is a doc comment.
+        #[cfg(not(windows))]
+        pub fn call() -> () {}
     }
-    #[inline(always)]
-    /// This is a doc comment.
-    #[cfg(not(windows))]
-    pub fn call() -> () {}
+    <op_maybe_windows as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/cfg.out
+++ b/ops/op2/test_cases/sync/cfg.out
@@ -42,10 +42,6 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_maybe_windows)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,
@@ -176,10 +172,6 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
     impl op_maybe_windows {
         pub const fn name() -> &'static str {
             stringify!(op_maybe_windows)
-        }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(

--- a/ops/op2/test_cases/sync/clippy_allow.out
+++ b/ops/op2/test_cases/sync/clippy_allow.out
@@ -42,10 +42,6 @@ pub const fn op_extra_annotation() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_extra_annotation)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,
@@ -174,10 +170,6 @@ pub const fn op_clippy_internal() -> ::deno_core::_ops::OpDecl {
     impl op_clippy_internal {
         pub const fn name() -> &'static str {
             stringify!(op_clippy_internal)
-        }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(

--- a/ops/op2/test_cases/sync/clippy_allow.out
+++ b/ops/op2/test_cases/sync/clippy_allow.out
@@ -1,247 +1,267 @@
 #[allow(non_camel_case_types)]
-/// This is a doc comment.
-#[allow(clippy::some_annotation)]
-pub struct op_extra_annotation {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_extra_annotation {
-    const NAME: &'static str = stringify!(op_extra_annotation);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_extra_annotation),
-        false,
-        false,
-        0usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_extra_annotation {
-    pub const fn name() -> &'static str {
-        stringify!(op_extra_annotation)
+pub const fn op_extra_annotation() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    /// This is a doc comment.
+    #[allow(clippy::some_annotation)]
+    pub struct op_extra_annotation {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
+    impl ::deno_core::_ops::Op for op_extra_annotation {
+        const NAME: &'static str = stringify!(op_extra_annotation);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_extra_annotation),
+            false,
+            false,
+            0usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let res = Self::v8_fn_ptr_fast(this);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = { Self::call() };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = { Self::call() };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+    impl op_extra_annotation {
+        pub const fn name() -> &'static str {
+            stringify!(op_extra_annotation)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = { Self::call() };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = { Self::call() };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
         }
+        #[inline(always)]
+        /// This is a doc comment.
+        #[allow(clippy::some_annotation)]
+        pub fn call() -> () {}
     }
-    #[inline(always)]
-    /// This is a doc comment.
-    #[allow(clippy::some_annotation)]
-    pub fn call() -> () {}
+    <op_extra_annotation as ::deno_core::_ops::Op>::DECL
 }
 
 #[allow(non_camel_case_types)]
-pub struct op_clippy_internal {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_clippy_internal {
-    const NAME: &'static str = stringify!(op_clippy_internal);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_clippy_internal),
-        false,
-        false,
-        0usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_clippy_internal {
-    pub const fn name() -> &'static str {
-        stringify!(op_clippy_internal)
+pub const fn op_clippy_internal() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_clippy_internal {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
+    impl ::deno_core::_ops::Op for op_clippy_internal {
+        const NAME: &'static str = stringify!(op_clippy_internal);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_clippy_internal),
+            false,
+            false,
+            0usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let res = Self::v8_fn_ptr_fast(this);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = { Self::call() };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = { Self::call() };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+    impl op_clippy_internal {
+        pub const fn name() -> &'static str {
+            stringify!(op_clippy_internal)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = { Self::call() };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = { Self::call() };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub fn call() -> () {
+            { #![allow(clippy::await_holding_refcell_ref)] }
         }
     }
-    #[inline(always)]
-    pub fn call() -> () {
-        { #![allow(clippy::await_holding_refcell_ref)] }
-    }
+    <op_clippy_internal as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -40,10 +40,6 @@ const fn op_file() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_file)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,
@@ -187,10 +183,6 @@ const fn op_make_cppgc_object() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_make_cppgc_object)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,
@@ -276,10 +268,6 @@ const fn op_make_cppgc_object_async() -> ::deno_core::_ops::OpDecl {
     impl op_make_cppgc_object_async {
         pub const fn name() -> &'static str {
             stringify!(op_make_cppgc_object_async)
-        }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
         }
         #[inline(always)]
         fn slow_function_impl(

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -1,302 +1,209 @@
 #[allow(non_camel_case_types)]
-struct op_file {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_file {
-    const NAME: &'static str = stringify!(op_file);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_file),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_file {
-    pub const fn name() -> &'static str {
-        stringify!(op_file)
+const fn op_file() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_file {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: deno_core::v8::Local<deno_core::v8::Value>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: deno_core::v8::Local<deno_core::v8::Value>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let result = {
-            let Some(arg0) = deno_core::cppgc::try_unwrap_cppgc_object::<
-                std::fs::File,
-            >(arg0) else {
-                fast_api_callback_options.fallback = true;
-                return unsafe { std::mem::zeroed() };
-            };
-            Self::call(arg0)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let Some(arg0) = deno_core::cppgc::try_unwrap_cppgc_object::<
-                std::fs::File,
-            >(arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected std::fs::File".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            Self::call(arg0)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
-        }
-    }
-    #[inline(always)]
-    fn call(_file: &std::fs::File) {}
-}
-
-#[allow(non_camel_case_types)]
-struct op_make_cppgc_object {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_make_cppgc_object {
-    const NAME: &'static str = stringify!(op_make_cppgc_object);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_make_cppgc_object),
-        false,
-        false,
-        0usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_make_cppgc_object {
-    pub const fn name() -> &'static str {
-        stringify!(op_make_cppgc_object)
-    }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = { Self::call() };
-        rv.set(
-            deno_core::_ops::RustToV8NoScope::to_v8(
-                deno_core::v8::Local::<
-                    deno_core::v8::Value,
-                >::from(deno_core::cppgc::make_cppgc_object(&mut scope, result)),
-            ),
-        );
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
-        }
-    }
-    #[inline(always)]
-    fn call() -> Wrap {
-        Wrap
-    }
-}
-
-#[allow(non_camel_case_types)]
-struct op_make_cppgc_object_async {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_make_cppgc_object_async {
-    const NAME: &'static str = stringify!(op_make_cppgc_object_async);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_make_cppgc_object_async),
-        true,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_make_cppgc_object_async {
-    pub const fn name() -> &'static str {
-        stringify!(op_make_cppgc_object_async)
-    }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let result = { Self::call() };
-        let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
-            .unwrap_or_default();
-        if let Some(result) = deno_core::_ops::map_async_op_infallible(
-            opctx,
+    impl ::deno_core::_ops::Op for op_file {
+        const NAME: &'static str = stringify!(op_file);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_file),
             false,
             false,
-            promise_id,
-            result,
-            |scope, result| {
-                Ok(
-                    deno_core::_ops::RustToV8NoScope::to_v8(
-                        deno_core::cppgc::make_cppgc_object(scope, result),
-                    ),
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
                 )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
             },
+        );
+    }
+    impl op_file {
+        pub const fn name() -> &'static str {
+            stringify!(op_file)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: deno_core::v8::Local<deno_core::v8::Value>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Completed,
+            );
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: deno_core::v8::Local<deno_core::v8::Value>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let result = {
+                let Some(arg0) = deno_core::cppgc::try_unwrap_cppgc_object::<
+                    std::fs::File,
+                >(arg0) else {
+                    fast_api_callback_options.fallback = true;
+                    return unsafe { std::mem::zeroed() };
+                };
+                Self::call(arg0)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let Some(arg0) = deno_core::cppgc::try_unwrap_cppgc_object::<
+                    std::fs::File,
+                >(arg0) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected std::fs::File".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                Self::call(arg0)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_slow(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(_file: &std::fs::File) {}
+    }
+    <op_file as ::deno_core::_ops::Op>::DECL
+}
+
+#[allow(non_camel_case_types)]
+const fn op_make_cppgc_object() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_make_cppgc_object {
+        _unconstructable: ::std::marker::PhantomData<()>,
+    }
+    impl ::deno_core::_ops::Op for op_make_cppgc_object {
+        const NAME: &'static str = stringify!(op_make_cppgc_object);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_make_cppgc_object),
+            false,
+            false,
+            0usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
+    }
+    impl op_make_cppgc_object {
+        pub const fn name() -> &'static str {
+            stringify!(op_make_cppgc_object)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = { Self::call() };
             rv.set(
                 deno_core::_ops::RustToV8NoScope::to_v8(
                     deno_core::v8::Local::<
@@ -306,38 +213,155 @@ impl op_make_cppgc_object_async {
             );
             return 0;
         }
-        return 2;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_async(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_async(
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else if res == 1 {
-            deno_core::_ops::dispatch_metrics_async(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call() -> Wrap {
+            Wrap
         }
     }
-    #[inline(always)]
-    async fn call() -> Wrap {
-        Wrap
+    <op_make_cppgc_object as ::deno_core::_ops::Op>::DECL
+}
+
+#[allow(non_camel_case_types)]
+const fn op_make_cppgc_object_async() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_make_cppgc_object_async {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
+    impl ::deno_core::_ops::Op for op_make_cppgc_object_async {
+        const NAME: &'static str = stringify!(op_make_cppgc_object_async);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_make_cppgc_object_async),
+            true,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
+    }
+    impl op_make_cppgc_object_async {
+        pub const fn name() -> &'static str {
+            stringify!(op_make_cppgc_object_async)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = { Self::call() };
+            let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+                .unwrap_or_default();
+            if let Some(result) = deno_core::_ops::map_async_op_infallible(
+                opctx,
+                false,
+                false,
+                promise_id,
+                result,
+                |scope, result| {
+                    Ok(
+                        deno_core::_ops::RustToV8NoScope::to_v8(
+                            deno_core::cppgc::make_cppgc_object(scope, result),
+                        ),
+                    )
+                },
+            ) {
+                rv.set(
+                    deno_core::_ops::RustToV8NoScope::to_v8(
+                        deno_core::v8::Local::<
+                            deno_core::v8::Value,
+                        >::from(deno_core::cppgc::make_cppgc_object(&mut scope, result)),
+                    ),
+                );
+                return 0;
+            }
+            return 2;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_async(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else if res == 1 {
+                deno_core::_ops::dispatch_metrics_async(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        async fn call() -> Wrap {
+            Wrap
+        }
+    }
+    <op_make_cppgc_object_async as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/doc_comment.out
+++ b/ops/op2/test_cases/sync/doc_comment.out
@@ -1,122 +1,132 @@
 #[allow(non_camel_case_types)]
-/// This is a doc comment.
-pub struct op_has_doc_comment {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_has_doc_comment {
-    const NAME: &'static str = stringify!(op_has_doc_comment);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_has_doc_comment),
-        false,
-        false,
-        0usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_has_doc_comment {
-    pub const fn name() -> &'static str {
-        stringify!(op_has_doc_comment)
+pub const fn op_has_doc_comment() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    /// This is a doc comment.
+    pub struct op_has_doc_comment {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
+    impl ::deno_core::_ops::Op for op_has_doc_comment {
+        const NAME: &'static str = stringify!(op_has_doc_comment);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_has_doc_comment),
+            false,
+            false,
+            0usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let res = Self::v8_fn_ptr_fast(this);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = { Self::call() };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = { Self::call() };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+    impl op_has_doc_comment {
+        pub const fn name() -> &'static str {
+            stringify!(op_has_doc_comment)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = { Self::call() };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = { Self::call() };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
         }
+        #[inline(always)]
+        /// This is a doc comment.
+        pub fn call() -> () {}
     }
-    #[inline(always)]
-    /// This is a doc comment.
-    pub fn call() -> () {}
+    <op_has_doc_comment as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/doc_comment.out
+++ b/ops/op2/test_cases/sync/doc_comment.out
@@ -41,10 +41,6 @@ pub const fn op_has_doc_comment() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_has_doc_comment)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/fast_alternative.out
+++ b/ops/op2/test_cases/sync/fast_alternative.out
@@ -13,8 +13,8 @@ const fn op_slow() -> ::deno_core::_ops::OpDecl {
             3usize as u8,
             Self::v8_fn_ptr as _,
             Self::v8_fn_ptr_metrics as _,
-            Some({ op_fast::DECL.fast_fn() }),
-            Some({ op_fast::DECL.fast_fn_with_metrics() }),
+            Some({ op_fast().fast_fn() }),
+            Some({ op_fast().fast_fn_with_metrics() }),
             ::deno_core::OpMetadata {
                 ..::deno_core::OpMetadata::default()
             },
@@ -303,8 +303,8 @@ const fn op_slow_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
             3usize as u8,
             Self::v8_fn_ptr as _,
             Self::v8_fn_ptr_metrics as _,
-            Some({ op_fast_generic::<T>::DECL.fast_fn() }),
-            Some({ op_fast_generic::<T>::DECL.fast_fn_with_metrics() }),
+            Some({ op_fast_generic::<T>().fast_fn() }),
+            Some({ op_fast_generic::<T>().fast_fn_with_metrics() }),
             ::deno_core::OpMetadata {
                 ..::deno_core::OpMetadata::default()
             },

--- a/ops/op2/test_cases/sync/fast_alternative.out
+++ b/ops/op2/test_cases/sync/fast_alternative.out
@@ -24,10 +24,6 @@ const fn op_slow() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_slow)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,
@@ -155,10 +151,6 @@ const fn op_fast() -> ::deno_core::_ops::OpDecl {
     impl op_fast {
         pub const fn name() -> &'static str {
             stringify!(op_fast)
-        }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
@@ -314,10 +306,6 @@ const fn op_slow_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_slow_generic)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,
@@ -445,10 +433,6 @@ const fn op_fast_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
     impl<T: Trait> op_fast_generic<T> {
         pub const fn name() -> &'static str {
             stringify!(op_fast_generic)
-        }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(

--- a/ops/op2/test_cases/sync/fast_alternative.out
+++ b/ops/op2/test_cases/sync/fast_alternative.out
@@ -1,547 +1,579 @@
 #[allow(non_camel_case_types)]
-struct op_slow {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_slow {
-    const NAME: &'static str = stringify!(op_slow);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_slow),
-        false,
-        false,
-        3usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({ op_fast::DECL.fast_fn() }),
-        Some({ op_fast::DECL.fast_fn_with_metrics() }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_slow {
-    pub const fn name() -> &'static str {
-        stringify!(op_slow)
+const fn op_slow() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_slow {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_slow {
+        const NAME: &'static str = stringify!(op_slow);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_slow),
+            false,
+            false,
+            3usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({ op_fast::DECL.fast_fn() }),
+            Some({ op_fast::DECL.fast_fn_with_metrics() }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg1 = args.get(0usize as i32);
-            let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected u32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg1 = arg1 as _;
-            let arg2 = args.get(1usize as i32);
-            let Some(arg2) = deno_core::_ops::to_u32_option(&arg2) else {
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected u32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg2 = arg2 as _;
-            let arg0 = &mut scope;
-            Self::call(arg0, arg1, arg2)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+    impl op_slow {
+        pub const fn name() -> &'static str {
+            stringify!(op_slow)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg1 = args.get(0usize as i32);
+                let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected u32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg1 = arg1 as _;
+                let arg2 = args.get(1usize as i32);
+                let Some(arg2) = deno_core::_ops::to_u32_option(&arg2) else {
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected u32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg2 = arg2 as _;
+                let arg0 = &mut scope;
+                Self::call(arg0, arg1, arg2)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(_scope: &v8::HandleScope, a: u32, b: u32) -> u32 {
+            a + b
         }
     }
-    #[inline(always)]
-    fn call(_scope: &v8::HandleScope, a: u32, b: u32) -> u32 {
-        a + b
-    }
+    <op_slow as ::deno_core::_ops::Op>::DECL
 }
 
 #[allow(non_camel_case_types)]
-struct op_fast {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_fast {
-    const NAME: &'static str = stringify!(op_fast);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_fast),
-        false,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::Uint32, Type::Uint32],
-                CType::Uint32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::Uint32, Type::Uint32, Type::CallbackOptions],
-                CType::Uint32,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_fast {
-    pub const fn name() -> &'static str {
-        stringify!(op_fast)
+const fn op_fast() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_fast {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
+    impl ::deno_core::_ops::Op for op_fast {
+        const NAME: &'static str = stringify!(op_fast);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_fast),
+            false,
+            false,
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::Uint32, Type::Uint32],
+                    CType::Uint32,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::Uint32, Type::Uint32, Type::CallbackOptions],
+                    CType::Uint32,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: u32,
-        arg1: u32,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> u32 {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: u32,
-        arg1: u32,
-    ) -> u32 {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = {
-            let arg0 = arg0 as _;
-            let arg1 = arg1 as _;
-            Self::call(arg0, arg1)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected u32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
+    impl op_fast {
+        pub const fn name() -> &'static str {
+            stringify!(op_fast)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: u32,
+            arg1: u32,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> u32 {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
             };
-            let arg0 = arg0 as _;
-            let arg1 = args.get(1usize as i32);
-            let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected u32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg1 = arg1 as _;
-            Self::call(arg0, arg1)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: u32,
+            arg1: u32,
+        ) -> u32 {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = {
+                let arg0 = arg0 as _;
+                let arg1 = arg1 as _;
+                Self::call(arg0, arg1)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected u32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg0 = arg0 as _;
+                let arg1 = args.get(1usize as i32);
+                let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected u32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg1 = arg1 as _;
+                Self::call(arg0, arg1)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(a: u32, b: u32) -> u32 {
+            a + b
         }
     }
-    #[inline(always)]
-    fn call(a: u32, b: u32) -> u32 {
-        a + b
-    }
+    <op_fast as ::deno_core::_ops::Op>::DECL
 }
 
 #[allow(non_camel_case_types)]
-struct op_slow_generic<T> {
-    _unconstructable: ::std::marker::PhantomData<(T)>,
-}
-impl<T: Trait> ::deno_core::_ops::Op for op_slow_generic<T> {
-    const NAME: &'static str = stringify!(op_slow_generic);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_slow_generic),
-        false,
-        false,
-        3usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({ op_fast_generic::<T>::DECL.fast_fn() }),
-        Some({ op_fast_generic::<T>::DECL.fast_fn_with_metrics() }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl<T: Trait> op_slow_generic<T> {
-    pub const fn name() -> &'static str {
-        stringify!(op_slow_generic)
+const fn op_slow_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_slow_generic<T> {
+        _unconstructable: ::std::marker::PhantomData<(T)>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl<T: Trait> ::deno_core::_ops::Op for op_slow_generic<T> {
+        const NAME: &'static str = stringify!(op_slow_generic);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_slow_generic),
+            false,
+            false,
+            3usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({ op_fast_generic::<T>::DECL.fast_fn() }),
+            Some({ op_fast_generic::<T>::DECL.fast_fn_with_metrics() }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg1 = args.get(0usize as i32);
-            let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected u32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg1 = arg1 as _;
-            let arg2 = args.get(1usize as i32);
-            let Some(arg2) = deno_core::_ops::to_u32_option(&arg2) else {
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected u32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg2 = arg2 as _;
-            let arg0 = &mut scope;
-            Self::call(arg0, arg1, arg2)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+    impl<T: Trait> op_slow_generic<T> {
+        pub const fn name() -> &'static str {
+            stringify!(op_slow_generic)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg1 = args.get(0usize as i32);
+                let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected u32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg1 = arg1 as _;
+                let arg2 = args.get(1usize as i32);
+                let Some(arg2) = deno_core::_ops::to_u32_option(&arg2) else {
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected u32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg2 = arg2 as _;
+                let arg0 = &mut scope;
+                Self::call(arg0, arg1, arg2)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(_scope: &v8::HandleScope, a: u32, b: u32) -> u32 {
+            a + b
         }
     }
-    #[inline(always)]
-    fn call(_scope: &v8::HandleScope, a: u32, b: u32) -> u32 {
-        a + b
-    }
+    <op_slow_generic<T> as ::deno_core::_ops::Op>::DECL
 }
 
 #[allow(non_camel_case_types)]
-struct op_fast_generic<T> {
-    _unconstructable: ::std::marker::PhantomData<(T)>,
-}
-impl<T: Trait> ::deno_core::_ops::Op for op_fast_generic<T> {
-    const NAME: &'static str = stringify!(op_fast_generic);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_fast_generic),
-        false,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::Uint32, Type::Uint32],
-                CType::Uint32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::Uint32, Type::Uint32, Type::CallbackOptions],
-                CType::Uint32,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl<T: Trait> op_fast_generic<T> {
-    pub const fn name() -> &'static str {
-        stringify!(op_fast_generic)
+const fn op_fast_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_fast_generic<T> {
+        _unconstructable: ::std::marker::PhantomData<(T)>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
+    impl<T: Trait> ::deno_core::_ops::Op for op_fast_generic<T> {
+        const NAME: &'static str = stringify!(op_fast_generic);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_fast_generic),
+            false,
+            false,
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::Uint32, Type::Uint32],
+                    CType::Uint32,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::Uint32, Type::Uint32, Type::CallbackOptions],
+                    CType::Uint32,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: u32,
-        arg1: u32,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> u32 {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: u32,
-        arg1: u32,
-    ) -> u32 {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = {
-            let arg0 = arg0 as _;
-            let arg1 = arg1 as _;
-            Self::call(arg0, arg1)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected u32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
+    impl<T: Trait> op_fast_generic<T> {
+        pub const fn name() -> &'static str {
+            stringify!(op_fast_generic)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: u32,
+            arg1: u32,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> u32 {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
             };
-            let arg0 = arg0 as _;
-            let arg1 = args.get(1usize as i32);
-            let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected u32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg1 = arg1 as _;
-            Self::call(arg0, arg1)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: u32,
+            arg1: u32,
+        ) -> u32 {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = {
+                let arg0 = arg0 as _;
+                let arg1 = arg1 as _;
+                Self::call(arg0, arg1)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected u32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg0 = arg0 as _;
+                let arg1 = args.get(1usize as i32);
+                let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected u32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg1 = arg1 as _;
+                Self::call(arg0, arg1)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(a: u32, b: u32) -> u32 {
+            a + b
         }
     }
-    #[inline(always)]
-    fn call(a: u32, b: u32) -> u32 {
-        a + b
-    }
+    <op_fast_generic<T> as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -1,365 +1,395 @@
 #[allow(non_camel_case_types)]
-pub struct op_generics<T> {
-    _unconstructable: ::std::marker::PhantomData<(T)>,
-}
-impl<T: Trait> ::deno_core::_ops::Op for op_generics<T> {
-    const NAME: &'static str = stringify!(op_generics);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_generics),
-        false,
-        false,
-        0usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl<T: Trait> op_generics<T> {
-    pub const fn name() -> &'static str {
-        stringify!(op_generics)
+pub const fn op_generics<T: Trait>() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_generics<T> {
+        _unconstructable: ::std::marker::PhantomData<(T)>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
+    impl<T: Trait> ::deno_core::_ops::Op for op_generics<T> {
+        const NAME: &'static str = stringify!(op_generics);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_generics),
+            false,
+            false,
+            0usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let res = Self::v8_fn_ptr_fast(this);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = { Self::call() };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = { Self::call() };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+    impl<T: Trait> op_generics<T> {
+        pub const fn name() -> &'static str {
+            stringify!(op_generics)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = { Self::call() };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = { Self::call() };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
         }
+        #[inline(always)]
+        pub fn call() {}
     }
-    #[inline(always)]
-    pub fn call() {}
+    <op_generics<T> as ::deno_core::_ops::Op>::DECL
 }
 
 #[allow(non_camel_case_types)]
-pub struct op_generics_static<T> {
-    _unconstructable: ::std::marker::PhantomData<(T)>,
-}
-impl<T: Trait + 'static> ::deno_core::_ops::Op for op_generics_static<T> {
-    const NAME: &'static str = stringify!(op_generics_static);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_generics_static),
-        false,
-        false,
-        0usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl<T: Trait + 'static> op_generics_static<T> {
-    pub const fn name() -> &'static str {
-        stringify!(op_generics_static)
+pub const fn op_generics_static<T: Trait + 'static>() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_generics_static<T> {
+        _unconstructable: ::std::marker::PhantomData<(T)>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
+    impl<T: Trait + 'static> ::deno_core::_ops::Op for op_generics_static<T> {
+        const NAME: &'static str = stringify!(op_generics_static);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_generics_static),
+            false,
+            false,
+            0usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let res = Self::v8_fn_ptr_fast(this);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = { Self::call() };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = { Self::call() };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+    impl<T: Trait + 'static> op_generics_static<T> {
+        pub const fn name() -> &'static str {
+            stringify!(op_generics_static)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = { Self::call() };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = { Self::call() };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
         }
+        #[inline(always)]
+        pub fn call() {}
     }
-    #[inline(always)]
-    pub fn call() {}
+    <op_generics_static<T> as ::deno_core::_ops::Op>::DECL
 }
 
 #[allow(non_camel_case_types)]
-pub struct op_generics_static_where<T> {
-    _unconstructable: ::std::marker::PhantomData<(T)>,
-}
-impl<T: Trait + 'static> ::deno_core::_ops::Op for op_generics_static_where<T> {
-    const NAME: &'static str = stringify!(op_generics_static_where);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_generics_static_where),
-        false,
-        false,
-        0usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl<T: Trait + 'static> op_generics_static_where<T> {
-    pub const fn name() -> &'static str {
-        stringify!(op_generics_static_where)
+pub const fn op_generics_static_where<T: Trait + 'static>() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_generics_static_where<T> {
+        _unconstructable: ::std::marker::PhantomData<(T)>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
+    impl<T: Trait + 'static> ::deno_core::_ops::Op for op_generics_static_where<T> {
+        const NAME: &'static str = stringify!(op_generics_static_where);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_generics_static_where),
+            false,
+            false,
+            0usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let res = Self::v8_fn_ptr_fast(this);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(_: deno_core::v8::Local<deno_core::v8::Object>) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = { Self::call() };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = { Self::call() };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+    impl<T: Trait + 'static> op_generics_static_where<T> {
+        pub const fn name() -> &'static str {
+            stringify!(op_generics_static_where)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = { Self::call() };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = { Self::call() };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
         }
+        #[inline(always)]
+        pub fn call()
+        where
+            T: Trait + 'static,
+        {}
     }
-    #[inline(always)]
-    pub fn call()
-    where
-        T: Trait + 'static,
-    {}
+    <op_generics_static_where<T> as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -40,10 +40,6 @@ pub const fn op_generics<T: Trait>() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_generics)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,
@@ -171,10 +167,6 @@ pub const fn op_generics_static<T: Trait + 'static>() -> ::deno_core::_ops::OpDe
         pub const fn name() -> &'static str {
             stringify!(op_generics_static)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,
@@ -301,10 +293,6 @@ pub const fn op_generics_static_where<T: Trait + 'static>() -> ::deno_core::_ops
     impl<T: Trait + 'static> op_generics_static_where<T> {
         pub const fn name() -> &'static str {
             stringify!(op_generics_static_where)
-        }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(

--- a/ops/op2/test_cases/sync/nofast.out
+++ b/ops/op2/test_cases/sync/nofast.out
@@ -1,107 +1,115 @@
 #[allow(non_camel_case_types)]
-struct op_nofast {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_nofast {
-    const NAME: &'static str = stringify!(op_nofast);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_nofast),
-        false,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_nofast {
-    pub const fn name() -> &'static str {
-        stringify!(op_nofast)
+const fn op_nofast() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_nofast {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_nofast {
+        const NAME: &'static str = stringify!(op_nofast);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_nofast),
+            false,
+            false,
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected u32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg0 = arg0 as _;
-            let arg1 = args.get(1usize as i32);
-            let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected u32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg1 = arg1 as _;
-            Self::call(arg0, arg1)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+    impl op_nofast {
+        pub const fn name() -> &'static str {
+            stringify!(op_nofast)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected u32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg0 = arg0 as _;
+                let arg1 = args.get(1usize as i32);
+                let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected u32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg1 = arg1 as _;
+                Self::call(arg0, arg1)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(a: u32, b: u32) -> u32 {
+            a + b
         }
     }
-    #[inline(always)]
-    fn call(a: u32, b: u32) -> u32 {
-        a + b
-    }
+    <op_nofast as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/nofast.out
+++ b/ops/op2/test_cases/sync/nofast.out
@@ -24,10 +24,6 @@ const fn op_nofast() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_nofast)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,

--- a/ops/op2/test_cases/sync/op_state_attr.out
+++ b/ops/op2/test_cases/sync/op_state_attr.out
@@ -1,150 +1,158 @@
 #[allow(non_camel_case_types)]
-struct op_state_rc {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_state_rc {
-    const NAME: &'static str = stringify!(op_state_rc);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_state_rc),
-        false,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_state_rc {
-    pub const fn name() -> &'static str {
-        stringify!(op_state_rc)
+const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_state_rc {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
+    impl ::deno_core::_ops::Op for op_state_rc {
+        const NAME: &'static str = stringify!(op_state_rc);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_state_rc),
+            false,
+            false,
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        let result = {
-            let arg0 = ::std::cell::RefCell::borrow(&opctx.state);
-            let arg0 = deno_core::_ops::opstate_borrow::<Something>(&arg0);
-            let arg1 = &::std::cell::RefCell::borrow(&opctx.state);
-            let arg1 = arg1.try_borrow::<Something>();
-            Self::call(arg0, arg1)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let opstate = &opctx.state;
-        let result = {
-            let arg0 = ::std::cell::RefCell::borrow(&opstate);
-            let arg0 = deno_core::_ops::opstate_borrow::<Something>(&arg0);
-            let arg1 = &::std::cell::RefCell::borrow(&opstate);
-            let arg1 = arg1.try_borrow::<Something>();
-            Self::call(arg0, arg1)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+    impl op_state_rc {
+        pub const fn name() -> &'static str {
+            stringify!(op_state_rc)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = {
+                let arg0 = ::std::cell::RefCell::borrow(&opctx.state);
+                let arg0 = deno_core::_ops::opstate_borrow::<Something>(&arg0);
+                let arg1 = &::std::cell::RefCell::borrow(&opctx.state);
+                let arg1 = arg1.try_borrow::<Something>();
+                Self::call(arg0, arg1)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let opstate = &opctx.state;
+            let result = {
+                let arg0 = ::std::cell::RefCell::borrow(&opstate);
+                let arg0 = deno_core::_ops::opstate_borrow::<Something>(&arg0);
+                let arg1 = &::std::cell::RefCell::borrow(&opstate);
+                let arg1 = arg1.try_borrow::<Something>();
+                Self::call(arg0, arg1)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
         }
+        #[inline(always)]
+        fn call(_arg: &Something, _arg_opt: Option<&Something>) {}
     }
-    #[inline(always)]
-    fn call(_arg: &Something, _arg_opt: Option<&Something>) {}
+    <op_state_rc as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/op_state_attr.out
+++ b/ops/op2/test_cases/sync/op_state_attr.out
@@ -40,10 +40,6 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_state_rc)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/op_state_rc.out
+++ b/ops/op2/test_cases/sync/op_state_rc.out
@@ -1,144 +1,152 @@
 #[allow(non_camel_case_types)]
-struct op_state_rc {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_state_rc {
-    const NAME: &'static str = stringify!(op_state_rc);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_state_rc),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_state_rc {
-    pub const fn name() -> &'static str {
-        stringify!(op_state_rc)
+const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_state_rc {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
+    impl ::deno_core::_ops::Op for op_state_rc {
+        const NAME: &'static str = stringify!(op_state_rc);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_state_rc),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        let result = {
-            let arg0 = opctx.state.clone();
-            Self::call(arg0)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let opstate = &opctx.state;
-        let result = {
-            let arg0 = opstate.clone();
-            Self::call(arg0)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+    impl op_state_rc {
+        pub const fn name() -> &'static str {
+            stringify!(op_state_rc)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = {
+                let arg0 = opctx.state.clone();
+                Self::call(arg0)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let opstate = &opctx.state;
+            let result = {
+                let arg0 = opstate.clone();
+                Self::call(arg0)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
         }
+        #[inline(always)]
+        fn call(_state: Rc<RefCell<OpState>>) {}
     }
-    #[inline(always)]
-    fn call(_state: Rc<RefCell<OpState>>) {}
+    <op_state_rc as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/op_state_rc.out
+++ b/ops/op2/test_cases/sync/op_state_rc.out
@@ -40,10 +40,6 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_state_rc)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -40,10 +40,6 @@ const fn op_state_ref() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_state_ref)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,
@@ -193,10 +189,6 @@ const fn op_state_mut() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_state_mut)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,
@@ -330,10 +322,6 @@ const fn op_state_and_v8() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_state_and_v8)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,
@@ -454,10 +442,6 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
     impl op_state_and_v8_local {
         pub const fn name() -> &'static str {
             stringify!(op_state_and_v8_local)
-        }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -1,560 +1,592 @@
 #[allow(non_camel_case_types)]
-struct op_state_ref {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_state_ref {
-    const NAME: &'static str = stringify!(op_state_ref);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_state_ref),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_state_ref {
-    pub const fn name() -> &'static str {
-        stringify!(op_state_ref)
+const fn op_state_ref() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_state_ref {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
+    impl ::deno_core::_ops::Op for op_state_ref {
+        const NAME: &'static str = stringify!(op_state_ref);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_state_ref),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        let result = {
-            let arg0 = &::std::cell::RefCell::borrow(&opctx.state);
-            Self::call(arg0)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let opstate = &opctx.state;
-        let result = {
-            let arg0 = &::std::cell::RefCell::borrow(&opstate);
-            Self::call(arg0)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+    impl op_state_ref {
+        pub const fn name() -> &'static str {
+            stringify!(op_state_ref)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = {
+                let arg0 = &::std::cell::RefCell::borrow(&opctx.state);
+                Self::call(arg0)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let opstate = &opctx.state;
+            let result = {
+                let arg0 = &::std::cell::RefCell::borrow(&opstate);
+                Self::call(arg0)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
         }
+        #[inline(always)]
+        fn call(_state: &OpState) {}
     }
-    #[inline(always)]
-    fn call(_state: &OpState) {}
+    <op_state_ref as ::deno_core::_ops::Op>::DECL
 }
 
 #[allow(non_camel_case_types)]
-struct op_state_mut {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_state_mut {
-    const NAME: &'static str = stringify!(op_state_mut);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_state_mut),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_state_mut {
-    pub const fn name() -> &'static str {
-        stringify!(op_state_mut)
+const fn op_state_mut() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_state_mut {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
+    impl ::deno_core::_ops::Op for op_state_mut {
+        const NAME: &'static str = stringify!(op_state_mut);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_state_mut),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        let result = {
-            let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opctx.state);
-            Self::call(arg0)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let opstate = &opctx.state;
-        let result = {
-            let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opstate);
-            Self::call(arg0)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+    impl op_state_mut {
+        pub const fn name() -> &'static str {
+            stringify!(op_state_mut)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = {
+                let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opctx.state);
+                Self::call(arg0)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let opstate = &opctx.state;
+            let result = {
+                let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opstate);
+                Self::call(arg0)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
         }
+        #[inline(always)]
+        fn call(_state: &mut OpState) {}
     }
-    #[inline(always)]
-    fn call(_state: &mut OpState) {}
+    <op_state_mut as ::deno_core::_ops::Op>::DECL
 }
 
 #[allow(non_camel_case_types)]
-struct op_state_and_v8 {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_state_and_v8 {
-    const NAME: &'static str = stringify!(op_state_and_v8);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_state_and_v8),
-        false,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_state_and_v8 {
-    pub const fn name() -> &'static str {
-        stringify!(op_state_and_v8)
+const fn op_state_and_v8() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_state_and_v8 {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_state_and_v8 {
+        const NAME: &'static str = stringify!(op_state_and_v8);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_state_and_v8),
+            false,
+            false,
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let mut scope = unsafe { &mut *opctx.isolate };
-        let opstate = &opctx.state;
-        let result = {
-            let arg1 = args.get(0usize as i32);
-            let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
-                deno_core::v8::Function,
-            >(arg1) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected Function".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg1 = deno_core::v8::Global::new(&mut scope, arg1);
-            let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opstate);
-            Self::call(arg0, arg1)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+    impl op_state_and_v8 {
+        pub const fn name() -> &'static str {
+            stringify!(op_state_and_v8)
         }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let mut scope = unsafe { &mut *opctx.isolate };
+            let opstate = &opctx.state;
+            let result = {
+                let arg1 = args.get(0usize as i32);
+                let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
+                    deno_core::v8::Function,
+                >(arg1) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected Function".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg1 = deno_core::v8::Global::new(&mut scope, arg1);
+                let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opstate);
+                Self::call(arg0, arg1)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_slow(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(_state: &mut OpState, _callback: v8::Global<v8::Function>) {}
     }
-    #[inline(always)]
-    fn call(_state: &mut OpState, _callback: v8::Global<v8::Function>) {}
+    <op_state_and_v8 as ::deno_core::_ops::Op>::DECL
 }
 
 #[allow(non_camel_case_types)]
-struct op_state_and_v8_local {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_state_and_v8_local {
-    const NAME: &'static str = stringify!(op_state_and_v8_local);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_state_and_v8_local),
-        false,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_state_and_v8_local {
-    pub const fn name() -> &'static str {
-        stringify!(op_state_and_v8_local)
+const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_state_and_v8_local {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
+    impl ::deno_core::_ops::Op for op_state_and_v8_local {
+        const NAME: &'static str = stringify!(op_state_and_v8_local);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_state_and_v8_local),
+            false,
+            false,
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        arg1: deno_core::v8::Local<deno_core::v8::Value>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, arg1, fast_api_callback_options);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg1: deno_core::v8::Local<deno_core::v8::Value>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        let result = {
-            let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opctx.state);
-            let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
-                deno_core::v8::Function,
-            >(arg1) else {
-                fast_api_callback_options.fallback = true;
-                return unsafe { std::mem::zeroed() };
+    impl op_state_and_v8_local {
+        pub const fn name() -> &'static str {
+            stringify!(op_state_and_v8_local)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg1: deno_core::v8::Local<deno_core::v8::Value>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
             };
-            let arg1 = arg1;
-            Self::call(arg0, arg1)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let opstate = &opctx.state;
-        let result = {
-            let arg1 = args.get(0usize as i32);
-            let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
-                deno_core::v8::Function,
-            >(arg1) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected Function".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg1 = arg1;
-            let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opstate);
-            Self::call(arg0, arg1)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, arg1, fast_api_callback_options);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            arg1: deno_core::v8::Local<deno_core::v8::Value>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = {
+                let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opctx.state);
+                let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
+                    deno_core::v8::Function,
+                >(arg1) else {
+                    fast_api_callback_options.fallback = true;
+                    return unsafe { std::mem::zeroed() };
+                };
+                let arg1 = arg1;
+                Self::call(arg0, arg1)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let opstate = &opctx.state;
+            let result = {
+                let arg1 = args.get(0usize as i32);
+                let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
+                    deno_core::v8::Function,
+                >(arg1) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected Function".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg1 = arg1;
+                let arg0 = &mut ::std::cell::RefCell::borrow_mut(&opstate);
+                Self::call(arg0, arg1)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
         }
+        #[inline(always)]
+        fn call(_state: &mut OpState, _callback: v8::Local<v8::Function>) {}
     }
-    #[inline(always)]
-    fn call(_state: &mut OpState, _callback: v8::Local<v8::Function>) {}
+    <op_state_and_v8_local as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/result_external.out
+++ b/ops/op2/test_cases/sync/result_external.out
@@ -1,135 +1,123 @@
 #[allow(non_camel_case_types)]
-pub struct op_external_with_result {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_external_with_result {
-    const NAME: &'static str = stringify!(op_external_with_result);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_external_with_result),
-        false,
-        false,
-        0usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Pointer,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Pointer,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_external_with_result {
-    pub const fn name() -> &'static str {
-        stringify!(op_external_with_result)
+pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_external_with_result {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
+    impl ::deno_core::_ops::Op for op_external_with_result {
+        const NAME: &'static str = stringify!(op_external_with_result);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_external_with_result),
+            false,
+            false,
+            0usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Pointer,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Pointer,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> *mut ::std::ffi::c_void {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> *mut ::std::ffi::c_void {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        let result = { Self::call() };
-        let result = match result {
-            Ok(result) => result,
-            Err(err) => {
-                let err = err.into();
-                unsafe {
-                    opctx.unsafely_set_last_error_for_ops_only(err);
+    impl op_external_with_result {
+        pub const fn name() -> &'static str {
+            stringify!(op_external_with_result)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> *mut ::std::ffi::c_void {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Completed,
+            );
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> *mut ::std::ffi::c_void {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = { Self::call() };
+            let result = match result {
+                Ok(result) => result,
+                Err(err) => {
+                    let err = err.into();
+                    unsafe {
+                        opctx.unsafely_set_last_error_for_ops_only(err);
+                    }
+                    fast_api_callback_options.fallback = true;
+                    return unsafe { std::mem::zeroed() };
                 }
-                fast_api_callback_options.fallback = true;
-                return unsafe { std::mem::zeroed() };
-            }
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        if let Some(err) = unsafe { opctx.unsafely_take_last_error_for_ops_only() } {
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
             let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
             let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
                 &*info
             });
-            let err = err.into();
-            let exception = deno_core::error::to_v8_error(
-                &mut scope,
-                opctx.get_error_class_fn,
-                &err,
-            );
-            scope.throw_exception(exception);
-            return 1;
-        }
-        let result = { Self::call() };
-        match result {
-            Ok(result) => rv.set(deno_core::_ops::RustToV8::to_v8(result, &mut scope)),
-            Err(err) => {
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            if let Some(err) = unsafe { opctx.unsafely_take_last_error_for_ops_only() } {
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                 let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
                     &*info
                 });
@@ -142,39 +130,61 @@ impl op_external_with_result {
                 scope.throw_exception(exception);
                 return 1;
             }
-        };
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+            let result = { Self::call() };
+            match result {
+                Ok(result) => {
+                    rv.set(deno_core::_ops::RustToV8::to_v8(result, &mut scope))
+                }
+                Err(err) => {
+                    let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                        &*info
+                    });
+                    let err = err.into();
+                    let exception = deno_core::error::to_v8_error(
+                        &mut scope,
+                        opctx.get_error_class_fn,
+                        &err,
+                    );
+                    scope.throw_exception(exception);
+                    return 1;
+                }
+            };
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub fn call() -> Result<*mut std::ffi::c_void, AnyError> {
+            Ok(0 as _)
         }
     }
-    #[inline(always)]
-    pub fn call() -> Result<*mut std::ffi::c_void, AnyError> {
-        Ok(0 as _)
-    }
+    <op_external_with_result as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/result_external.out
+++ b/ops/op2/test_cases/sync/result_external.out
@@ -40,10 +40,6 @@ pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_external_with_result)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -40,10 +40,6 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_u32_with_result)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -1,134 +1,121 @@
 #[allow(non_camel_case_types)]
-pub struct op_u32_with_result {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_u32_with_result {
-    const NAME: &'static str = stringify!(op_u32_with_result);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_u32_with_result),
-        false,
-        false,
-        0usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Uint32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Uint32,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_u32_with_result {
-    pub const fn name() -> &'static str {
-        stringify!(op_u32_with_result)
+pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_u32_with_result {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
+    impl ::deno_core::_ops::Op for op_u32_with_result {
+        const NAME: &'static str = stringify!(op_u32_with_result);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_u32_with_result),
+            false,
+            false,
+            0usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Uint32,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Uint32,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> u32 {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> u32 {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        let result = { Self::call() };
-        let result = match result {
-            Ok(result) => result,
-            Err(err) => {
-                let err = err.into();
-                unsafe {
-                    opctx.unsafely_set_last_error_for_ops_only(err);
+    impl op_u32_with_result {
+        pub const fn name() -> &'static str {
+            stringify!(op_u32_with_result)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> u32 {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Completed,
+            );
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> u32 {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = { Self::call() };
+            let result = match result {
+                Ok(result) => result,
+                Err(err) => {
+                    let err = err.into();
+                    unsafe {
+                        opctx.unsafely_set_last_error_for_ops_only(err);
+                    }
+                    fast_api_callback_options.fallback = true;
+                    return unsafe { std::mem::zeroed() };
                 }
-                fast_api_callback_options.fallback = true;
-                return unsafe { std::mem::zeroed() };
-            }
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        if let Some(err) = unsafe { opctx.unsafely_take_last_error_for_ops_only() } {
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
             let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
                 &*info
             });
-            let err = err.into();
-            let exception = deno_core::error::to_v8_error(
-                &mut scope,
-                opctx.get_error_class_fn,
-                &err,
-            );
-            scope.throw_exception(exception);
-            return 1;
-        }
-        let result = { Self::call() };
-        match result {
-            Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
-            Err(err) => {
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            if let Some(err) = unsafe { opctx.unsafely_take_last_error_for_ops_only() } {
                 let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                 let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
                     &*info
@@ -142,39 +129,60 @@ impl op_u32_with_result {
                 scope.throw_exception(exception);
                 return 1;
             }
-        };
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+            let result = { Self::call() };
+            match result {
+                Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
+                Err(err) => {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                        &*info
+                    });
+                    let err = err.into();
+                    let exception = deno_core::error::to_v8_error(
+                        &mut scope,
+                        opctx.get_error_class_fn,
+                        &err,
+                    );
+                    scope.throw_exception(exception);
+                    return 1;
+                }
+            };
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub fn call() -> Result<u32, AnyError> {
+            Ok(0)
         }
     }
-    #[inline(always)]
-    pub fn call() -> Result<u32, AnyError> {
-        Ok(0)
-    }
+    <op_u32_with_result as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/result_scope.out
+++ b/ops/op2/test_cases/sync/result_scope.out
@@ -24,10 +24,6 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_void_with_result)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,

--- a/ops/op2/test_cases/sync/result_scope.out
+++ b/ops/op2/test_cases/sync/result_scope.out
@@ -1,97 +1,107 @@
 #[allow(non_camel_case_types)]
-pub struct op_void_with_result {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_void_with_result {
-    const NAME: &'static str = stringify!(op_void_with_result);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_void_with_result),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_void_with_result {
-    pub const fn name() -> &'static str {
-        stringify!(op_void_with_result)
+pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_void_with_result {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_void_with_result {
+        const NAME: &'static str = stringify!(op_void_with_result);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_void_with_result),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = &mut scope;
-            Self::call(arg0)
-        };
-        match result {
-            Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
-            Err(err) => {
-                let opctx = unsafe {
-                    &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
-                        .value() as *const deno_core::_ops::OpCtx)
-                };
-                let err = err.into();
-                let exception = deno_core::error::to_v8_error(
-                    &mut scope,
-                    opctx.get_error_class_fn,
-                    &err,
+    }
+    impl op_void_with_result {
+        pub const fn name() -> &'static str {
+            stringify!(op_void_with_result)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = &mut scope;
+                Self::call(arg0)
+            };
+            match result {
+                Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
+                Err(err) => {
+                    let opctx = unsafe {
+                        &*(deno_core::v8::Local::<
+                            deno_core::v8::External,
+                        >::cast(args.data())
+                            .value() as *const deno_core::_ops::OpCtx)
+                    };
+                    let err = err.into();
+                    let exception = deno_core::error::to_v8_error(
+                        &mut scope,
+                        opctx.get_error_class_fn,
+                        &err,
+                    );
+                    scope.throw_exception(exception);
+                    return 1;
+                }
+            };
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_slow(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
                 );
-                scope.throw_exception(exception);
-                return 1;
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
             }
-        };
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+        }
+        #[inline(always)]
+        pub fn call(_scope: &mut v8::HandleScope) -> Result<(), AnyError> {
+            Ok(())
         }
     }
-    #[inline(always)]
-    pub fn call(_scope: &mut v8::HandleScope) -> Result<(), AnyError> {
-        Ok(())
-    }
+    <op_void_with_result as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -40,10 +40,6 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_void_with_result)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -1,134 +1,121 @@
 #[allow(non_camel_case_types)]
-pub struct op_void_with_result {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_void_with_result {
-    const NAME: &'static str = stringify!(op_void_with_result);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_void_with_result),
-        false,
-        false,
-        0usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_void_with_result {
-    pub const fn name() -> &'static str {
-        stringify!(op_void_with_result)
+pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_void_with_result {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
+    impl ::deno_core::_ops::Op for op_void_with_result {
+        const NAME: &'static str = stringify!(op_void_with_result);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_void_with_result),
+            false,
+            false,
+            0usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        let result = { Self::call() };
-        let result = match result {
-            Ok(result) => result,
-            Err(err) => {
-                let err = err.into();
-                unsafe {
-                    opctx.unsafely_set_last_error_for_ops_only(err);
+    impl op_void_with_result {
+        pub const fn name() -> &'static str {
+            stringify!(op_void_with_result)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Completed,
+            );
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = { Self::call() };
+            let result = match result {
+                Ok(result) => result,
+                Err(err) => {
+                    let err = err.into();
+                    unsafe {
+                        opctx.unsafely_set_last_error_for_ops_only(err);
+                    }
+                    fast_api_callback_options.fallback = true;
+                    return unsafe { std::mem::zeroed() };
                 }
-                fast_api_callback_options.fallback = true;
-                return unsafe { std::mem::zeroed() };
-            }
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        if let Some(err) = unsafe { opctx.unsafely_take_last_error_for_ops_only() } {
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
             let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
                 &*info
             });
-            let err = err.into();
-            let exception = deno_core::error::to_v8_error(
-                &mut scope,
-                opctx.get_error_class_fn,
-                &err,
-            );
-            scope.throw_exception(exception);
-            return 1;
-        }
-        let result = { Self::call() };
-        match result {
-            Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
-            Err(err) => {
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            if let Some(err) = unsafe { opctx.unsafely_take_last_error_for_ops_only() } {
                 let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                 let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
                     &*info
@@ -142,39 +129,60 @@ impl op_void_with_result {
                 scope.throw_exception(exception);
                 return 1;
             }
-        };
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+            let result = { Self::call() };
+            match result {
+                Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
+                Err(err) => {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                        &*info
+                    });
+                    let err = err.into();
+                    let exception = deno_core::error::to_v8_error(
+                        &mut scope,
+                        opctx.get_error_class_fn,
+                        &err,
+                    );
+                    scope.throw_exception(exception);
+                    return 1;
+                }
+            };
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub fn call() -> std::io::Result<()> {
+            Ok(())
         }
     }
-    #[inline(always)]
-    pub fn call() -> std::io::Result<()> {
-        Ok(())
-    }
+    <op_void_with_result as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/serde_v8.out
+++ b/ops/op2/test_cases/sync/serde_v8.out
@@ -1,52 +1,77 @@
 #[allow(non_camel_case_types)]
-pub struct op_serde_v8 {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_serde_v8 {
-    const NAME: &'static str = stringify!(op_serde_v8);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_serde_v8),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_serde_v8 {
-    pub const fn name() -> &'static str {
-        stringify!(op_serde_v8)
+pub const fn op_serde_v8() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_serde_v8 {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_serde_v8 {
+        const NAME: &'static str = stringify!(op_serde_v8);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_serde_v8),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let arg0 = match deno_core::_ops::serde_v8_to_rust(&mut scope, arg0) {
-                Ok(t) => t,
-                Err(arg0_err) => {
+    }
+    impl op_serde_v8 {
+        pub const fn name() -> &'static str {
+            stringify!(op_serde_v8)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let arg0 = match deno_core::_ops::serde_v8_to_rust(&mut scope, arg0) {
+                    Ok(t) => t,
+                    Err(arg0_err) => {
+                        let msg = deno_core::v8::String::new(
+                                &mut scope,
+                                &format!("{}", deno_core::anyhow::Error::from(arg0_err)),
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    }
+                };
+                Self::call(arg0)
+            };
+            match deno_core::_ops::RustToV8Fallible::to_v8_fallible(
+                deno_core::_ops::RustToV8Marker::<
+                    deno_core::_ops::SerdeMarker,
+                    _,
+                >::from(result),
+                &mut scope,
+            ) {
+                Ok(v) => rv.set(v),
+                Err(rv_err) => {
                     let msg = deno_core::v8::String::new(
                             &mut scope,
-                            &format!("{}", deno_core::anyhow::Error::from(arg0_err)),
+                            &format!("{}", deno_core::anyhow::Error::from(rv_err)),
                         )
                         .unwrap();
                     let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
@@ -54,59 +79,42 @@ impl op_serde_v8 {
                     return 1;
                 }
             };
-            Self::call(arg0)
-        };
-        match deno_core::_ops::RustToV8Fallible::to_v8_fallible(
-            deno_core::_ops::RustToV8Marker::<
-                deno_core::_ops::SerdeMarker,
-                _,
-            >::from(result),
-            &mut scope,
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            Ok(v) => rv.set(v),
-            Err(rv_err) => {
-                let msg = deno_core::v8::String::new(
-                        &mut scope,
-                        &format!("{}", deno_core::anyhow::Error::from(rv_err)),
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_slow(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
             }
-        };
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+        }
+        #[inline(always)]
+        pub fn call(_input: Input) -> Output {
+            Output {}
         }
     }
-    #[inline(always)]
-    pub fn call(_input: Input) -> Output {
-        Output {}
-    }
+    <op_serde_v8 as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/serde_v8.out
+++ b/ops/op2/test_cases/sync/serde_v8.out
@@ -24,10 +24,6 @@ pub const fn op_serde_v8() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_serde_v8)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -47,10 +47,6 @@ const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_smi_unsigned_return)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,
@@ -268,10 +264,6 @@ const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_smi_signed_return)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,
@@ -465,10 +457,6 @@ const fn op_smi_option() -> ::deno_core::_ops::OpDecl {
     impl op_smi_option {
         pub const fn name() -> &'static str {
             stringify!(op_smi_option)
-        }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
         }
         #[inline(always)]
         fn slow_function_impl(

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -1,474 +1,120 @@
 #[allow(non_camel_case_types)]
-struct op_smi_unsigned_return {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_smi_unsigned_return {
-    const NAME: &'static str = stringify!(op_smi_unsigned_return);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_smi_unsigned_return),
-        false,
-        false,
-        4usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::Int32, Type::Int32, Type::Int32, Type::Int32],
-                CType::Int32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[
-                    Type::V8Value,
-                    Type::Int32,
-                    Type::Int32,
-                    Type::Int32,
-                    Type::Int32,
-                    Type::CallbackOptions,
-                ],
-                CType::Int32,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_smi_unsigned_return {
-    pub const fn name() -> &'static str {
-        stringify!(op_smi_unsigned_return)
+const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_smi_unsigned_return {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
+    impl ::deno_core::_ops::Op for op_smi_unsigned_return {
+        const NAME: &'static str = stringify!(op_smi_unsigned_return);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_smi_unsigned_return),
+            false,
+            false,
+            4usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::Int32, Type::Int32, Type::Int32, Type::Int32],
+                    CType::Int32,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[
+                        Type::V8Value,
+                        Type::Int32,
+                        Type::Int32,
+                        Type::Int32,
+                        Type::Int32,
+                        Type::CallbackOptions,
+                    ],
+                    CType::Int32,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: i32,
-        arg1: i32,
-        arg2: i32,
-        arg3: i32,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> i32 {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: i32,
-        arg1: i32,
-        arg2: i32,
-        arg3: i32,
-    ) -> i32 {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = {
-            let arg0 = arg0 as _;
-            let arg1 = arg1 as _;
-            let arg2 = arg2 as _;
-            let arg3 = arg3 as _;
-            Self::call(arg0, arg1, arg2, arg3)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected i32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
+    impl op_smi_unsigned_return {
+        pub const fn name() -> &'static str {
+            stringify!(op_smi_unsigned_return)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: i32,
+            arg1: i32,
+            arg2: i32,
+            arg3: i32,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> i32 {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
             };
-            let arg0 = arg0 as _;
-            let arg1 = args.get(1usize as i32);
-            let Some(arg1) = deno_core::_ops::to_i32_option(&arg1) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected i32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg1 = arg1 as _;
-            let arg2 = args.get(2usize as i32);
-            let Some(arg2) = deno_core::_ops::to_i32_option(&arg2) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected i32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg2 = arg2 as _;
-            let arg3 = args.get(3usize as i32);
-            let Some(arg3) = deno_core::_ops::to_i32_option(&arg3) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected i32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg3 = arg3 as _;
-            Self::call(arg0, arg1, arg2, arg3)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(
-            deno_core::_ops::RustToV8Marker::<
-                deno_core::_ops::SmiMarker,
-                _,
-            >::from(result),
-            &mut rv,
-        );
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            res
         }
-    }
-    #[inline(always)]
-    fn call(a: Int16, b: Int32, c: Uint16, d: Uint32) -> Uint32 {
-        a as Uint32 + b as Uint32 + c as Uint32 + d as Uint32
-    }
-}
-
-#[allow(non_camel_case_types)]
-struct op_smi_signed_return {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_smi_signed_return {
-    const NAME: &'static str = stringify!(op_smi_signed_return);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_smi_signed_return),
-        false,
-        false,
-        4usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::Int32, Type::Int32, Type::Int32, Type::Int32],
-                CType::Int32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[
-                    Type::V8Value,
-                    Type::Int32,
-                    Type::Int32,
-                    Type::Int32,
-                    Type::Int32,
-                    Type::CallbackOptions,
-                ],
-                CType::Int32,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_smi_signed_return {
-    pub const fn name() -> &'static str {
-        stringify!(op_smi_signed_return)
-    }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: i32,
-        arg1: i32,
-        arg2: i32,
-        arg3: i32,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> i32 {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: i32,
-        arg1: i32,
-        arg2: i32,
-        arg3: i32,
-    ) -> i32 {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = {
-            let arg0 = arg0 as _;
-            let arg1 = arg1 as _;
-            let arg2 = arg2 as _;
-            let arg3 = arg3 as _;
-            Self::call(arg0, arg1, arg2, arg3)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected i32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg0 = arg0 as _;
-            let arg1 = args.get(1usize as i32);
-            let Some(arg1) = deno_core::_ops::to_i32_option(&arg1) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected i32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg1 = arg1 as _;
-            let arg2 = args.get(2usize as i32);
-            let Some(arg2) = deno_core::_ops::to_i32_option(&arg2) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected i32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg2 = arg2 as _;
-            let arg3 = args.get(3usize as i32);
-            let Some(arg3) = deno_core::_ops::to_i32_option(&arg3) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected i32".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg3 = arg3 as _;
-            Self::call(arg0, arg1, arg2, arg3)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(
-            deno_core::_ops::RustToV8Marker::<
-                deno_core::_ops::SmiMarker,
-                _,
-            >::from(result),
-            &mut rv,
-        );
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: i32,
+            arg1: i32,
+            arg2: i32,
+            arg3: i32,
+        ) -> i32 {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
             );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let result = {
+                let arg0 = arg0 as _;
+                let arg1 = arg1 as _;
+                let arg2 = arg2 as _;
+                let arg3 = arg3 as _;
+                Self::call(arg0, arg1, arg2, arg3)
+            };
+            result as _
         }
-    }
-    #[inline(always)]
-    fn call(a: Int16, b: Int32, c: Uint16, d: Uint32) -> Int32 {
-        a as Int32 + b as Int32 + c as Int32 + d as Int32
-    }
-}
-
-#[allow(non_camel_case_types)]
-struct op_smi_option {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_smi_option {
-    const NAME: &'static str = stringify!(op_smi_option);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_smi_option),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_smi_option {
-    pub const fn name() -> &'static str {
-        stringify!(op_smi_option)
-    }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let arg0 = if arg0.is_null_or_undefined() {
-                None
-            } else {
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
@@ -482,43 +128,423 @@ impl op_smi_option {
                     return 1;
                 };
                 let arg0 = arg0 as _;
-                Some(arg0)
+                let arg1 = args.get(1usize as i32);
+                let Some(arg1) = deno_core::_ops::to_i32_option(&arg1) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected i32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg1 = arg1 as _;
+                let arg2 = args.get(2usize as i32);
+                let Some(arg2) = deno_core::_ops::to_i32_option(&arg2) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected i32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg2 = arg2 as _;
+                let arg3 = args.get(3usize as i32);
+                let Some(arg3) = deno_core::_ops::to_i32_option(&arg3) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected i32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg3 = arg3 as _;
+                Self::call(arg0, arg1, arg2, arg3)
             };
-            Self::call(arg0)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(
+                deno_core::_ops::RustToV8Marker::<
+                    deno_core::_ops::SmiMarker,
+                    _,
+                >::from(result),
+                &mut rv,
+            );
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(a: Int16, b: Int32, c: Uint16, d: Uint32) -> Uint32 {
+            a as Uint32 + b as Uint32 + c as Uint32 + d as Uint32
+        }
+    }
+    <op_smi_unsigned_return as ::deno_core::_ops::Op>::DECL
+}
+
+#[allow(non_camel_case_types)]
+const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_smi_signed_return {
+        _unconstructable: ::std::marker::PhantomData<()>,
+    }
+    impl ::deno_core::_ops::Op for op_smi_signed_return {
+        const NAME: &'static str = stringify!(op_smi_signed_return);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_smi_signed_return),
+            false,
+            false,
+            4usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::Int32, Type::Int32, Type::Int32, Type::Int32],
+                    CType::Int32,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[
+                        Type::V8Value,
+                        Type::Int32,
+                        Type::Int32,
+                        Type::Int32,
+                        Type::Int32,
+                        Type::CallbackOptions,
+                    ],
+                    CType::Int32,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
+    }
+    impl op_smi_signed_return {
+        pub const fn name() -> &'static str {
+            stringify!(op_smi_signed_return)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: i32,
+            arg1: i32,
+            arg2: i32,
+            arg3: i32,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> i32 {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: i32,
+            arg1: i32,
+            arg2: i32,
+            arg3: i32,
+        ) -> i32 {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = {
+                let arg0 = arg0 as _;
+                let arg1 = arg1 as _;
+                let arg2 = arg2 as _;
+                let arg3 = arg3 as _;
+                Self::call(arg0, arg1, arg2, arg3)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected i32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg0 = arg0 as _;
+                let arg1 = args.get(1usize as i32);
+                let Some(arg1) = deno_core::_ops::to_i32_option(&arg1) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected i32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg1 = arg1 as _;
+                let arg2 = args.get(2usize as i32);
+                let Some(arg2) = deno_core::_ops::to_i32_option(&arg2) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected i32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg2 = arg2 as _;
+                let arg3 = args.get(3usize as i32);
+                let Some(arg3) = deno_core::_ops::to_i32_option(&arg3) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected i32".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg3 = arg3 as _;
+                Self::call(arg0, arg1, arg2, arg3)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(
+                deno_core::_ops::RustToV8Marker::<
+                    deno_core::_ops::SmiMarker,
+                    _,
+                >::from(result),
+                &mut rv,
+            );
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(a: Int16, b: Int32, c: Uint16, d: Uint32) -> Int32 {
+            a as Int32 + b as Int32 + c as Int32 + d as Int32
         }
     }
-    #[inline(always)]
-    fn call(a: Option<Uint32>) -> Option<Uint32> {
-        a
+    <op_smi_signed_return as ::deno_core::_ops::Op>::DECL
+}
+
+#[allow(non_camel_case_types)]
+const fn op_smi_option() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_smi_option {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
+    impl ::deno_core::_ops::Op for op_smi_option {
+        const NAME: &'static str = stringify!(op_smi_option);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_smi_option),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
+    }
+    impl op_smi_option {
+        pub const fn name() -> &'static str {
+            stringify!(op_smi_option)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let arg0 = if arg0.is_null_or_undefined() {
+                    None
+                } else {
+                    let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let msg = deno_core::v8::String::new_from_one_byte(
+                                &mut scope,
+                                "expected i32".as_bytes(),
+                                deno_core::v8::NewStringType::Normal,
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    };
+                    let arg0 = arg0 as _;
+                    Some(arg0)
+                };
+                Self::call(arg0)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_slow(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(a: Option<Uint32>) -> Option<Uint32> {
+            a
+        }
+    }
+    <op_smi_option as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/string_cow.out
+++ b/ops/op2/test_cases/sync/string_cow.out
@@ -40,10 +40,6 @@ const fn op_string_cow() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_string_cow)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/string_cow.out
+++ b/ops/op2/test_cases/sync/string_cow.out
@@ -1,150 +1,158 @@
 #[allow(non_camel_case_types)]
-struct op_string_cow {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_string_cow {
-    const NAME: &'static str = stringify!(op_string_cow);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_string_cow),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::SeqOneByteString],
-                CType::Uint32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
-                CType::Uint32,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_string_cow {
-    pub const fn name() -> &'static str {
-        stringify!(op_string_cow)
+const fn op_string_cow() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_string_cow {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
+    impl ::deno_core::_ops::Op for op_string_cow {
+        const NAME: &'static str = stringify!(op_string_cow);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_string_cow),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::SeqOneByteString],
+                    CType::Uint32,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
+                    CType::Uint32,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> u32 {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, arg0);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
-    ) -> u32 {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = {
-            let mut arg0_temp: [::std::mem::MaybeUninit<
-                u8,
-            >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
-            let arg0 = deno_core::_ops::to_str_ptr(
-                unsafe { &mut *arg0 },
-                &mut arg0_temp,
+    impl op_string_cow {
+        pub const fn name() -> &'static str {
+            stringify!(op_string_cow)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> u32 {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-            Self::call(arg0)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let mut scope = unsafe { &mut *opctx.isolate };
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let mut arg0_temp: [::std::mem::MaybeUninit<
-                u8,
-            >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
-            let arg0 = deno_core::_ops::to_str(&mut scope, &arg0, &mut arg0_temp);
-            Self::call(arg0)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+            let res = Self::v8_fn_ptr_fast(this, arg0);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
+        ) -> u32 {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = {
+                let mut arg0_temp: [::std::mem::MaybeUninit<
+                    u8,
+                >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
+                let arg0 = deno_core::_ops::to_str_ptr(
+                    unsafe { &mut *arg0 },
+                    &mut arg0_temp,
+                );
+                Self::call(arg0)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let mut scope = unsafe { &mut *opctx.isolate };
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let mut arg0_temp: [::std::mem::MaybeUninit<
+                    u8,
+                >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
+                let arg0 = deno_core::_ops::to_str(&mut scope, &arg0, &mut arg0_temp);
+                Self::call(arg0)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(s: Cow<str>) -> u32 {
+            s.len() as _
         }
     }
-    #[inline(always)]
-    fn call(s: Cow<str>) -> u32 {
-        s.len() as _
-    }
+    <op_string_cow as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/string_onebyte.out
+++ b/ops/op2/test_cases/sync/string_onebyte.out
@@ -1,155 +1,165 @@
 #[allow(non_camel_case_types)]
-struct op_string_onebyte {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_string_onebyte {
-    const NAME: &'static str = stringify!(op_string_onebyte);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_string_onebyte),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::SeqOneByteString],
-                CType::Uint32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
-                CType::Uint32,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_string_onebyte {
-    pub const fn name() -> &'static str {
-        stringify!(op_string_onebyte)
+const fn op_string_onebyte() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_string_onebyte {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
+    impl ::deno_core::_ops::Op for op_string_onebyte {
+        const NAME: &'static str = stringify!(op_string_onebyte);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_string_onebyte),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::SeqOneByteString],
+                    CType::Uint32,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
+                    CType::Uint32,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> u32 {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, arg0);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
-    ) -> u32 {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = {
-            let arg0 = deno_core::_ops::to_cow_byte_ptr(unsafe { &mut *arg0 });
-            Self::call(arg0)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let mut scope = unsafe { &mut *opctx.isolate };
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let arg0 = match deno_core::_ops::to_cow_one_byte(&mut scope, &arg0) {
-                Ok(arg0) => arg0,
-                Err(arg0) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            arg0.as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
-                    return 1;
-                }
+    impl op_string_onebyte {
+        pub const fn name() -> &'static str {
+            stringify!(op_string_onebyte)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> u32 {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
             };
-            Self::call(arg0)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, arg0);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
+        ) -> u32 {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = {
+                let arg0 = deno_core::_ops::to_cow_byte_ptr(unsafe { &mut *arg0 });
+                Self::call(arg0)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let mut scope = unsafe { &mut *opctx.isolate };
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let arg0 = match deno_core::_ops::to_cow_one_byte(&mut scope, &arg0) {
+                    Ok(arg0) => arg0,
+                    Err(arg0) => {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(&*info)
+                        };
+                        let msg = deno_core::v8::String::new_from_one_byte(
+                                &mut scope,
+                                arg0.as_bytes(),
+                                deno_core::v8::NewStringType::Normal,
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    }
+                };
+                Self::call(arg0)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(s: Cow<[u8]>) -> u32 {
+            s.len() as _
         }
     }
-    #[inline(always)]
-    fn call(s: Cow<[u8]>) -> u32 {
-        s.len() as _
-    }
+    <op_string_onebyte as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/string_onebyte.out
+++ b/ops/op2/test_cases/sync/string_onebyte.out
@@ -40,10 +40,6 @@ const fn op_string_onebyte() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_string_onebyte)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/string_option_return.out
+++ b/ops/op2/test_cases/sync/string_option_return.out
@@ -24,10 +24,6 @@ pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_string_return)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,

--- a/ops/op2/test_cases/sync/string_option_return.out
+++ b/ops/op2/test_cases/sync/string_option_return.out
@@ -1,98 +1,106 @@
 #[allow(non_camel_case_types)]
-pub struct op_string_return {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_string_return {
-    const NAME: &'static str = stringify!(op_string_return);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_string_return),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_string_return {
-    pub const fn name() -> &'static str {
-        stringify!(op_string_return)
+pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_string_return {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_string_return {
+        const NAME: &'static str = stringify!(op_string_return);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_string_return),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let arg0 = if arg0.is_null_or_undefined() {
-                None
-            } else {
-                Some(deno_core::_ops::to_string(&mut scope, &arg0))
+    }
+    impl op_string_return {
+        pub const fn name() -> &'static str {
+            stringify!(op_string_return)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let arg0 = if arg0.is_null_or_undefined() {
+                    None
+                } else {
+                    Some(deno_core::_ops::to_string(&mut scope, &arg0))
+                };
+                Self::call(arg0)
             };
-            Self::call(arg0)
-        };
-        match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
-            Ok(v) => rv.set(v),
-            Err(rv_err) => {
-                let msg = deno_core::v8::String::new(
-                        &mut scope,
-                        &format!("{}", deno_core::anyhow::Error::from(rv_err)),
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
+            match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
+                Ok(v) => rv.set(v),
+                Err(rv_err) => {
+                    let msg = deno_core::v8::String::new(
+                            &mut scope,
+                            &format!("{}", deno_core::anyhow::Error::from(rv_err)),
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                }
+            };
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_slow(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
             }
-        };
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+        }
+        #[inline(always)]
+        pub fn call(s: Option<String>) -> Option<String> {
+            s
         }
     }
-    #[inline(always)]
-    pub fn call(s: Option<String>) -> Option<String> {
-        s
-    }
+    <op_string_return as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/string_owned.out
+++ b/ops/op2/test_cases/sync/string_owned.out
@@ -1,141 +1,149 @@
 #[allow(non_camel_case_types)]
-struct op_string_owned {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_string_owned {
-    const NAME: &'static str = stringify!(op_string_owned);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_string_owned),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::SeqOneByteString],
-                CType::Uint32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
-                CType::Uint32,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_string_owned {
-    pub const fn name() -> &'static str {
-        stringify!(op_string_owned)
+const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_string_owned {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> u32 {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
+    impl ::deno_core::_ops::Op for op_string_owned {
+        const NAME: &'static str = stringify!(op_string_owned);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_string_owned),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::SeqOneByteString],
+                    CType::Uint32,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
+                    CType::Uint32,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let res = Self::v8_fn_ptr_fast(this, arg0);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
-    ) -> u32 {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = {
-            let arg0 = deno_core::_ops::to_string_ptr(unsafe { &mut *arg0 });
-            Self::call(arg0)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let mut scope = unsafe { &mut *opctx.isolate };
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let arg0 = deno_core::_ops::to_string(&mut scope, &arg0);
-            Self::call(arg0)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+    impl op_string_owned {
+        pub const fn name() -> &'static str {
+            stringify!(op_string_owned)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> u32 {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, arg0);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
+        ) -> u32 {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = {
+                let arg0 = deno_core::_ops::to_string_ptr(unsafe { &mut *arg0 });
+                Self::call(arg0)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let mut scope = unsafe { &mut *opctx.isolate };
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let arg0 = deno_core::_ops::to_string(&mut scope, &arg0);
+                Self::call(arg0)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(s: String) -> u32 {
+            s.len() as _
         }
     }
-    #[inline(always)]
-    fn call(s: String) -> u32 {
-        s.len() as _
-    }
+    <op_string_owned as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/string_owned.out
+++ b/ops/op2/test_cases/sync/string_owned.out
@@ -40,10 +40,6 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_string_owned)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/string_ref.out
+++ b/ops/op2/test_cases/sync/string_ref.out
@@ -1,150 +1,158 @@
 #[allow(non_camel_case_types)]
-struct op_string_owned {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_string_owned {
-    const NAME: &'static str = stringify!(op_string_owned);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_string_owned),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::SeqOneByteString],
-                CType::Uint32,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
-                CType::Uint32,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_string_owned {
-    pub const fn name() -> &'static str {
-        stringify!(op_string_owned)
+const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_string_owned {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
+    impl ::deno_core::_ops::Op for op_string_owned {
+        const NAME: &'static str = stringify!(op_string_owned);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_string_owned),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::SeqOneByteString],
+                    CType::Uint32,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::SeqOneByteString, Type::CallbackOptions],
+                    CType::Uint32,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> u32 {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::v8_fn_ptr_fast(this, arg0);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
-    ) -> u32 {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let result = {
-            let mut arg0_temp: [::std::mem::MaybeUninit<
-                u8,
-            >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
-            let arg0 = &deno_core::_ops::to_str_ptr(
-                unsafe { &mut *arg0 },
-                &mut arg0_temp,
+    impl op_string_owned {
+        pub const fn name() -> &'static str {
+            stringify!(op_string_owned)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> u32 {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-            Self::call(arg0)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        let mut scope = unsafe { &mut *opctx.isolate };
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let mut arg0_temp: [::std::mem::MaybeUninit<
-                u8,
-            >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
-            let arg0 = &deno_core::_ops::to_str(&mut scope, &arg0, &mut arg0_temp);
-            Self::call(arg0)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+            let res = Self::v8_fn_ptr_fast(this, arg0);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
+        ) -> u32 {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let result = {
+                let mut arg0_temp: [::std::mem::MaybeUninit<
+                    u8,
+                >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
+                let arg0 = &deno_core::_ops::to_str_ptr(
+                    unsafe { &mut *arg0 },
+                    &mut arg0_temp,
+                );
+                Self::call(arg0)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let mut scope = unsafe { &mut *opctx.isolate };
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let mut arg0_temp: [::std::mem::MaybeUninit<
+                    u8,
+                >; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
+                let arg0 = &deno_core::_ops::to_str(&mut scope, &arg0, &mut arg0_temp);
+                Self::call(arg0)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call(s: &str) -> u32 {
+            s.len() as _
         }
     }
-    #[inline(always)]
-    fn call(s: &str) -> u32 {
-        s.len() as _
-    }
+    <op_string_owned as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/string_ref.out
+++ b/ops/op2/test_cases/sync/string_ref.out
@@ -40,10 +40,6 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_string_owned)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/string_return.out
+++ b/ops/op2/test_cases/sync/string_return.out
@@ -1,263 +1,287 @@
 #[allow(non_camel_case_types)]
-pub struct op_string_return {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_string_return {
-    const NAME: &'static str = stringify!(op_string_return);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_string_return),
-        false,
-        false,
-        0usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_string_return {
-    pub const fn name() -> &'static str {
-        stringify!(op_string_return)
+pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_string_return {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_string_return {
+        const NAME: &'static str = stringify!(op_string_return);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_string_return),
+            false,
+            false,
+            0usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = { Self::call() };
-        match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
-            Ok(v) => rv.set(v),
-            Err(rv_err) => {
-                let msg = deno_core::v8::String::new(
-                        &mut scope,
-                        &format!("{}", deno_core::anyhow::Error::from(rv_err)),
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
+    }
+    impl op_string_return {
+        pub const fn name() -> &'static str {
+            stringify!(op_string_return)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = { Self::call() };
+            match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
+                Ok(v) => rv.set(v),
+                Err(rv_err) => {
+                    let msg = deno_core::v8::String::new(
+                            &mut scope,
+                            &format!("{}", deno_core::anyhow::Error::from(rv_err)),
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                }
+            };
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_slow(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
             }
-        };
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+        }
+        #[inline(always)]
+        pub fn call() -> String {
+            "".into()
         }
     }
-    #[inline(always)]
-    pub fn call() -> String {
-        "".into()
-    }
+    <op_string_return as ::deno_core::_ops::Op>::DECL
 }
 
 #[allow(non_camel_case_types)]
-pub struct op_string_return_ref {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_string_return_ref {
-    const NAME: &'static str = stringify!(op_string_return_ref);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_string_return_ref),
-        false,
-        false,
-        0usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_string_return_ref {
-    pub const fn name() -> &'static str {
-        stringify!(op_string_return_ref)
+pub const fn op_string_return_ref() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_string_return_ref {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_string_return_ref {
+        const NAME: &'static str = stringify!(op_string_return_ref);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_string_return_ref),
+            false,
+            false,
+            0usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = { Self::call() };
-        match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
-            Ok(v) => rv.set(v),
-            Err(rv_err) => {
-                let msg = deno_core::v8::String::new(
-                        &mut scope,
-                        &format!("{}", deno_core::anyhow::Error::from(rv_err)),
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
+    }
+    impl op_string_return_ref {
+        pub const fn name() -> &'static str {
+            stringify!(op_string_return_ref)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = { Self::call() };
+            match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
+                Ok(v) => rv.set(v),
+                Err(rv_err) => {
+                    let msg = deno_core::v8::String::new(
+                            &mut scope,
+                            &format!("{}", deno_core::anyhow::Error::from(rv_err)),
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                }
+            };
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_slow(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
             }
-        };
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+        }
+        #[inline(always)]
+        pub fn call() -> &'static str {
+            ""
         }
     }
-    #[inline(always)]
-    pub fn call() -> &'static str {
-        ""
-    }
+    <op_string_return_ref as ::deno_core::_ops::Op>::DECL
 }
 
 #[allow(non_camel_case_types)]
-pub struct op_string_return_cow {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_string_return_cow {
-    const NAME: &'static str = stringify!(op_string_return_cow);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_string_return_cow),
-        false,
-        false,
-        0usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_string_return_cow {
-    pub const fn name() -> &'static str {
-        stringify!(op_string_return_cow)
+pub const fn op_string_return_cow() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_string_return_cow {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_string_return_cow {
+        const NAME: &'static str = stringify!(op_string_return_cow);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_string_return_cow),
+            false,
+            false,
+            0usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = { Self::call() };
-        match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
-            Ok(v) => rv.set(v),
-            Err(rv_err) => {
-                let msg = deno_core::v8::String::new(
-                        &mut scope,
-                        &format!("{}", deno_core::anyhow::Error::from(rv_err)),
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
+    }
+    impl op_string_return_cow {
+        pub const fn name() -> &'static str {
+            stringify!(op_string_return_cow)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = { Self::call() };
+            match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
+                Ok(v) => rv.set(v),
+                Err(rv_err) => {
+                    let msg = deno_core::v8::String::new(
+                            &mut scope,
+                            &format!("{}", deno_core::anyhow::Error::from(rv_err)),
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                }
+            };
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_slow(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
             }
-        };
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+        }
+        #[inline(always)]
+        pub fn call<'a>() -> Cow<'a, str> {
+            "".into()
         }
     }
-    #[inline(always)]
-    pub fn call<'a>() -> Cow<'a, str> {
-        "".into()
-    }
+    <op_string_return_cow as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/string_return.out
+++ b/ops/op2/test_cases/sync/string_return.out
@@ -24,10 +24,6 @@ pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_string_return)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,
@@ -120,10 +116,6 @@ pub const fn op_string_return_ref() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_string_return_ref)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,
@@ -215,10 +207,6 @@ pub const fn op_string_return_cow() -> ::deno_core::_ops::OpDecl {
     impl op_string_return_cow {
         pub const fn name() -> &'static str {
             stringify!(op_string_return_cow)
-        }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
         }
         #[inline(always)]
         fn slow_function_impl(

--- a/ops/op2/test_cases/sync/v8_global.out
+++ b/ops/op2/test_cases/sync/v8_global.out
@@ -1,96 +1,104 @@
 #[allow(non_camel_case_types)]
-pub struct op_global {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_global {
-    const NAME: &'static str = stringify!(op_global);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_global),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_global {
-    pub const fn name() -> &'static str {
-        stringify!(op_global)
+pub const fn op_global() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_global {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_global {
+        const NAME: &'static str = stringify!(op_global);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_global),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
-                deno_core::v8::String,
-            >(arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected String".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
+    }
+    impl op_global {
+        pub const fn name() -> &'static str {
+            stringify!(op_global)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
+                    deno_core::v8::String,
+                >(arg0) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected String".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg0 = deno_core::v8::Global::new(&mut scope, arg0);
+                Self::call(arg0)
             };
-            let arg0 = deno_core::v8::Global::new(&mut scope, arg0);
-            Self::call(arg0)
-        };
-        rv.set(deno_core::_ops::RustToV8::to_v8(result, &mut scope));
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+            rv.set(deno_core::_ops::RustToV8::to_v8(result, &mut scope));
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub fn call(g: v8::Global<v8::String>) -> v8::Global<v8::String> {
+            g
         }
     }
-    #[inline(always)]
-    pub fn call(g: v8::Global<v8::String>) -> v8::Global<v8::String> {
-        g
-    }
+    <op_global as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/v8_global.out
+++ b/ops/op2/test_cases/sync/v8_global.out
@@ -24,10 +24,6 @@ pub const fn op_global() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_global)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,

--- a/ops/op2/test_cases/sync/v8_handlescope.out
+++ b/ops/op2/test_cases/sync/v8_handlescope.out
@@ -1,99 +1,107 @@
 #[allow(non_camel_case_types)]
-struct op_handlescope {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_handlescope {
-    const NAME: &'static str = stringify!(op_handlescope);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_handlescope),
-        false,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_handlescope {
-    pub const fn name() -> &'static str {
-        stringify!(op_handlescope)
+const fn op_handlescope() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_handlescope {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_handlescope {
+        const NAME: &'static str = stringify!(op_handlescope);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_handlescope),
+            false,
+            false,
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg1 = args.get(0usize as i32);
-            let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
-                deno_core::v8::String,
-            >(arg1) else {
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected String".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
+    }
+    impl op_handlescope {
+        pub const fn name() -> &'static str {
+            stringify!(op_handlescope)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg1 = args.get(0usize as i32);
+                let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
+                    deno_core::v8::String,
+                >(arg1) else {
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected String".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg1 = arg1;
+                let arg0 = &mut scope;
+                Self::call(arg0, arg1)
             };
-            let arg1 = arg1;
-            let arg0 = &mut scope;
-            Self::call(arg0, arg1)
-        };
-        rv.set(deno_core::_ops::RustToV8NoScope::to_v8(result));
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+            rv.set(deno_core::_ops::RustToV8NoScope::to_v8(result));
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call<'a>(
+            _scope: &v8::HandleScope<'a>,
+            _str2: v8::Local<v8::String>,
+        ) -> v8::Local<'a, v8::String> {
+            unimplemented!()
         }
     }
-    #[inline(always)]
-    fn call<'a>(
-        _scope: &v8::HandleScope<'a>,
-        _str2: v8::Local<v8::String>,
-    ) -> v8::Local<'a, v8::String> {
-        unimplemented!()
-    }
+    <op_handlescope as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/v8_handlescope.out
+++ b/ops/op2/test_cases/sync/v8_handlescope.out
@@ -24,10 +24,6 @@ const fn op_handlescope() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_handlescope)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,

--- a/ops/op2/test_cases/sync/v8_lifetime.out
+++ b/ops/op2/test_cases/sync/v8_lifetime.out
@@ -1,95 +1,103 @@
 #[allow(non_camel_case_types)]
-pub struct op_v8_lifetime {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_v8_lifetime {
-    const NAME: &'static str = stringify!(op_v8_lifetime);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_v8_lifetime),
-        false,
-        false,
-        1usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_v8_lifetime {
-    pub const fn name() -> &'static str {
-        stringify!(op_v8_lifetime)
+pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_v8_lifetime {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_v8_lifetime {
+        const NAME: &'static str = stringify!(op_v8_lifetime);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_v8_lifetime),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
-                deno_core::v8::String,
-            >(arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected String".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
+    }
+    impl op_v8_lifetime {
+        pub const fn name() -> &'static str {
+            stringify!(op_v8_lifetime)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
+                    deno_core::v8::String,
+                >(arg0) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected String".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg0 = arg0;
+                Self::call(arg0)
             };
-            let arg0 = arg0;
-            Self::call(arg0)
-        };
-        rv.set(deno_core::_ops::RustToV8NoScope::to_v8(result));
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+            rv.set(deno_core::_ops::RustToV8NoScope::to_v8(result));
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        pub fn call<'s>(_s: v8::Local<'s, v8::String>) -> v8::Local<'s, v8::String> {
+            unimplemented!()
         }
     }
-    #[inline(always)]
-    pub fn call<'s>(_s: v8::Local<'s, v8::String>) -> v8::Local<'s, v8::String> {
-        unimplemented!()
-    }
+    <op_v8_lifetime as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/v8_lifetime.out
+++ b/ops/op2/test_cases/sync/v8_lifetime.out
@@ -24,10 +24,6 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_v8_lifetime)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -1,193 +1,211 @@
 #[allow(non_camel_case_types)]
-pub struct op_v8_lifetime {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_v8_lifetime {
-    const NAME: &'static str = stringify!(op_v8_lifetime);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_v8_lifetime),
-        false,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::V8Value, Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-            )
-        }),
-        Some({
-            use deno_core::v8::fast_api::Type;
-            use deno_core::v8::fast_api::CType;
-            deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                &[Type::V8Value, Type::V8Value, Type::V8Value, Type::CallbackOptions],
-                CType::Void,
-                Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-            )
-        }),
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_v8_lifetime {
-    pub const fn name() -> &'static str {
-        stringify!(op_v8_lifetime)
+pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_v8_lifetime {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast_metrics(
-        this: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: deno_core::v8::Local<deno_core::v8::Value>,
-        arg1: deno_core::v8::Local<deno_core::v8::Value>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<
-                deno_core::v8::External,
-            >::cast(unsafe { fast_api_callback_options.data.data })
-                .value() as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
+    impl ::deno_core::_ops::Op for op_v8_lifetime {
+        const NAME: &'static str = stringify!(op_v8_lifetime);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_v8_lifetime),
+            false,
+            false,
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[
+                        Type::V8Value,
+                        Type::V8Value,
+                        Type::V8Value,
+                        Type::CallbackOptions,
+                    ],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[
+                        Type::V8Value,
+                        Type::V8Value,
+                        Type::V8Value,
+                        Type::CallbackOptions,
+                    ],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let res = Self::v8_fn_ptr_fast(this, arg0, arg1, fast_api_callback_options);
-        deno_core::_ops::dispatch_metrics_fast(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Completed,
-        );
-        res
     }
-    #[allow(clippy::too_many_arguments)]
-    extern "C" fn v8_fn_ptr_fast(
-        _: deno_core::v8::Local<deno_core::v8::Object>,
-        arg0: deno_core::v8::Local<deno_core::v8::Value>,
-        arg1: deno_core::v8::Local<deno_core::v8::Value>,
-        fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
-    ) -> () {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-        let result = {
-            let Ok(mut arg0) = deno_core::_ops::v8_try_convert_option::<
-                deno_core::v8::String,
-            >(arg0) else {
-                fast_api_callback_options.fallback = true;
-                return unsafe { std::mem::zeroed() };
+    impl op_v8_lifetime {
+        pub const fn name() -> &'static str {
+            stringify!(op_v8_lifetime)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: deno_core::v8::Local<deno_core::v8::Value>,
+            arg1: deno_core::v8::Local<deno_core::v8::Value>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
             };
-            let arg0 = match &arg0 {
-                None => None,
-                Some(v) => Some(::std::ops::Deref::deref(v)),
-            };
-            let Ok(mut arg1) = deno_core::_ops::v8_try_convert_option::<
-                deno_core::v8::String,
-            >(arg1) else {
-                fast_api_callback_options.fallback = true;
-                return unsafe { std::mem::zeroed() };
-            };
-            let arg1 = match &arg1 {
-                None => None,
-                Some(v) => Some(::std::ops::Deref::deref(v)),
-            };
-            Self::call(arg0, arg1)
-        };
-        result as _
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
-        );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let Ok(mut arg0) = deno_core::_ops::v8_try_convert_option::<
-                deno_core::v8::String,
-            >(arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected String".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg0 = match &arg0 {
-                None => None,
-                Some(v) => Some(::std::ops::Deref::deref(v)),
-            };
-            let arg1 = args.get(1usize as i32);
-            let Ok(mut arg1) = deno_core::_ops::v8_try_convert_option::<
-                deno_core::v8::String,
-            >(arg1) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected String".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg1 = match &arg1 {
-                None => None,
-                Some(v) => Some(::std::ops::Deref::deref(v)),
-            };
-            Self::call(arg0, arg1)
-        };
-        deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-        return 0;
-    }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-            deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_fast(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, arg0, arg1, fast_api_callback_options);
+            deno_core::_ops::dispatch_metrics_fast(
                 &opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
-        } else {
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast(
+            _: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: deno_core::v8::Local<deno_core::v8::Value>,
+            arg1: deno_core::v8::Local<deno_core::v8::Value>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let result = {
+                let Ok(mut arg0) = deno_core::_ops::v8_try_convert_option::<
+                    deno_core::v8::String,
+                >(arg0) else {
+                    fast_api_callback_options.fallback = true;
+                    return unsafe { std::mem::zeroed() };
+                };
+                let arg0 = match &arg0 {
+                    None => None,
+                    Some(v) => Some(::std::ops::Deref::deref(v)),
+                };
+                let Ok(mut arg1) = deno_core::_ops::v8_try_convert_option::<
+                    deno_core::v8::String,
+                >(arg1) else {
+                    fast_api_callback_options.fallback = true;
+                    return unsafe { std::mem::zeroed() };
+                };
+                let arg1 = match &arg1 {
+                    None => None,
+                    Some(v) => Some(::std::ops::Deref::deref(v)),
+                };
+                Self::call(arg0, arg1)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let Ok(mut arg0) = deno_core::_ops::v8_try_convert_option::<
+                    deno_core::v8::String,
+                >(arg0) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected String".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg0 = match &arg0 {
+                    None => None,
+                    Some(v) => Some(::std::ops::Deref::deref(v)),
+                };
+                let arg1 = args.get(1usize as i32);
+                let Ok(mut arg1) = deno_core::_ops::v8_try_convert_option::<
+                    deno_core::v8::String,
+                >(arg1) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected String".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg1 = match &arg1 {
+                    None => None,
+                    Some(v) => Some(::std::ops::Deref::deref(v)),
+                };
+                Self::call(arg0, arg1)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
         }
+        #[inline(always)]
+        pub fn call<'s>(_s: Option<&v8::String>, _s2: Option<&v8::String>) {}
     }
-    #[inline(always)]
-    pub fn call<'s>(_s: Option<&v8::String>, _s2: Option<&v8::String>) {}
+    <op_v8_lifetime as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -50,10 +50,6 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_v8_lifetime)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics(
             this: deno_core::v8::Local<deno_core::v8::Object>,

--- a/ops/op2/test_cases/sync/v8_string.out
+++ b/ops/op2/test_cases/sync/v8_string.out
@@ -24,10 +24,6 @@ const fn op_v8_string() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_v8_string)
         }
-        #[deprecated(note = "Use the const op::DECL instead")]
-        pub const fn decl() -> deno_core::_ops::OpDecl {
-            <Self as deno_core::_ops::Op>::DECL
-        }
         #[inline(always)]
         fn slow_function_impl(
             info: *const deno_core::v8::FunctionCallbackInfo,

--- a/ops/op2/test_cases/sync/v8_string.out
+++ b/ops/op2/test_cases/sync/v8_string.out
@@ -1,114 +1,122 @@
 #[allow(non_camel_case_types)]
-struct op_v8_string {
-    _unconstructable: ::std::marker::PhantomData<()>,
-}
-impl ::deno_core::_ops::Op for op_v8_string {
-    const NAME: &'static str = stringify!(op_v8_string);
-    const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-        ::deno_core::__op_name_fast!(op_v8_string),
-        false,
-        false,
-        2usize as u8,
-        Self::v8_fn_ptr as _,
-        Self::v8_fn_ptr_metrics as _,
-        None,
-        None,
-        ::deno_core::OpMetadata {
-            ..::deno_core::OpMetadata::default()
-        },
-    );
-}
-impl op_v8_string {
-    pub const fn name() -> &'static str {
-        stringify!(op_v8_string)
+const fn op_v8_string() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_v8_string {
+        _unconstructable: ::std::marker::PhantomData<()>,
     }
-    #[deprecated(note = "Use the const op::DECL instead")]
-    pub const fn decl() -> deno_core::_ops::OpDecl {
-        <Self as deno_core::_ops::Op>::DECL
-    }
-    #[inline(always)]
-    fn slow_function_impl(info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
-        #[cfg(debug_assertions)]
-        let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-            &<Self as deno_core::_ops::Op>::DECL,
+    impl ::deno_core::_ops::Op for op_v8_string {
+        const NAME: &'static str = stringify!(op_v8_string);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_v8_string),
+            false,
+            false,
+            2usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
         );
-        let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-            &*info
-        });
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let result = {
-            let arg0 = args.get(0usize as i32);
-            let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
-                deno_core::v8::String,
-            >(arg0) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected String".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg0 = &arg0;
-            let arg1 = args.get(1usize as i32);
-            let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
-                deno_core::v8::String,
-            >(arg1) else {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let msg = deno_core::v8::String::new_from_one_byte(
-                        &mut scope,
-                        "expected String".as_bytes(),
-                        deno_core::v8::NewStringType::Normal,
-                    )
-                    .unwrap();
-                let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                scope.throw_exception(exc);
-                return 1;
-            };
-            let arg1 = arg1;
-            Self::call(arg0, arg1)
-        };
-        rv.set(deno_core::_ops::RustToV8NoScope::to_v8(result));
-        return 0;
     }
-    extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(info);
-    }
-    extern "C" fn v8_fn_ptr_metrics(info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-            &*info
-        });
-        let opctx = unsafe {
-            &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
-                as *const deno_core::_ops::OpCtx)
-        };
-        deno_core::_ops::dispatch_metrics_slow(
-            &opctx,
-            deno_core::_ops::OpMetricsEvent::Dispatched,
-        );
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
+    impl op_v8_string {
+        pub const fn name() -> &'static str {
+            stringify!(op_v8_string)
+        }
+        #[deprecated(note = "Use the const op::DECL instead")]
+        pub const fn decl() -> deno_core::_ops::OpDecl {
+            <Self as deno_core::_ops::Op>::DECL
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
+                    deno_core::v8::String,
+                >(arg0) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected String".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg0 = &arg0;
+                let arg1 = args.get(1usize as i32);
+                let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
+                    deno_core::v8::String,
+                >(arg1) else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected String".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let arg1 = arg1;
+                Self::call(arg0, arg1)
+            };
+            rv.set(deno_core::_ops::RustToV8NoScope::to_v8(result));
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             deno_core::_ops::dispatch_metrics_slow(
                 &opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-        } else {
-            deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
-                deno_core::_ops::OpMetricsEvent::Error,
-            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+        #[inline(always)]
+        fn call<'a>(
+            _str1: &v8::String,
+            _str2: v8::Local<v8::String>,
+        ) -> v8::Local<'a, v8::String> {
+            unimplemented!()
         }
     }
-    #[inline(always)]
-    fn call<'a>(
-        _str1: &v8::String,
-        _str2: v8::Local<v8::String>,
-    ) -> v8::Local<'a, v8::String> {
-        unimplemented!()
-    }
+    <op_v8_string as ::deno_core::_ops::Op>::DECL
 }


### PR DESCRIPTION
Switch op declaration from a `impl #name` to a `const fn #name`. 
This form for declaration can be used inside `impl` blocks.

```rust
struct Foo {}

impl Foo {
    #[op2(fast)]
    pub fn bar(#[state] state: &mut OpState) {}
}

// const DECL: OpDecl = Foo::bar();
```

Based on Matt's suggestion in https://github.com/denoland/deno_core/pull/682

[Playground link](https://play.rust-lang.org/?version=stable&mode=release&edition=2021&gist=2d7152d548b4a466779c401551b21b05)

This patch wraps `const` around the existing
`impl` codegen to unblock work on op2++