### PR TITLE
feat(core): Exposes `OpDriver` poll task

### DIFF
--- a/core/benches/ops/async.rs
+++ b/core/benches/ops/async.rs
@@ -110,7 +110,7 @@ fn bench_op(
   let tokio = tokio::runtime::Builder::new_current_thread()
     .build()
     .unwrap();
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, op_driver_poll_task) = JsRuntime::new(RuntimeOptions {
     extensions: vec![testing::init_ops_and_esm()],
     // We need to feature gate this here to prevent IDE errors
     #[cfg(feature = "unsafe_runtime_options")]
@@ -142,6 +142,7 @@ fn bench_op(
     .map_err(err_mapper)
     .unwrap();
   let guard = tokio.enter();
+  deno_unsync::spawn(op_driver_poll_task);
   let run = runtime.execute_script("", ascii_str!("run()")).unwrap();
   #[allow(deprecated)]
   let bench = tokio.block_on(runtime.resolve_value(run)).unwrap();

--- a/core/benches/ops/sync.rs
+++ b/core/benches/ops/sync.rs
@@ -154,7 +154,7 @@ fn bench_op(
     "This benchmark must be run with --features=unsafe_runtime_options"
   );
 
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     extensions: vec![testing::init_ops_and_esm()],
     // We need to feature gate this here to prevent IDE errors
     #[cfg(feature = "unsafe_runtime_options")]

--- a/core/benches/snapshot/snapshot.rs
+++ b/core/benches/snapshot/snapshot.rs
@@ -82,7 +82,7 @@ fn bench_take_snapshot_empty(c: &mut Criterion) {
     b.iter_custom(|iters| {
       let mut total = 0;
       for _ in 0..iters {
-        let runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
+        let (runtime, _) = JsRuntimeForSnapshot::new(RuntimeOptions {
           startup_snapshot: None,
           ..Default::default()
         });
@@ -101,7 +101,7 @@ fn bench_take_snapshot(c: &mut Criterion) {
       let mut total = 0;
       for _ in 0..iters {
         let extensions = make_extensions();
-        let runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
+        let (runtime, _) = JsRuntimeForSnapshot::new(RuntimeOptions {
           startup_snapshot: None,
           extension_transpiler: if transpile {
             Some(Rc::new(|specifier, source| {
@@ -130,7 +130,7 @@ fn bench_take_snapshot(c: &mut Criterion) {
 fn bench_load_snapshot(c: &mut Criterion) {
   fn inner(b: &mut Bencher, transpile: bool) {
     let extensions = make_extensions();
-    let runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
+    let (runtime, _) = JsRuntimeForSnapshot::new(RuntimeOptions {
       extensions,
       extension_transpiler: if transpile {
         Some(Rc::new(|specifier, source| {

--- a/core/examples/disable_ops.rs
+++ b/core/examples/disable_ops.rs
@@ -17,7 +17,7 @@ fn main() {
   };
 
   // Initialize a runtime instance
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     extensions: vec![my_ext],
     ..Default::default()
   });

--- a/core/examples/eval_js_value.rs
+++ b/core/examples/eval_js_value.rs
@@ -11,7 +11,7 @@ use deno_core::JsRuntime;
 use deno_core::RuntimeOptions;
 
 fn main() {
-  let mut runtime = JsRuntime::new(RuntimeOptions::default());
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions::default());
 
   // Evaluate some code
   let code = "let a = 1+4; a*2";

--- a/core/examples/hello_world.rs
+++ b/core/examples/hello_world.rs
@@ -24,7 +24,7 @@ fn main() {
   };
 
   // Initialize a runtime instance
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     extensions: vec![ext],
     ..Default::default()
   });

--- a/core/examples/op2.rs
+++ b/core/examples/op2.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Error> {
   "
   .to_string();
 
-  let mut js_runtime = JsRuntime::new(deno_core::RuntimeOptions {
+  let (mut js_runtime, _) = JsRuntime::new(deno_core::RuntimeOptions {
     module_loader: Some(Rc::new(FsModuleLoader)),
     extensions: vec![op2_sample::init_ops_and_esm()],
     ..Default::default()

--- a/core/examples/ts_module_loader.rs
+++ b/core/examples/ts_module_loader.rs
@@ -142,7 +142,7 @@ fn main() -> Result<(), Error> {
 
   let source_map_store = SourceMapStore(Rc::new(RefCell::new(HashMap::new())));
 
-  let mut js_runtime = JsRuntime::new(RuntimeOptions {
+  let (mut js_runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(Rc::new(TypescriptModuleLoader {
       source_maps: source_map_store.clone(),
     })),

--- a/core/examples/wasm.rs
+++ b/core/examples/wasm.rs
@@ -66,7 +66,7 @@ deno_core::extension!(
 
 fn main() {
   // Initialize a runtime instance
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     extensions: vec![wasm_example::init_ops()],
     ..Default::default()
   });

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -286,7 +286,7 @@ impl ModuleLoader for MockLoader {
 fn test_recursive_load() {
   let loader = MockLoader::new();
   let loads = loader.loads.clone();
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader),
     ..Default::default()
   });
@@ -369,7 +369,7 @@ fn test_mods() {
 
   deno_core::extension!(test_ext, ops = [op_test]);
 
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     extensions: vec![test_ext::init_ops()],
     module_loader: Some(loader.clone()),
     ..Default::default()
@@ -451,7 +451,7 @@ fn test_mods() {
 fn test_lazy_loaded_esm() {
   deno_core::extension!(test_ext, lazy_loaded_esm = [dir "modules/testdata", "lazy_loaded.js"]);
 
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     extensions: vec![test_ext::init_ops_and_esm()],
     ..Default::default()
   });
@@ -481,7 +481,7 @@ fn test_lazy_loaded_esm() {
 #[test]
 fn test_json_module() {
   let loader = Rc::new(TestingModuleLoader::new(StaticModuleLoader::default()));
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader.clone()),
     ..Default::default()
   });
@@ -593,7 +593,7 @@ fn test_validate_import_attributes_default() {
   // are allowed and don't have any problem executing "invalid" code.
 
   let loader = Rc::new(TestingModuleLoader::new(StaticModuleLoader::default()));
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader.clone()),
     ..Default::default()
   });
@@ -653,7 +653,7 @@ fn test_validate_import_attributes_callback() {
   }
 
   let loader = Rc::new(TestingModuleLoader::new(StaticModuleLoader::default()));
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader.clone()),
     validate_import_attributes_cb: Some(Box::new(validate_import_attributes)),
     ..Default::default()
@@ -724,7 +724,7 @@ fn test_validate_import_attributes_callback2() {
   }
 
   let loader = Rc::new(TestingModuleLoader::new(StaticModuleLoader::default()));
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader.clone()),
     validate_import_attributes_cb: Some(Box::new(validate_import_attrs)),
     ..Default::default()
@@ -758,7 +758,7 @@ fn test_validate_import_attributes_callback2() {
 #[test]
 fn test_custom_module_type_default() {
   let loader = Rc::new(TestingModuleLoader::new(StaticModuleLoader::default()));
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader.clone()),
     ..Default::default()
   });
@@ -825,7 +825,7 @@ fn test_custom_module_type_callback_synthetic() {
   }
 
   let loader = Rc::new(TestingModuleLoader::new(StaticModuleLoader::default()));
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader.clone()),
     custom_module_evaluation_cb: Some(Box::new(custom_eval_cb)),
     ..Default::default()
@@ -922,7 +922,7 @@ export const foo = bytes;
   }
 
   let loader = Rc::new(TestingModuleLoader::new(StaticModuleLoader::default()));
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader.clone()),
     custom_module_evaluation_cb: Some(Box::new(custom_eval_cb)),
     ..Default::default()
@@ -983,7 +983,7 @@ export const foo = bytes;
 #[tokio::test]
 async fn dyn_import_err() {
   let loader = Rc::new(TestingModuleLoader::new(StaticModuleLoader::default()));
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader.clone()),
     ..Default::default()
   });
@@ -1016,7 +1016,7 @@ async fn dyn_import_ok() {
     Url::parse("file:///b.js").unwrap(),
     ascii_str!("export function b() { return 'b' }"),
   )));
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader.clone()),
     ..Default::default()
   });
@@ -1063,7 +1063,7 @@ async fn dyn_import_borrow_mut_error() {
     Url::parse("file:///b.js").unwrap(),
     ascii_str!("export function b() { return 'b' }"),
   )));
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader.clone()),
     ..Default::default()
   });
@@ -1101,7 +1101,7 @@ async fn dyn_import_borrow_mut_error() {
 fn test_circular_load() {
   let loader = MockLoader::new();
   let loads = loader.loads.clone();
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader),
     ..Default::default()
   });
@@ -1181,7 +1181,7 @@ fn test_circular_load() {
 fn test_redirect_load() {
   let loader = MockLoader::new();
   let loads = loader.loads.clone();
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader),
     ..Default::default()
   });
@@ -1249,7 +1249,7 @@ fn test_redirect_load() {
 async fn slow_never_ready_modules() {
   let loader = MockLoader::new();
   let loads = loader.loads.clone();
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader),
     ..Default::default()
   });
@@ -1294,7 +1294,7 @@ async fn slow_never_ready_modules() {
 #[tokio::test]
 async fn loader_disappears_after_error() {
   let loader = MockLoader::new();
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader),
     ..Default::default()
   });
@@ -1321,7 +1321,7 @@ fn recursive_load_main_with_code() {
 
   let loader = MockLoader::new();
   let loads = loader.loads.clone();
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader),
     ..Default::default()
   });
@@ -1408,7 +1408,7 @@ fn main_and_side_module() {
     ),
   ]);
 
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(Rc::new(loader)),
     ..Default::default()
   });
@@ -1445,7 +1445,7 @@ fn dynamic_imports_snapshot() {
     "#;
 
     let loader = MockLoader::new();
-    let mut runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
+    let (mut runtime, _) = JsRuntimeForSnapshot::new(RuntimeOptions {
       module_loader: Some(loader),
       ..Default::default()
     });
@@ -1466,7 +1466,7 @@ fn dynamic_imports_snapshot() {
   };
 
   let snapshot = Box::leak(snapshot);
-  let mut runtime2 = JsRuntime::new(RuntimeOptions {
+  let (mut runtime2, _) = JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(snapshot),
     ..Default::default()
   });
@@ -1485,7 +1485,7 @@ fn import_meta_snapshot() {
     "#;
 
     let loader = MockLoader::new();
-    let mut runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
+    let (mut runtime, _) = JsRuntimeForSnapshot::new(RuntimeOptions {
       module_loader: Some(loader),
       ..Default::default()
     });
@@ -1507,7 +1507,7 @@ fn import_meta_snapshot() {
   };
 
   let snapshot = Box::leak(snapshot);
-  let mut runtime2 = JsRuntime::new(RuntimeOptions {
+  let (mut runtime2, _) = JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(snapshot),
     ..Default::default()
   });
@@ -1616,7 +1616,7 @@ async fn no_duplicate_loads() {
   }
 
   let loader = Rc::new(ConsumingLoader::default());
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(loader),
     ..Default::default()
   });
@@ -1646,7 +1646,7 @@ async fn import_meta_resolve_cb() {
     bail!("unexpected")
   }
 
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     import_meta_resolve_callback: Some(Box::new(import_meta_resolve_cb)),
     ..Default::default()
   });
@@ -1692,7 +1692,7 @@ fn builtin_core_module() {
   "#;
   let loader = StaticModuleLoader::new([(main_specifier.clone(), source_code)]);
 
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(Rc::new(loader)),
     ..Default::default()
   });
@@ -1724,7 +1724,7 @@ fn import_meta_filename_dirname() {
 
   let loader = StaticModuleLoader::new([(main_specifier.clone(), code)]);
 
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: Some(Rc::new(loader)),
     ..Default::default()
   });
@@ -1744,7 +1744,7 @@ fn test_load_with_code_cache() {
     let loader = MockLoader::new();
     let loads = loader.loads.clone();
     let updated_code_cache = loader.updated_code_cache.clone();
-    let mut runtime = JsRuntime::new(RuntimeOptions {
+    let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
       module_loader: Some(loader),
       enable_code_cache: true,
       ..Default::default()
@@ -1788,7 +1788,7 @@ fn test_load_with_code_cache() {
     let loader = MockLoader::new_with_code_cache(code_cache.clone());
     let loads = loader.loads.clone();
     let updated_code_cache = loader.updated_code_cache.clone();
-    let mut runtime = JsRuntime::new(RuntimeOptions {
+    let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
       module_loader: Some(loader),
       enable_code_cache: true,
       ..Default::default()
@@ -1825,7 +1825,7 @@ fn test_load_with_code_cache() {
     let loader = MockLoader::new_with_code_cache(code_cache);
     let loads = loader.loads.clone();
     let updated_code_cache = loader.updated_code_cache.clone();
-    let mut runtime = JsRuntime::new(RuntimeOptions {
+    let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
       module_loader: Some(loader),
       enable_code_cache: true,
       ..Default::default()

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -654,10 +654,11 @@ mod tests {
 
   /// Run a test for a single op.
   fn run_test2(repeat: usize, op: &str, test: &str) -> Result<(), AnyError> {
-    let mut runtime = JsRuntime::new(RuntimeOptions {
+    let (mut runtime, op_driver_poll_task) = JsRuntime::new(RuntimeOptions {
       extensions: vec![testing::init_ops_and_esm()],
       ..Default::default()
     });
+    deno_unsync::spawn(op_driver_poll_task);
     let err_mapper =
       |err| generic_error(format!("{op} test failed ({test}): {err:?}"));
     runtime
@@ -705,10 +706,11 @@ mod tests {
     op: &str,
     test: &str,
   ) -> Result<(), AnyError> {
-    let mut runtime = JsRuntime::new(RuntimeOptions {
+    let (mut runtime, op_driver_poll_task) = JsRuntime::new(RuntimeOptions {
       extensions: vec![testing::init_ops_and_esm()],
       ..Default::default()
     });
+    deno_unsync::spawn(op_driver_poll_task);
     let err_mapper =
       |err| generic_error(format!("{op} test failed ({test}): {err:?}"));
     runtime
@@ -1898,8 +1900,9 @@ mod tests {
     resource.value
   }
 
-  #[test]
-  pub fn test_op_cppgc_object() -> Result<(), Box<dyn std::error::Error>> {
+  #[tokio::test]
+  pub async fn test_op_cppgc_object() -> Result<(), Box<dyn std::error::Error>>
+  {
     run_test2(
       10,
       "op_test_make_cppgc_resource, op_test_get_cppgc_resource",

--- a/core/runtime/snapshot.rs
+++ b/core/runtime/snapshot.rs
@@ -141,7 +141,7 @@ pub fn create_snapshot(
       .collect::<Vec<_>>()
   });
 
-  let mut js_runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
+  let (mut js_runtime, _) = JsRuntimeForSnapshot::new(RuntimeOptions {
     startup_snapshot: create_snapshot_options.startup_snapshot,
     extensions: create_snapshot_options.extensions,
     extension_transpiler: create_snapshot_options.extension_transpiler,
@@ -172,7 +172,7 @@ pub fn create_snapshot(
     // - Create a new isolate with cold snapshot blob.
     // - Run warmup script in new context.
     // - Serialize the new context into a new snapshot blob.
-    let mut js_runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
+    let (mut js_runtime, _) = JsRuntimeForSnapshot::new(RuntimeOptions {
       startup_snapshot: Some(leaked_snapshot),
       extensions: warmup_exts,
       skip_op_registration: true,

--- a/core/runtime/tests/error.rs
+++ b/core/runtime/tests/error.rs
@@ -20,7 +20,7 @@ async fn test_error_builder() {
   }
 
   deno_core::extension!(test_ext, ops = [op_err]);
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     extensions: vec![test_ext::init_ops()],
     get_error_class_fn: Some(&get_error_class_name),
     ..Default::default()
@@ -43,7 +43,7 @@ async fn test_error_builder() {
 
 #[test]
 fn syntax_error() {
-  let mut runtime = JsRuntime::new(Default::default());
+  let (mut runtime, _) = JsRuntime::new(Default::default());
   let src = "hocuspocus(";
   let r = runtime.execute_script("i.js", src);
   let e = r.unwrap_err();

--- a/core/runtime/tests/jsrealm.rs
+++ b/core/runtime/tests/jsrealm.rs
@@ -11,7 +11,7 @@ use std::task::Poll;
 
 #[test]
 fn test_set_format_exception_callback_realms() {
-  let mut runtime = JsRuntime::new(RuntimeOptions::default());
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions::default());
   let main_realm = runtime.main_realm();
 
   let realm_expectations = &[(&main_realm, "main_realm")];
@@ -81,7 +81,7 @@ async fn js_realm_ref_unref_ops() {
   }
 
   deno_core::extension!(test_ext, ops = [op_pending]);
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     extensions: vec![test_ext::init_ops()],
     ..Default::default()
   });
@@ -133,7 +133,7 @@ fn es_snapshot() {
         { source = "globalThis.TEST = 'foo'; export const TEST = 'bar';" },]
     );
 
-    let runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
+    let (runtime, _) = JsRuntimeForSnapshot::new(RuntimeOptions {
       extensions: vec![module_snapshot::init_ops_and_esm()],
       module_loader: Some(Rc::new(StaticModuleLoader::default())),
       ..Default::default()
@@ -141,7 +141,7 @@ fn es_snapshot() {
     runtime.snapshot()
   };
   let snapshot = Box::leak(startup_data);
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: None,
     startup_snapshot: Some(snapshot),
     ..Default::default()

--- a/core/runtime/tests/mod.rs
+++ b/core/runtime/tests/mod.rs
@@ -78,7 +78,7 @@ fn setup(mode: Mode) -> (JsRuntime, Arc<AtomicUsize>) {
       })
     }
   );
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     extensions: vec![test_ext::init_ops(mode, dispatch_count.clone())],
     get_error_class_fn: Some(&|error| {
       crate::error::get_custom_error_class(error).unwrap()

--- a/core/runtime/tests/snapshot.rs
+++ b/core/runtime/tests/snapshot.rs
@@ -14,13 +14,13 @@ use self::runtime::CreateSnapshotOptions;
 #[test]
 fn will_snapshot() {
   let snapshot = {
-    let mut runtime = JsRuntimeForSnapshot::new(Default::default());
+    let (mut runtime, _) = JsRuntimeForSnapshot::new(Default::default());
     runtime.execute_script("a.js", "a = 1 + 2").unwrap();
     runtime.snapshot()
   };
 
   let snapshot = Box::leak(snapshot);
-  let mut runtime2 = JsRuntime::new(RuntimeOptions {
+  let (mut runtime2, _) = JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(snapshot),
     ..Default::default()
   });
@@ -32,13 +32,13 @@ fn will_snapshot() {
 #[test]
 fn will_snapshot2() {
   let startup_data = {
-    let mut runtime = JsRuntimeForSnapshot::new(Default::default());
+    let (mut runtime, _) = JsRuntimeForSnapshot::new(Default::default());
     runtime.execute_script("a.js", "let a = 1 + 2").unwrap();
     runtime.snapshot()
   };
 
   let snapshot = Box::leak(startup_data);
-  let mut runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntimeForSnapshot::new(RuntimeOptions {
     startup_snapshot: Some(snapshot),
     ..Default::default()
   });
@@ -53,7 +53,7 @@ fn will_snapshot2() {
 
   let snapshot = Box::leak(startup_data);
   {
-    let mut runtime = JsRuntime::new(RuntimeOptions {
+    let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
       startup_snapshot: Some(snapshot),
       ..Default::default()
     });
@@ -69,7 +69,7 @@ fn will_snapshot2() {
 #[test]
 fn test_snapshot_callbacks() {
   let snapshot = {
-    let mut runtime = JsRuntimeForSnapshot::new(Default::default());
+    let (mut runtime, _) = JsRuntimeForSnapshot::new(Default::default());
     runtime
       .execute_script(
         "a.js",
@@ -91,7 +91,7 @@ fn test_snapshot_callbacks() {
   };
 
   let snapshot = Box::leak(snapshot);
-  let mut runtime2 = JsRuntime::new(RuntimeOptions {
+  let (mut runtime2, _) = JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(snapshot),
     ..Default::default()
   });
@@ -103,13 +103,13 @@ fn test_snapshot_callbacks() {
 #[test]
 fn test_from_snapshot() {
   let snapshot = {
-    let mut runtime = JsRuntimeForSnapshot::new(Default::default());
+    let (mut runtime, _) = JsRuntimeForSnapshot::new(Default::default());
     runtime.execute_script("a.js", "a = 1 + 2").unwrap();
     runtime.snapshot()
   };
 
   let snapshot = Box::leak(snapshot);
-  let mut runtime2 = JsRuntime::new(RuntimeOptions {
+  let (mut runtime2, _) = JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(snapshot),
     ..Default::default()
   });
@@ -138,7 +138,7 @@ fn test_snapshot_creator() {
 
   let snapshot = Box::leak(output.output);
 
-  let mut runtime2 = JsRuntime::new(RuntimeOptions {
+  let (mut runtime2, _) = JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(snapshot),
     ..Default::default()
   });
@@ -175,7 +175,7 @@ fn test_snapshot_creator_warmup() {
 
   let snapshot = Box::leak(output.output);
 
-  let mut runtime2 = JsRuntime::new(RuntimeOptions {
+  let (mut runtime2, _) = JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(snapshot),
     ..Default::default()
   });
@@ -235,7 +235,7 @@ fn es_snapshot() {
   fn op_test() -> Result<String, Error> {
     Ok(String::from("test"))
   }
-  let mut runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntimeForSnapshot::new(RuntimeOptions {
     extensions: vec![Extension {
       name: "test_ext",
       ops: Cow::Borrowed(&[DECL]),
@@ -272,7 +272,7 @@ fn es_snapshot() {
   let snapshot = runtime.snapshot();
   let snapshot = Box::leak(snapshot);
 
-  let mut runtime2 = JsRuntimeForSnapshot::new(RuntimeOptions {
+  let (mut runtime2, _) = JsRuntimeForSnapshot::new(RuntimeOptions {
     startup_snapshot: Some(snapshot),
     extensions: vec![Extension {
       name: "test_ext",
@@ -293,7 +293,7 @@ fn es_snapshot() {
   let snapshot2 = Box::leak(snapshot2);
 
   const DECL: OpDecl = op_test();
-  let mut runtime3 = JsRuntime::new(RuntimeOptions {
+  let (mut runtime3, _) = JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(snapshot2),
     extensions: vec![Extension {
       name: "test_ext",
@@ -330,7 +330,7 @@ pub(crate) fn es_snapshot_without_runtime_module_loader() {
         { source = "globalThis.TEST = 'foo'; export const TEST = 'bar';" },]
     );
 
-    let runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
+    let (runtime, _) = JsRuntimeForSnapshot::new(RuntimeOptions {
       extensions: vec![module_snapshot::init_ops_and_esm()],
       ..Default::default()
     });
@@ -340,7 +340,7 @@ pub(crate) fn es_snapshot_without_runtime_module_loader() {
 
   let snapshot = Box::leak(startup_data);
 
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     module_loader: None,
     startup_snapshot: Some(snapshot),
     ..Default::default()
@@ -425,7 +425,7 @@ pub fn snapshot_with_additional_extensions() {
   );
 
   let snapshot = {
-    let runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
+    let (runtime, _) = JsRuntimeForSnapshot::new(RuntimeOptions {
       extensions: vec![before_snapshot::init_ops_and_esm()],
       ..Default::default()
     });
@@ -433,7 +433,7 @@ pub fn snapshot_with_additional_extensions() {
     Box::leak(runtime.snapshot())
   };
 
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(snapshot),
     extensions: vec![
       before_snapshot::init_ops(),

--- a/dcore/src/main.rs
+++ b/dcore/src/main.rs
@@ -62,7 +62,7 @@ fn main() -> Result<(), Error> {
   // .unwrap();
   // return Ok(());
 
-  let mut js_runtime = JsRuntime::new(RuntimeOptions {
+  let (mut js_runtime, _) = JsRuntime::new(RuntimeOptions {
     // TODO(bartlomieju): figure out how we can incorporate snapshotting here
     // startup_snapshot: Some(deno_core::Snapshot::Static(SNAPSHOT_BYTES)),
     module_loader: Some(Rc::new(FsModuleLoader)),

--- a/testing/checkin/runner/mod.rs
+++ b/testing/checkin/runner/mod.rs
@@ -101,7 +101,7 @@ fn create_runtime(
   let (worker, worker_host_side) = worker_create(parent);
   let extensions_for_snapshot = vec![checkin_runtime::init_ops_and_esm::<()>()];
 
-  let runtime_for_snapshot = JsRuntimeForSnapshot::new(RuntimeOptions {
+  let (runtime_for_snapshot, _) = JsRuntimeForSnapshot::new(RuntimeOptions {
     extensions: extensions_for_snapshot,
     extension_transpiler: Some(Rc::new(|specifier, source| {
       maybe_transpile_source(specifier, source)
@@ -114,7 +114,7 @@ fn create_runtime(
   let extensions = vec![checkin_runtime::init_ops::<()>()];
   let module_loader =
     Rc::new(ts_module_loader::TypescriptModuleLoader::default());
-  let mut runtime = JsRuntime::new(RuntimeOptions {
+  let (mut runtime, _) = JsRuntime::new(RuntimeOptions {
     extensions,
     startup_snapshot: Some(snapshot),
     module_loader: Some(module_loader.clone()),


### PR DESCRIPTION
Exposes `OpDriver` poll task

Prevents `deno_core` internals relying on being in a Tokio runtime, this locks users into using a specific and global runtime.

Considered three options:

1. Make `ContextState` generic with `O: OpDriver`. This would have polluted all `deno_core` types like `JsRuntime` with the argument and required each user to re-implement the entire surface. Not nice 🫠. (I also saw this very thing had been removed https://github.com/denoland/deno_core/pull/506).

2. Create `OpDriver::new() -> (Self, op_driver_poll_task)`, which ensures that the `op_driver_poll_task` reaches the user and they can use any polling method to drive it.

3. Store `op_driver_poll_task` within `JsRuntime` and poll in `poll_event_loop`. I don't have the knowledge to know whether this is a valid approach but would be simple, however, it does not pass `runtime::tests::misc::test_wakers_for_async_ops` since the test case stops polling the event loop. Performance is markedly increased for lazy async functions. https://github.com/Suficio/deno_core/tree/expose_op_driver_poll_task

Option 2 is the one in this PR.

The main downside is it leads to a breaking change where `JsRuntime::new` now returns `(JsRuntime, op_driver_poll_task)`. On the other hand, it simplifies the logic within `FuturesUnorderedDriver` and is async executor agnostic, similar to other `deno_core` API (such as `JsRuntime::mod_evaluate`).

`tokio` is still present in `deno_core` but I can simply remove the relevant modules from my runtime to avoid hitting the logic.

The motivation behind this is https://github.com/Suficio/bevy_js_prototype. Where I managed to create first-class Bevy systems within Deno but was blocked on Bevy features.

---

main:

```
test baseline                             ... bench:       2,398 ns/iter (+/- 446)
test baseline_op_promise                  ... bench:      99,871 ns/iter (+/- 5,490)
test baseline_op_promise_resolver         ... bench:     107,142 ns/iter (+/- 3,162)
test baseline_promise                     ... bench:      40,409 ns/iter (+/- 1,997)
test baseline_promise_with_resolver       ... bench:      61,734 ns/iter (+/- 1,333)
test baseline_sync                        ... bench:      49,772 ns/iter (+/- 2,387)
test bench_op_async_void                  ... bench:      59,162 ns/iter (+/- 2,687)
test bench_op_async_void_deferred         ... bench:     735,740 ns/iter (+/- 22,760)
test bench_op_async_void_deferred_nofast  ... bench:     735,988 ns/iter (+/- 15,784)
test bench_op_async_void_deferred_return  ... bench:     751,995 ns/iter (+/- 22,771)
test bench_op_async_void_lazy             ... bench:     716,987 ns/iter (+/- 26,406)
test bench_op_async_void_lazy_nofast      ... bench:     715,105 ns/iter (+/- 22,032)
test bench_op_async_yield                 ... bench:     747,403 ns/iter (+/- 16,580)
test bench_op_async_yield_deferred        ... bench:     748,494 ns/iter (+/- 21,832)
test bench_op_async_yield_deferred_nofast ... bench:     741,166 ns/iter (+/- 19,344)
test bench_op_async_yield_lazy            ... bench:     875,238 ns/iter (+/- 46,945)
test bench_op_async_yield_lazy_nofast     ... bench:     881,266 ns/iter (+/- 23,659)
```

Option 2:

```
test baseline                             ... bench:       2,220 ns/iter (+/- 102)
test baseline_op_promise                  ... bench:      99,533 ns/iter (+/- 3,875)
test baseline_op_promise_resolver         ... bench:     106,270 ns/iter (+/- 7,187)
test baseline_promise                     ... bench:      40,905 ns/iter (+/- 2,617)
test baseline_promise_with_resolver       ... bench:      61,053 ns/iter (+/- 2,688)
test baseline_sync                        ... bench:      49,126 ns/iter (+/- 1,512)
test bench_op_async_void                  ... bench:      58,107 ns/iter (+/- 2,814)
test bench_op_async_void_deferred         ... bench:     726,145 ns/iter (+/- 21,675)
test bench_op_async_void_deferred_nofast  ... bench:     730,051 ns/iter (+/- 24,114)
test bench_op_async_void_deferred_return  ... bench:     752,984 ns/iter (+/- 15,361)
test bench_op_async_void_lazy             ... bench:     704,201 ns/iter (+/- 12,323)
test bench_op_async_void_lazy_nofast      ... bench:     708,369 ns/iter (+/- 43,983)
test bench_op_async_yield                 ... bench:     730,098 ns/iter (+/- 27,439)
test bench_op_async_yield_deferred        ... bench:     732,443 ns/iter (+/- 18,550)
test bench_op_async_yield_deferred_nofast ... bench:     748,298 ns/iter (+/- 48,505)
test bench_op_async_yield_lazy            ... bench:     849,824 ns/iter (+/- 30,802)
test bench_op_async_yield_lazy_nofast     ... bench:     848,200 ns/iter (+/- 16,016)
```

Option 3:

```
test baseline                             ... bench:       2,243 ns/iter (+/- 235)
test baseline_op_promise                  ... bench:     100,104 ns/iter (+/- 4,008)
test baseline_op_promise_resolver         ... bench:     107,737 ns/iter (+/- 5,616)
test baseline_promise                     ... bench:      41,293 ns/iter (+/- 1,157)
test baseline_promise_with_resolver       ... bench:      61,714 ns/iter (+/- 3,169)
test baseline_sync                        ... bench:      49,470 ns/iter (+/- 2,712)
test bench_op_async_void                  ... bench:      60,322 ns/iter (+/- 1,041)
test bench_op_async_void_deferred         ... bench:     746,695 ns/iter (+/- 54,612)
test bench_op_async_void_deferred_nofast  ... bench:     726,972 ns/iter (+/- 30,032)
test bench_op_async_void_deferred_return  ... bench:     737,755 ns/iter (+/- 26,370)
test bench_op_async_void_lazy             ... bench:     698,823 ns/iter (+/- 18,995)
test bench_op_async_void_lazy_nofast      ... bench:     705,422 ns/iter (+/- 20,888)
test bench_op_async_yield                 ... bench:     718,865 ns/iter (+/- 19,122)
test bench_op_async_yield_deferred        ... bench:     719,372 ns/iter (+/- 20,141)
test bench_op_async_yield_deferred_nofast ... bench:     721,726 ns/iter (+/- 17,530)
test bench_op_async_yield_lazy            ... bench:     727,769 ns/iter (+/- 49,308)
test bench_op_async_yield_lazy_nofast     ... bench:     740,983 ns/iter (+/- 50,091)
```

