### PR TITLE
fix(core): don't lose waker for tasks

### DIFF
--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -2278,12 +2278,24 @@ impl JsRuntime {
 
     // Poll any pending task spawner tasks. Note that we need to poll separately because otherwise
     // Rust will extend the lifetime of the borrow longer than we expect.
-    let tasks = context_state.task_spawner_factory.poll_inner(cx);
-    if let Poll::Ready(tasks) = tasks {
+    let mut retries = 3;
+    while let Poll::Ready(tasks) =
+      context_state.task_spawner_factory.poll_inner(cx)
+    {
       // TODO(mmastrac): we are using this flag
       dispatched_ops = true;
       for task in tasks {
         task(scope);
+      }
+      // We may need to perform a microtask checkpoint here
+      scope.perform_microtask_checkpoint();
+
+      // We don't want tasks that spawn other tasks the starve the event loop, so break
+      // after three times around and allow the remainder of the event loop to spin.
+      retries -= 1;
+      if retries == 0 {
+        cx.waker().wake_by_ref();
+        break;
       }
     }
 

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -2290,7 +2290,7 @@ impl JsRuntime {
       // We may need to perform a microtask checkpoint here
       scope.perform_microtask_checkpoint();
 
-      // We don't want tasks that spawn other tasks the starve the event loop, so break
+      // We don't want tasks that spawn other tasks to starve the event loop, so break
       // after three times around and allow the remainder of the event loop to spin.
       retries -= 1;
       if retries == 0 {

--- a/core/tasks.rs
+++ b/core/tasks.rs
@@ -89,7 +89,6 @@ impl V8TaskSpawnerFactory {
   }
 
   fn spawn(&self, task: SendTask) {
-    eprintln!("spawn");
     self.tasks.lock().unwrap().push(task);
     // TODO(mmastrac): can we skip the mutex here?
     // Release ordering means that the writes in the above lock happen-before the atomic store

--- a/core/tasks.rs
+++ b/core/tasks.rs
@@ -89,6 +89,7 @@ impl V8TaskSpawnerFactory {
   }
 
   fn spawn(&self, task: SendTask) {
+    eprintln!("spawn");
     self.tasks.lock().unwrap().push(task);
     // TODO(mmastrac): can we skip the mutex here?
     // Release ordering means that the writes in the above lock happen-before the atomic store

--- a/testing/checkin/runner/mod.rs
+++ b/testing/checkin/runner/mod.rs
@@ -54,6 +54,7 @@ deno_core::extension!(
     ops::op_nop_generic<P>,
     ops_io::op_pipe_create,
     ops_io::op_file_open,
+    ops_async::op_task_submit,
     ops_async::op_async_yield,
     ops_async::op_async_barrier_create,
     ops_async::op_async_barrier_await,

--- a/testing/checkin/runner/ops_async.rs
+++ b/testing/checkin/runner/ops_async.rs
@@ -1,6 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 use deno_core::op2;
+use deno_core::v8;
 use deno_core::OpState;
+use deno_core::V8TaskSpawner;
 use futures::future::poll_fn;
 use std::cell::RefCell;
 use std::future::Future;
@@ -8,6 +10,15 @@ use std::rc::Rc;
 
 use super::testing::Output;
 use super::testing::TestData;
+
+#[op2]
+pub fn op_task_submit(state: &mut OpState, #[global] f: v8::Global<v8::Function>) {
+  state.borrow_mut::<V8TaskSpawner>().spawn(move |scope| {
+    let f = v8::Local::new(scope, f);
+    let recv = v8::undefined(scope);
+    f.call(scope, recv.into(), &[]);
+  });
+}
 
 #[op2(async)]
 pub async fn op_async_yield() {

--- a/testing/checkin/runner/ops_async.rs
+++ b/testing/checkin/runner/ops_async.rs
@@ -12,7 +12,10 @@ use super::testing::Output;
 use super::testing::TestData;
 
 #[op2]
-pub fn op_task_submit(state: &mut OpState, #[global] f: v8::Global<v8::Function>) {
+pub fn op_task_submit(
+  state: &mut OpState,
+  #[global] f: v8::Global<v8::Function>,
+) {
   state.borrow_mut::<V8TaskSpawner>().spawn(move |scope| {
     let f = v8::Local::new(scope, f);
     let recv = v8::undefined(scope);

--- a/testing/lib.rs
+++ b/testing/lib.rs
@@ -41,6 +41,7 @@ unit_test!(
   resource_test,
   serialize_deserialize_test,
   stats_test,
+  task_test,
   tc39_test,
   timer_test,
   type_test,

--- a/testing/unit/task_test.ts
+++ b/testing/unit/task_test.ts
@@ -30,3 +30,13 @@ test(async function testTaskSubmit3() {
     await promise;
   }
 });
+
+test(async function testTaskSubmit100() {
+  for (let i = 0; i < 100; i++) {
+    const { promise, resolve } = Promise.withResolvers();
+    op_task_submit(() => {
+      resolve(undefined);
+    });
+    await promise;
+  }
+});

--- a/testing/unit/task_test.ts
+++ b/testing/unit/task_test.ts
@@ -1,0 +1,12 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+import { assert, fail, test } from "checkin:testing";
+
+const { op_task_submit } = Deno.core.ops;
+
+test(async function testTaskSubmit() {
+  let { promise, resolve } = Promise.withResolvers();
+  op_task_submit(() => {
+    resolve(undefined);
+  });
+  await promise;
+});

--- a/testing/unit/task_test.ts
+++ b/testing/unit/task_test.ts
@@ -1,10 +1,10 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assert, fail, test } from "checkin:testing";
+import { test } from "checkin:testing";
 
 const { op_task_submit } = Deno.core.ops;
 
 test(async function testTaskSubmit1() {
-  let { promise, resolve } = Promise.withResolvers();
+  const { promise, resolve } = Promise.withResolvers();
   op_task_submit(() => {
     resolve(undefined);
   });
@@ -13,7 +13,7 @@ test(async function testTaskSubmit1() {
 
 test(async function testTaskSubmit2() {
   for (let i = 0; i < 2; i++) {
-    let { promise, resolve } = Promise.withResolvers();
+    const { promise, resolve } = Promise.withResolvers();
     op_task_submit(() => {
       resolve(undefined);
     });
@@ -23,7 +23,7 @@ test(async function testTaskSubmit2() {
 
 test(async function testTaskSubmit3() {
   for (let i = 0; i < 3; i++) {
-    let { promise, resolve } = Promise.withResolvers();
+    const { promise, resolve } = Promise.withResolvers();
     op_task_submit(() => {
       resolve(undefined);
     });

--- a/testing/unit/task_test.ts
+++ b/testing/unit/task_test.ts
@@ -3,10 +3,30 @@ import { assert, fail, test } from "checkin:testing";
 
 const { op_task_submit } = Deno.core.ops;
 
-test(async function testTaskSubmit() {
+test(async function testTaskSubmit1() {
   let { promise, resolve } = Promise.withResolvers();
   op_task_submit(() => {
     resolve(undefined);
   });
   await promise;
+});
+
+test(async function testTaskSubmit2() {
+  for (let i = 0; i < 2; i++) {
+    let { promise, resolve } = Promise.withResolvers();
+    op_task_submit(() => {
+      resolve(undefined);
+    });
+    await promise;
+  }
+});
+
+test(async function testTaskSubmit3() {
+  for (let i = 0; i < 3; i++) {
+    let { promise, resolve } = Promise.withResolvers();
+    op_task_submit(() => {
+      resolve(undefined);
+    });
+    await promise;
+  }
 });


### PR DESCRIPTION
Ref https://github.com/denoland/deno/issues/21686

If we had additional tasks generated while servicing these tasks we'd eventually fail to wake the waker (which no longer exists in the task spawner). 