### PR TITLE
op2++: codegen for `&self` parameter

### DIFF
--- a/ops/op2/dispatch_async.rs
+++ b/ops/op2/dispatch_async.rs
@@ -10,6 +10,7 @@ use super::dispatch_slow::with_opctx;
 use super::dispatch_slow::with_opstate;
 use super::dispatch_slow::with_retval;
 use super::dispatch_slow::with_scope;
+use super::dispatch_slow::with_self;
 use super::generator_state::gs_quote;
 use super::generator_state::GeneratorState;
 use super::signature::ParsedSignature;
@@ -136,6 +137,12 @@ pub(crate) fn generate_dispatch_async(
     quote!()
   };
 
+  let with_self = if generator_state.needs_self {
+    with_self(generator_state)
+  } else {
+    quote!()
+  };
+
   Ok(
     gs_quote!(generator_state(info, slow_function, slow_function_metrics, opctx) => {
       #[inline(always)]
@@ -148,6 +155,7 @@ pub(crate) fn generate_dispatch_async(
         #with_args
         #with_opctx
         #with_opstate
+        #with_self
 
         #output
       }

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -135,6 +135,12 @@ pub(crate) fn generate_dispatch_slow(
     quote!()
   };
 
+  let with_self = if generator_state.needs_self {
+    with_self(generator_state)
+  } else {
+    quote!()
+  };
+
   Ok(
     gs_quote!(generator_state(opctx, info, slow_function, slow_function_metrics) => {
       #[inline(always)]
@@ -149,6 +155,7 @@ pub(crate) fn generate_dispatch_slow(
         #with_isolate
         #with_opstate
         #with_js_runtime_state
+        #with_self
 
         #output;
         return 0;
@@ -233,6 +240,13 @@ pub(crate) fn with_js_runtime_state(
   generator_state.needs_opctx = true;
   gs_quote!(generator_state(opctx, js_runtime_state) =>
     (let #js_runtime_state = &#opctx.runtime_state();)
+  )
+}
+
+pub(crate) fn with_self(generator_state: &mut GeneratorState) -> TokenStream {
+  generator_state.needs_opctx = true;
+  gs_quote!(generator_state(fn_args, self_ty) =>
+    (let self_: &#self_ty = unsafe { deno_core::cppgc::try_unwrap_cppgc_object(#fn_args.this().into()).unwrap() };)
   )
 }
 
@@ -679,7 +693,15 @@ pub fn call(generator_state: &mut GeneratorState) -> TokenStream {
   for arg in &generator_state.args {
     tokens.extend(quote!( #arg , ));
   }
-  quote!(Self::call( #tokens ))
+
+  let name = &generator_state.name;
+  let call_ = if generator_state.needs_self {
+    quote!(self_. #name)
+  } else {
+    quote!(Self:: #name)
+  };
+
+  quote!(#call_ ( #tokens ))
 }
 
 pub fn return_value(

--- a/ops/op2/generator_state.rs
+++ b/ops/op2/generator_state.rs
@@ -2,6 +2,7 @@
 use proc_macro2::Ident;
 
 pub struct GeneratorState {
+  pub name: Ident,
   /// Identifiers for each of the arguments of the original function
   pub args: Vec<Ident>,
   /// The result of the `call` function
@@ -33,6 +34,8 @@ pub struct GeneratorState {
   pub fast_function_metrics: Ident,
   /// The async function promise ID argument
   pub promise_id: Ident,
+  /// Type of the self argument
+  pub self_ty: Ident,
 
   pub needs_args: bool,
   pub needs_retval: bool,
@@ -44,6 +47,7 @@ pub struct GeneratorState {
   pub needs_fast_opctx: bool,
   pub needs_fast_api_callback_options: bool,
   pub needs_fast_js_runtime_state: bool,
+  pub needs_self: bool,
 }
 
 /// Quotes a set of generator_state fields, along with variables captured from

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -989,7 +989,8 @@ pub fn parse_signature(
   let mut names = vec![];
   for input in signature.inputs {
     let name = match &input {
-      FnArg::Receiver(_) => "self".to_owned(),
+      // Skip receiver
+      FnArg::Receiver(_) => continue,
       FnArg::Typed(ty) => match &*ty.pat {
         Pat::Ident(ident) => ident.ident.to_string(),
         _ => "(complex)".to_owned(),

--- a/ops/op2/test_cases/async/async_arg_return.out
+++ b/ops/op2/test_cases/async/async_arg_return.out
@@ -104,6 +104,8 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_async {
         #[inline(always)]
         pub async fn call(x: i32) -> i32 {
             x

--- a/ops/op2/test_cases/async/async_arg_return_result.out
+++ b/ops/op2/test_cases/async/async_arg_return_result.out
@@ -121,6 +121,8 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_async {
         #[inline(always)]
         pub async fn call(x: i32) -> std::io::Result<i32> {
             Ok(x)

--- a/ops/op2/test_cases/async/async_deferred.out
+++ b/ops/op2/test_cases/async/async_deferred.out
@@ -66,7 +66,7 @@ pub const fn op_async_deferred() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             promise_id: i32,
             fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
         ) -> () {
@@ -152,6 +152,8 @@ pub const fn op_async_deferred() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_async_deferred {
         #[inline(always)]
         pub async fn call() -> std::io::Result<i32> {
             Ok(0)

--- a/ops/op2/test_cases/async/async_jsbuffer.out
+++ b/ops/op2/test_cases/async/async_jsbuffer.out
@@ -128,6 +128,8 @@ pub const fn op_async_v8_buffer() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_async_v8_buffer {
         #[inline(always)]
         pub async fn call(buf: JsBuffer) -> JsBuffer {
             buf

--- a/ops/op2/test_cases/async/async_lazy.out
+++ b/ops/op2/test_cases/async/async_lazy.out
@@ -66,7 +66,7 @@ pub const fn op_async_lazy() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             promise_id: i32,
             fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
         ) -> () {
@@ -152,6 +152,8 @@ pub const fn op_async_lazy() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_async_lazy {
         #[inline(always)]
         pub async fn call() -> std::io::Result<i32> {
             Ok(0)

--- a/ops/op2/test_cases/async/async_op_metadata.out
+++ b/ops/op2/test_cases/async/async_op_metadata.out
@@ -90,6 +90,8 @@ const fn op_blob_read_part() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_blob_read_part {
         #[inline(always)]
         async fn call() {
             return;
@@ -190,6 +192,8 @@ const fn op_broadcast_recv() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_broadcast_recv {
         #[inline(always)]
         async fn call() {
             return;

--- a/ops/op2/test_cases/async/async_opstate.out
+++ b/ops/op2/test_cases/async/async_opstate.out
@@ -109,6 +109,8 @@ pub const fn op_async_opstate() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_async_opstate {
         #[inline(always)]
         pub async fn call(state: Rc<RefCell<OpState>>) -> std::io::Result<i32> {
             Ok(*state.borrow().borrow::<i32>())

--- a/ops/op2/test_cases/async/async_result.out
+++ b/ops/op2/test_cases/async/async_result.out
@@ -105,6 +105,8 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_async {
         #[inline(always)]
         pub async fn call() -> std::io::Result<i32> {
             Ok(0)

--- a/ops/op2/test_cases/async/async_result_impl.out
+++ b/ops/op2/test_cases/async/async_result_impl.out
@@ -135,6 +135,8 @@ pub const fn op_async_result_impl() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_async_result_impl {
         #[inline(always)]
         pub fn call(
             x: i32,

--- a/ops/op2/test_cases/async/async_result_smi.out
+++ b/ops/op2/test_cases/async/async_result_smi.out
@@ -137,6 +137,8 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_async {
         #[inline(always)]
         pub async fn call(rid: ResourceId) -> std::io::Result<ResourceId> {
             Ok(rid as _)

--- a/ops/op2/test_cases/async/async_v8_global.out
+++ b/ops/op2/test_cases/async/async_v8_global.out
@@ -107,6 +107,8 @@ pub const fn op_async_v8_global() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_async_v8_global {
         #[inline(always)]
         pub async fn call(_s: v8::Global<v8::String>) {}
     }

--- a/ops/op2/test_cases/async/async_void.out
+++ b/ops/op2/test_cases/async/async_void.out
@@ -88,6 +88,8 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_async {
         #[inline(always)]
         pub async fn call() {}
     }

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -67,7 +67,7 @@ const fn op_add() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: u32,
             arg1: u32,
         ) -> u32 {
@@ -160,6 +160,8 @@ const fn op_add() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_add {
         #[inline(always)]
         fn call(a: u32, b: u32) -> u32 {
             a + b

--- a/ops/op2/test_cases/sync/add_options.out
+++ b/ops/op2/test_cases/sync/add_options.out
@@ -109,6 +109,8 @@ pub const fn op_test_add_option() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_test_add_option {
         #[inline(always)]
         pub fn call(a: u32, b: Option<u32>) -> u32 {
             a + b.unwrap_or(100)

--- a/ops/op2/test_cases/sync/bigint.out
+++ b/ops/op2/test_cases/sync/bigint.out
@@ -65,7 +65,7 @@ pub const fn op_bigint() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
         ) -> u64 {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
@@ -120,6 +120,8 @@ pub const fn op_bigint() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_bigint {
         #[inline(always)]
         pub fn call() -> u64 {
             0

--- a/ops/op2/test_cases/sync/bool.out
+++ b/ops/op2/test_cases/sync/bool.out
@@ -66,7 +66,7 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: bool,
         ) -> bool {
             #[cfg(debug_assertions)]
@@ -131,6 +131,8 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_bool {
         #[inline(always)]
         pub fn call(arg: bool) -> bool {
             arg

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -66,7 +66,7 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: bool,
             fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
         ) -> bool {
@@ -178,6 +178,8 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_bool {
         #[inline(always)]
         pub fn call(arg: bool) -> Result<bool, AnyError> {
             Ok(arg)

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -82,7 +82,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
             arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
             arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
@@ -271,6 +271,8 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_buffers {
         #[inline(always)]
         fn call(_a: &[u8], _b: &mut [u8], _c: *const u8, _d: *mut u8) {}
     }
@@ -361,7 +363,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
             arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
             arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
@@ -550,6 +552,8 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_buffers_32 {
         #[inline(always)]
         fn call(_a: &[u32], _b: &mut [u32], _c: *const u32, _d: *mut u32) {}
     }
@@ -692,6 +696,8 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_buffers_option {
         #[inline(always)]
         fn call(_a: Option<&[u8]>, _b: Option<JsBuffer>) {}
     }

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -79,7 +79,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
             arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
             arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
@@ -224,6 +224,8 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_buffers {
         #[inline(always)]
         fn call(_a: Vec<u8>, _b: Box<[u8]>, _c: bytes::Bytes) {}
     }
@@ -308,7 +310,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
             arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
         ) -> () {
@@ -425,6 +427,8 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_buffers_32 {
         #[inline(always)]
         fn call(_a: Vec<u32>, _b: Box<[u32]>) {}
     }

--- a/ops/op2/test_cases/sync/buffers_out.out
+++ b/ops/op2/test_cases/sync/buffers_out.out
@@ -107,6 +107,8 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_buffers {
         #[inline(always)]
         fn call(buffer: JsBuffer) -> JsBuffer {
             buffer
@@ -234,6 +236,8 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_buffers_option {
         #[inline(always)]
         fn call(buffer: Option<JsBuffer>) -> Option<JsBuffer> {
             buffer
@@ -347,6 +351,8 @@ const fn op_arraybuffers() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_arraybuffers {
         #[inline(always)]
         fn call(buffer: JsBuffer) -> JsBuffer {
             buffer

--- a/ops/op2/test_cases/sync/cfg.out
+++ b/ops/op2/test_cases/sync/cfg.out
@@ -67,7 +67,7 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
@@ -121,6 +121,8 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_maybe_windows {
         #[inline(always)]
         /// This is a doc comment.
         #[cfg(windows)]
@@ -198,7 +200,7 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
@@ -252,6 +254,8 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_maybe_windows {
         #[inline(always)]
         /// This is a doc comment.
         #[cfg(not(windows))]

--- a/ops/op2/test_cases/sync/clippy_allow.out
+++ b/ops/op2/test_cases/sync/clippy_allow.out
@@ -67,7 +67,7 @@ pub const fn op_extra_annotation() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
@@ -121,6 +121,8 @@ pub const fn op_extra_annotation() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_extra_annotation {
         #[inline(always)]
         /// This is a doc comment.
         #[allow(clippy::some_annotation)]
@@ -196,7 +198,7 @@ pub const fn op_clippy_internal() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
@@ -250,6 +252,8 @@ pub const fn op_clippy_internal() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_clippy_internal {
         #[inline(always)]
         pub fn call() -> () {
             { #![allow(clippy::await_holding_refcell_ref)] }

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -66,7 +66,7 @@ const fn op_file() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: deno_core::v8::Local<deno_core::v8::Value>,
             fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
         ) -> () {
@@ -151,6 +151,8 @@ const fn op_file() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_file {
         #[inline(always)]
         fn call(_file: &std::fs::File) {}
     }
@@ -235,6 +237,8 @@ const fn op_make_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_make_cppgc_object {
         #[inline(always)]
         fn call() -> Wrap {
             Wrap
@@ -346,6 +350,8 @@ const fn op_make_cppgc_object_async() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_make_cppgc_object_async {
         #[inline(always)]
         async fn call() -> Wrap {
             Wrap

--- a/ops/op2/test_cases/sync/doc_comment.out
+++ b/ops/op2/test_cases/sync/doc_comment.out
@@ -66,7 +66,7 @@ pub const fn op_has_doc_comment() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
@@ -120,6 +120,8 @@ pub const fn op_has_doc_comment() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_has_doc_comment {
         #[inline(always)]
         /// This is a doc comment.
         pub fn call() -> () {}

--- a/ops/op2/test_cases/sync/fast_alternative.out
+++ b/ops/op2/test_cases/sync/fast_alternative.out
@@ -102,6 +102,8 @@ const fn op_slow() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_slow {
         #[inline(always)]
         fn call(_scope: &v8::HandleScope, a: u32, b: u32) -> u32 {
             a + b
@@ -179,7 +181,7 @@ const fn op_fast() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: u32,
             arg1: u32,
         ) -> u32 {
@@ -272,6 +274,8 @@ const fn op_fast() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_fast {
         #[inline(always)]
         fn call(a: u32, b: u32) -> u32 {
             a + b
@@ -384,6 +388,8 @@ const fn op_slow_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl<T: Trait> op_slow_generic<T> {
         #[inline(always)]
         fn call(_scope: &v8::HandleScope, a: u32, b: u32) -> u32 {
             a + b
@@ -461,7 +467,7 @@ const fn op_fast_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: u32,
             arg1: u32,
         ) -> u32 {
@@ -554,6 +560,8 @@ const fn op_fast_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl<T: Trait> op_fast_generic<T> {
         #[inline(always)]
         fn call(a: u32, b: u32) -> u32 {
             a + b

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -65,7 +65,7 @@ pub const fn op_generics<T: Trait>() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
@@ -119,6 +119,8 @@ pub const fn op_generics<T: Trait>() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl<T: Trait> op_generics<T> {
         #[inline(always)]
         pub fn call() {}
     }
@@ -192,7 +194,7 @@ pub const fn op_generics_static<T: Trait + 'static>() -> ::deno_core::_ops::OpDe
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
@@ -246,6 +248,8 @@ pub const fn op_generics_static<T: Trait + 'static>() -> ::deno_core::_ops::OpDe
                 );
             }
         }
+    }
+    impl<T: Trait + 'static> op_generics_static<T> {
         #[inline(always)]
         pub fn call() {}
     }
@@ -319,7 +323,7 @@ pub const fn op_generics_static_where<T: Trait + 'static>() -> ::deno_core::_ops
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
@@ -373,6 +377,8 @@ pub const fn op_generics_static_where<T: Trait + 'static>() -> ::deno_core::_ops
                 );
             }
         }
+    }
+    impl<T: Trait + 'static> op_generics_static_where<T> {
         #[inline(always)]
         pub fn call()
         where

--- a/ops/op2/test_cases/sync/nofast.out
+++ b/ops/op2/test_cases/sync/nofast.out
@@ -102,6 +102,8 @@ const fn op_nofast() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_nofast {
         #[inline(always)]
         fn call(a: u32, b: u32) -> u32 {
             a + b

--- a/ops/op2/test_cases/sync/op_state_attr.out
+++ b/ops/op2/test_cases/sync/op_state_attr.out
@@ -65,7 +65,7 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
         ) -> () {
             #[cfg(debug_assertions)]
@@ -147,6 +147,8 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_state_rc {
         #[inline(always)]
         fn call(_arg: &Something, _arg_opt: Option<&Something>) {}
     }

--- a/ops/op2/test_cases/sync/op_state_rc.out
+++ b/ops/op2/test_cases/sync/op_state_rc.out
@@ -65,7 +65,7 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
         ) -> () {
             #[cfg(debug_assertions)]
@@ -141,6 +141,8 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_state_rc {
         #[inline(always)]
         fn call(_state: Rc<RefCell<OpState>>) {}
     }

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -65,7 +65,7 @@ const fn op_state_ref() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
         ) -> () {
             #[cfg(debug_assertions)]
@@ -141,6 +141,8 @@ const fn op_state_ref() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_state_ref {
         #[inline(always)]
         fn call(_state: &OpState) {}
     }
@@ -214,7 +216,7 @@ const fn op_state_mut() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
         ) -> () {
             #[cfg(debug_assertions)]
@@ -290,6 +292,8 @@ const fn op_state_mut() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_state_mut {
         #[inline(always)]
         fn call(_state: &mut OpState) {}
     }
@@ -395,6 +399,8 @@ const fn op_state_and_v8() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_state_and_v8 {
         #[inline(always)]
         fn call(_state: &mut OpState, _callback: v8::Global<v8::Function>) {}
     }
@@ -469,7 +475,7 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             arg1: deno_core::v8::Local<deno_core::v8::Value>,
             fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
         ) -> () {
@@ -569,6 +575,8 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_state_and_v8_local {
         #[inline(always)]
         fn call(_state: &mut OpState, _callback: v8::Local<v8::Function>) {}
     }

--- a/ops/op2/test_cases/sync/result_external.out
+++ b/ops/op2/test_cases/sync/result_external.out
@@ -65,7 +65,7 @@ pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
         ) -> *mut ::std::ffi::c_void {
             #[cfg(debug_assertions)]
@@ -177,6 +177,8 @@ pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_external_with_result {
         #[inline(always)]
         pub fn call() -> Result<*mut std::ffi::c_void, AnyError> {
             Ok(0 as _)

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -65,7 +65,7 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
         ) -> u32 {
             #[cfg(debug_assertions)]
@@ -175,6 +175,8 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_u32_with_result {
         #[inline(always)]
         pub fn call() -> Result<u32, AnyError> {
             Ok(0)

--- a/ops/op2/test_cases/sync/result_scope.out
+++ b/ops/op2/test_cases/sync/result_scope.out
@@ -94,6 +94,8 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_void_with_result {
         #[inline(always)]
         pub fn call(_scope: &mut v8::HandleScope) -> Result<(), AnyError> {
             Ok(())

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -65,7 +65,7 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
         ) -> () {
             #[cfg(debug_assertions)]
@@ -175,6 +175,8 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_void_with_result {
         #[inline(always)]
         pub fn call() -> std::io::Result<()> {
             Ok(())

--- a/ops/op2/test_cases/sync/serde_v8.out
+++ b/ops/op2/test_cases/sync/serde_v8.out
@@ -107,6 +107,8 @@ pub const fn op_serde_v8() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_serde_v8 {
         #[inline(always)]
         pub fn call(_input: Input) -> Output {
             Output {}

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -76,7 +76,7 @@ const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: i32,
             arg1: i32,
             arg2: i32,
@@ -207,6 +207,8 @@ const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_smi_unsigned_return {
         #[inline(always)]
         fn call(a: Int16, b: Int32, c: Uint16, d: Uint32) -> Uint32 {
             a as Uint32 + b as Uint32 + c as Uint32 + d as Uint32
@@ -293,7 +295,7 @@ const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: i32,
             arg1: i32,
             arg2: i32,
@@ -424,6 +426,8 @@ const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_smi_signed_return {
         #[inline(always)]
         fn call(a: Int16, b: Int32, c: Uint16, d: Uint32) -> Int32 {
             a as Int32 + b as Int32 + c as Int32 + d as Int32
@@ -529,6 +533,8 @@ const fn op_smi_option() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_smi_option {
         #[inline(always)]
         fn call(a: Option<Uint32>) -> Option<Uint32> {
             a

--- a/ops/op2/test_cases/sync/string_cow.out
+++ b/ops/op2/test_cases/sync/string_cow.out
@@ -66,7 +66,7 @@ const fn op_string_cow() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
         ) -> u32 {
             #[cfg(debug_assertions)]
@@ -145,6 +145,8 @@ const fn op_string_cow() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_string_cow {
         #[inline(always)]
         fn call(s: Cow<str>) -> u32 {
             s.len() as _

--- a/ops/op2/test_cases/sync/string_onebyte.out
+++ b/ops/op2/test_cases/sync/string_onebyte.out
@@ -66,7 +66,7 @@ const fn op_string_onebyte() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
         ) -> u32 {
             #[cfg(debug_assertions)]
@@ -152,6 +152,8 @@ const fn op_string_onebyte() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_string_onebyte {
         #[inline(always)]
         fn call(s: Cow<[u8]>) -> u32 {
             s.len() as _

--- a/ops/op2/test_cases/sync/string_option_return.out
+++ b/ops/op2/test_cases/sync/string_option_return.out
@@ -93,6 +93,8 @@ pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_string_return {
         #[inline(always)]
         pub fn call(s: Option<String>) -> Option<String> {
             s

--- a/ops/op2/test_cases/sync/string_owned.out
+++ b/ops/op2/test_cases/sync/string_owned.out
@@ -66,7 +66,7 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
         ) -> u32 {
             #[cfg(debug_assertions)]
@@ -136,6 +136,8 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_string_owned {
         #[inline(always)]
         fn call(s: String) -> u32 {
             s.len() as _

--- a/ops/op2/test_cases/sync/string_ref.out
+++ b/ops/op2/test_cases/sync/string_ref.out
@@ -66,7 +66,7 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
         ) -> u32 {
             #[cfg(debug_assertions)]
@@ -145,6 +145,8 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_string_owned {
         #[inline(always)]
         fn call(s: &str) -> u32 {
             s.len() as _

--- a/ops/op2/test_cases/sync/string_return.out
+++ b/ops/op2/test_cases/sync/string_return.out
@@ -82,6 +82,8 @@ pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_string_return {
         #[inline(always)]
         pub fn call() -> String {
             "".into()
@@ -174,6 +176,8 @@ pub const fn op_string_return_ref() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_string_return_ref {
         #[inline(always)]
         pub fn call() -> &'static str {
             ""
@@ -266,6 +270,8 @@ pub const fn op_string_return_cow() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_string_return_cow {
         #[inline(always)]
         pub fn call<'a>() -> Cow<'a, str> {
             "".into()

--- a/ops/op2/test_cases/sync/v8_global.out
+++ b/ops/op2/test_cases/sync/v8_global.out
@@ -91,6 +91,8 @@ pub const fn op_global() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_global {
         #[inline(always)]
         pub fn call(g: v8::Global<v8::String>) -> v8::Global<v8::String> {
             g

--- a/ops/op2/test_cases/sync/v8_handlescope.out
+++ b/ops/op2/test_cases/sync/v8_handlescope.out
@@ -91,6 +91,8 @@ const fn op_handlescope() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_handlescope {
         #[inline(always)]
         fn call<'a>(
             _scope: &v8::HandleScope<'a>,

--- a/ops/op2/test_cases/sync/v8_lifetime.out
+++ b/ops/op2/test_cases/sync/v8_lifetime.out
@@ -90,6 +90,8 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_v8_lifetime {
         #[inline(always)]
         pub fn call<'s>(_s: v8::Local<'s, v8::String>) -> v8::Local<'s, v8::String> {
             unimplemented!()

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -77,7 +77,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast(
-            _: deno_core::v8::Local<deno_core::v8::Object>,
+            this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: deno_core::v8::Local<deno_core::v8::Value>,
             arg1: deno_core::v8::Local<deno_core::v8::Value>,
             fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
@@ -200,6 +200,8 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_v8_lifetime {
         #[inline(always)]
         pub fn call<'s>(_s: Option<&v8::String>, _s2: Option<&v8::String>) {}
     }

--- a/ops/op2/test_cases/sync/v8_string.out
+++ b/ops/op2/test_cases/sync/v8_string.out
@@ -106,6 +106,8 @@ const fn op_v8_string() -> ::deno_core::_ops::OpDecl {
                 );
             }
         }
+    }
+    impl op_v8_string {
         #[inline(always)]
         fn call<'a>(
             _str1: &v8::String,


### PR DESCRIPTION
Refactor out codegen for `&self` from #682 

```rust
struct State {
  name: &'static str,
}

impl State {
  #[op2(fast, method(State)]
  fn print(&self) {
    println!("{}", self.name);
  }
}

const STATE_DECL: [OpDecl; 1] = [
  State::print()
];
```