### PR TITLE
Support ToV8/FromV8 in `#[op2]`

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -26,6 +26,7 @@ mod path;
 mod runtime;
 mod source_map;
 mod tasks;
+mod to_from_v8;
 mod web_timeout;
 
 // Re-exports
@@ -150,6 +151,8 @@ pub use crate::source_map::SourceMapData;
 pub use crate::source_map::SourceMapGetter;
 pub use crate::tasks::V8CrossThreadTaskSpawner;
 pub use crate::tasks::V8TaskSpawner;
+pub use crate::to_from_v8::FromV8;
+pub use crate::to_from_v8::ToV8;
 
 // Ensure we can use op2 in deno_core without any hackery.
 extern crate self as deno_core;

--- a/core/runtime/ops_rust_to_v8.rs
+++ b/core/runtime/ops_rust_to_v8.rs
@@ -161,6 +161,9 @@ impl Marker for NumberMarker {}
 pub struct ArrayBufferMarker;
 impl Marker for ArrayBufferMarker {}
 
+pub struct ToV8Marker;
+impl Marker for ToV8Marker {}
+
 trait Marker {}
 
 /// Helper macro for [`RustToV8`] to reduce boilerplate.
@@ -399,6 +402,21 @@ impl<'a, T: serde::Serialize> RustToV8Fallible<'a>
     scope: &mut v8::HandleScope<'a>,
   ) -> serde_v8::Result<v8::Local<'a, v8::Value>> {
     serde_v8::to_v8(scope, self.0)
+  }
+}
+
+impl<'a, T: crate::ToV8<'a>> RustToV8Fallible<'a>
+  for RustToV8Marker<ToV8Marker, T>
+{
+  #[inline(always)]
+  fn to_v8_fallible(
+    self,
+    scope: &mut v8::HandleScope<'a>,
+  ) -> serde_v8::Result<v8::Local<'a, v8::Value>> {
+    self
+      .0
+      .to_v8(scope)
+      .map_err(|e| serde_v8::Error::Custom(Box::new(e)))
   }
 }
 

--- a/core/to_from_v8.rs
+++ b/core/to_from_v8.rs
@@ -1,0 +1,54 @@
+pub trait ToV8<'a> {
+  type Error: std::error::Error;
+
+  fn to_v8(
+    &mut self,
+    scope: &mut v8::HandleScope<'a>,
+  ) -> Result<v8::Local<'a, v8::Value>, Self::Error>;
+}
+
+pub trait FromV8<'a>: Sized {
+  type Error: std::error::Error;
+
+  fn from_v8(
+    scope: &mut v8::HandleScope<'a>,
+    value: v8::Local<'a, v8::Value>,
+  ) -> Result<Self, Self::Error>;
+}
+
+// Impls for Option
+
+impl<'a, T> ToV8<'a> for Option<T>
+where
+  T: ToV8<'a>,
+{
+  type Error = T::Error;
+
+  fn to_v8(
+    &mut self,
+    scope: &mut v8::HandleScope<'a>,
+  ) -> Result<v8::Local<'a, v8::Value>, Self::Error> {
+    match self {
+      Some(x) => x.to_v8(scope).map(Into::into),
+      None => Ok(v8::undefined(scope).into()),
+    }
+  }
+}
+
+impl<'a, T> FromV8<'a> for Option<T>
+where
+  T: FromV8<'a>,
+{
+  type Error = T::Error;
+
+  fn from_v8(
+    scope: &mut v8::HandleScope<'a>,
+    value: v8::Local<'a, v8::Value>,
+  ) -> Result<Self, Self::Error> {
+    if value.is_null_or_undefined() {
+      Ok(None)
+    } else {
+      T::from_v8(scope, value).map(Some)
+    }
+  }
+}

--- a/core/to_from_v8.rs
+++ b/core/to_from_v8.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 pub trait ToV8<'a> {
-  type Error: std::error::Error;
+  type Error: std::error::Error + Send + Sync + 'static;
 
   fn to_v8(
     self,
@@ -10,47 +10,10 @@ pub trait ToV8<'a> {
 }
 
 pub trait FromV8<'a>: Sized {
-  type Error: std::error::Error;
+  type Error: std::error::Error + Send + Sync + 'static;
 
   fn from_v8(
     scope: &mut v8::HandleScope<'a>,
     value: v8::Local<'a, v8::Value>,
   ) -> Result<Self, Self::Error>;
-}
-
-// Impls for Option
-
-impl<'a, T> ToV8<'a> for Option<T>
-where
-  T: ToV8<'a>,
-{
-  type Error = T::Error;
-
-  fn to_v8(
-    self,
-    scope: &mut v8::HandleScope<'a>,
-  ) -> Result<v8::Local<'a, v8::Value>, Self::Error> {
-    match self {
-      Some(x) => x.to_v8(scope).map(Into::into),
-      None => Ok(v8::undefined(scope).into()),
-    }
-  }
-}
-
-impl<'a, T> FromV8<'a> for Option<T>
-where
-  T: FromV8<'a>,
-{
-  type Error = T::Error;
-
-  fn from_v8(
-    scope: &mut v8::HandleScope<'a>,
-    value: v8::Local<'a, v8::Value>,
-  ) -> Result<Self, Self::Error> {
-    if value.is_null_or_undefined() {
-      Ok(None)
-    } else {
-      T::from_v8(scope, value).map(Some)
-    }
-  }
 }

--- a/core/to_from_v8.rs
+++ b/core/to_from_v8.rs
@@ -1,3 +1,5 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
 pub trait ToV8<'a> {
   type Error: std::error::Error;
 

--- a/core/to_from_v8.rs
+++ b/core/to_from_v8.rs
@@ -4,7 +4,7 @@ pub trait ToV8<'a> {
   type Error: std::error::Error;
 
   fn to_v8(
-    &mut self,
+    self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, Self::Error>;
 }
@@ -27,7 +27,7 @@ where
   type Error = T::Error;
 
   fn to_v8(
-    &mut self,
+    self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, Self::Error> {
     match self {

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -810,6 +810,7 @@ fn map_arg_to_v8_fastcall_type(
     | Arg::OptionString(_)
     | Arg::OptionBuffer(..)
     | Arg::SerdeV8(_)
+    | Arg::FromV8(_)
     | Arg::Ref(..) => return Ok(None),
     // We don't support v8 global arguments
     Arg::V8Global(_) | Arg::OptionV8Global(_) => return Ok(None),
@@ -859,7 +860,7 @@ fn map_retval_to_v8_fastcall_type(
   arg: &Arg,
 ) -> Result<Option<V8FastCallType>, V8MappingError> {
   let rv = match arg {
-    Arg::OptionNumeric(..) | Arg::SerdeV8(_) => return Ok(None),
+    Arg::OptionNumeric(..) | Arg::SerdeV8(_) | Arg::ToV8(_) => return Ok(None),
     Arg::Void => V8FastCallType::Void,
     Arg::Numeric(NumericArg::bool, _) => V8FastCallType::Bool,
     Arg::Numeric(NumericArg::u32, _)

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -2114,4 +2114,23 @@ mod tests {
     ArgError("s", InvalidAttributeType("serde", "&str")),
     fn f(#[serde] s: &str) {}
   );
+
+  expect_fail!(
+    op_with_bad_from_v8_string,
+    ArgError("s", InvalidAttributeType("from_v8", "String")),
+    fn f(#[from_v8] s: String) {}
+  );
+
+  expect_fail!(
+    op_with_to_v8_arg,
+    ArgError("s", InvalidAttributePosition("to_v8", "return value")),
+    fn f(#[to_v8] s: Foo) {}
+  );
+
+  expect_fail!(
+    op_with_from_v8_ret,
+    RetError(InvalidType(InvalidAttributePosition("from_v8", "argument"))),
+    #[from_v8]
+    fn f() -> Foo {}
+  );
 }

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -1484,14 +1484,14 @@ fn parse_cppgc(position: Position, ty: &Type) -> Result<Arg, ArgError> {
 }
 
 fn better_alternative_exists(position: Position, of: &TypePath) -> bool {
-  // If this type will parse without #[serde]/#[to_v8]/#[from_v8] (or with #[string]), it is illegal to use this type
+  // If this type will parse without #[serde]/#[to_v8]/#[from_v8], it is illegal to use this type
   // with #[serde]/#[to_v8]/#[from_v8]
   if parse_type_path(position, Attributes::default(), TypePathContext::None, of)
     .is_ok()
   {
     return true;
   }
-  // If this type will parse without #[serde] (or with #[string]), it is illegal to use this type with #[serde]
+  // If this type will parse with #[string], it is illegal to use this type with #[serde]/#[to_v8]/#[from_v8]
   if parse_type_path(position, Attributes::string(), TypePathContext::None, of)
     .is_ok()
   {

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -281,6 +281,8 @@ pub enum Arg {
   CppGcResource(String),
   WasmMemory(RefType, WasmMemorySource),
   OptionWasmMemory(RefType, WasmMemorySource),
+  FromV8(String),
+  ToV8(String),
 }
 
 impl Arg {
@@ -459,6 +461,7 @@ impl Arg {
         // Fast return value path for empty strings
         Arg::String(_) => ArgSlowRetval::RetValFallible,
         Arg::SerdeV8(_) => ArgSlowRetval::V8LocalFalliable,
+        Arg::ToV8(_) => ArgSlowRetval::V8LocalFalliable,
         // No scope required for these
         Arg::V8Local(_) => ArgSlowRetval::V8LocalNoScope,
         Arg::V8Global(_) => ArgSlowRetval::V8Local,
@@ -493,6 +496,7 @@ impl Arg {
       Arg::Numeric(NumericArg::__SMI__, _) => ArgMarker::Smi,
       Arg::Numeric(_, NumericFlag::Number) => ArgMarker::Number,
       Arg::CppGcResource(_) => ArgMarker::Cppgc,
+      Arg::ToV8(_) => ArgMarker::ToV8,
       _ => ArgMarker::None,
     }
   }
@@ -531,6 +535,8 @@ pub enum ArgMarker {
   ArrayBuffer,
   /// This type should be wrapped as a cppgc V8 object.
   Cppgc,
+  /// This type should be converted with `ToV8``
+  ToV8,
 }
 
 #[derive(Debug)]
@@ -757,6 +763,10 @@ pub enum WasmMemorySource {
 pub enum AttributeModifier {
   /// #[serde], for serde_v8 types.
   Serde,
+  /// #[to_v8], for types that impl `ToV8`
+  ToV8,
+  /// #[from_v8] for types that impl `FromV8`
+  FromV8,
   /// #[smi], for non-integral ID types representing small integers (-2³¹ and 2³¹-1 on 64-bit platforms,
   /// see https://medium.com/fhinkel/v8-internals-how-small-is-a-small-integer-e0badc18b6da).
   Smi,
@@ -781,6 +791,8 @@ pub enum AttributeModifier {
 impl AttributeModifier {
   fn name(&self) -> &'static str {
     match self {
+      AttributeModifier::ToV8 => "to_v8",
+      AttributeModifier::FromV8 => "from_v8",
       AttributeModifier::Bigint => "bigint",
       AttributeModifier::Number => "number",
       AttributeModifier::Buffer(..) => "buffer",
@@ -851,8 +863,6 @@ pub enum ArgError {
   InvalidReference(String),
   #[error("The type {0} must be a reference")]
   MissingReference(String),
-  #[error("Invalid or deprecated #[serde] type '{0}': {1}")]
-  InvalidSerdeType(String, &'static str),
   #[error("Invalid #[{0}] for type: {1}")]
   InvalidAttributeType(&'static str, String),
   #[error("Cannot use #[serde] for type: {0}")]
@@ -877,6 +887,8 @@ pub enum ArgError {
   ExpectedCppGcReference(String),
   #[error("Invalid #[cppgc] type '{0}'")]
   InvalidCppGcType(String),
+  #[error("#[{0}] is only valid in {1} position")]
+  InvalidAttributePosition(&'static str, &'static str),
 }
 
 #[derive(Error, Debug)]
@@ -1258,6 +1270,8 @@ fn parse_attribute(
       (#[global]) => Some(AttributeModifier::Global),
       (#[memory(caller)]) => Some(AttributeModifier::WasmMemory(WasmMemorySource::Caller)),
       (#[cppgc]) => Some(AttributeModifier::CppGcResource),
+      (#[to_v8]) => Some(AttributeModifier::ToV8),
+      (#[from_v8]) => Some(AttributeModifier::FromV8),
       (#[allow ($_rule:path)]) => None,
       (#[doc = $_attr:literal]) => None,
       (#[cfg $_cfg:tt]) => None,
@@ -1469,6 +1483,35 @@ fn parse_cppgc(position: Position, ty: &Type) -> Result<Arg, ArgError> {
   }
 }
 
+fn better_alternative_exists(position: Position, of: &TypePath) -> bool {
+  // If this type will parse without #[serde]/#[to_v8]/#[from_v8] (or with #[string]), it is illegal to use this type
+  // with #[serde]/#[to_v8]/#[from_v8]
+  if parse_type_path(position, Attributes::default(), TypePathContext::None, of)
+    .is_ok()
+  {
+    return true;
+  }
+  // If this type will parse without #[serde] (or with #[string]), it is illegal to use this type with #[serde]
+  if parse_type_path(position, Attributes::string(), TypePathContext::None, of)
+    .is_ok()
+  {
+    return true;
+  }
+
+  // Denylist of serde_v8 types with better alternatives
+  let ty = of.into_token_stream();
+  if let Ok(res) = std::panic::catch_unwind(|| {
+    rules!(ty => {
+      ( Value $( < $_lifetime:lifetime $(,)? >)? ) => true,
+      ( $_ty:ty ) => false,
+    })
+  }) {
+    res
+  } else {
+    false
+  }
+}
+
 pub(crate) fn parse_type(
   position: Position,
   attrs: Attributes,
@@ -1480,56 +1523,48 @@ pub(crate) fn parse_type(
   if let Some(primary) = attrs.primary {
     match primary {
       AttributeModifier::CppGcResource => return parse_cppgc(position, ty),
-      AttributeModifier::Serde => match ty {
-        Type::Tuple(of) => {
-          return Ok(Arg::SerdeV8(stringify_token(of)));
-        }
-        Type::Path(of) => {
-          // If this type will parse without #[serde] (or with #[string]), it is illegal to use this type with #[serde]
-          if parse_type_path(
-            position,
-            Attributes::default(),
-            TypePathContext::None,
-            of,
-          )
-          .is_ok()
-          {
-            return Err(ArgError::InvalidSerdeAttributeType(stringify_token(
-              ty,
-            )));
-          }
-          // If this type will parse without #[serde] (or with #[string]), it is illegal to use this type with #[serde]
-          if parse_type_path(
-            position,
-            Attributes::string(),
-            TypePathContext::None,
-            of,
-          )
-          .is_ok()
-          {
-            return Err(ArgError::InvalidSerdeAttributeType(stringify_token(
-              ty,
-            )));
-          }
+      AttributeModifier::FromV8 if position == Position::RetVal => {
+        return Err(ArgError::InvalidAttributePosition(
+          primary.name(),
+          "argument",
+        ))
+      }
+      AttributeModifier::ToV8 if position == Position::Arg => {
+        return Err(ArgError::InvalidAttributePosition(
+          primary.name(),
+          "return value",
+        ))
+      }
+      AttributeModifier::Serde
+      | AttributeModifier::FromV8
+      | AttributeModifier::ToV8 => {
+        let make_arg = match primary {
+          AttributeModifier::Serde => Arg::SerdeV8,
+          AttributeModifier::FromV8 => Arg::FromV8,
+          AttributeModifier::ToV8 => Arg::ToV8,
+          _ => unreachable!(),
+        };
+        match ty {
+          Type::Tuple(of) => return Ok(make_arg(stringify_token(of))),
+          Type::Path(of) => {
+            if better_alternative_exists(position, of) {
+              return Err(ArgError::InvalidAttributeType(
+                primary.name(),
+                stringify_token(ty),
+              ));
+            }
 
-          // Denylist of serde_v8 types with better alternatives
-          let ty = of.into_token_stream();
-          let token = stringify_token(of.path.clone());
-          if let Ok(Some(err)) = std::panic::catch_unwind(|| {
-            rules!(ty => {
-              ( Value $( < $_lifetime:lifetime $(,)? >)? ) => Some("use a fully-qualified type: v8::Value or serde_json::Value"),
-              ( $_ty:ty ) => None,
-            })
-          }) {
-            return Err(ArgError::InvalidSerdeType(stringify_token(ty), err));
+            return Ok(make_arg(stringify_token(of.path.clone())));
           }
+          _ => {
+            return Err(ArgError::InvalidAttributeType(
+              primary.name(),
+              stringify_token(ty),
+            ));
+          }
+        }
+      }
 
-          return Ok(Arg::SerdeV8(token));
-        }
-        _ => {
-          return Err(ArgError::InvalidSerdeAttributeType(stringify_token(ty)))
-        }
-      },
       AttributeModifier::State => {
         return parse_type_state(ty);
       }

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -865,8 +865,6 @@ pub enum ArgError {
   MissingReference(String),
   #[error("Invalid #[{0}] for type: {1}")]
   InvalidAttributeType(&'static str, String),
-  #[error("Cannot use #[serde] for type: {0}")]
-  InvalidSerdeAttributeType(String),
   #[error("Cannot use #[number] for type: {0}")]
   InvalidNumberAttributeType(String),
   #[error("Invalid v8 type: {0}")]
@@ -2108,12 +2106,12 @@ mod tests {
 
   expect_fail!(
     op_with_bad_serde_string,
-    ArgError("s", InvalidSerdeAttributeType("String")),
+    ArgError("s", InvalidAttributeType("serde", "String")),
     fn f(#[serde] s: String) {}
   );
   expect_fail!(
     op_with_bad_serde_str,
-    ArgError("s", InvalidSerdeAttributeType("&str")),
+    ArgError("s", InvalidAttributeType("serde", "&str")),
     fn f(#[serde] s: &str) {}
   );
 }

--- a/ops/op2/test_cases/sync/from_v8.out
+++ b/ops/op2/test_cases/sync/from_v8.out
@@ -1,0 +1,100 @@
+#[allow(non_camel_case_types)]
+pub const fn op_from_v8_arg() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_from_v8_arg {
+        _unconstructable: ::std::marker::PhantomData<()>,
+    }
+    impl ::deno_core::_ops::Op for op_from_v8_arg {
+        const NAME: &'static str = stringify!(op_from_v8_arg);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_from_v8_arg),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
+    }
+    impl op_from_v8_arg {
+        pub const fn name() -> &'static str {
+            stringify!(op_from_v8_arg)
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let arg0 = match <Foo as deno_core::FromV8>::from_v8(&mut scope, arg0) {
+                    Ok(t) => t,
+                    Err(arg0_err) => {
+                        let msg = deno_core::v8::String::new(
+                                &mut scope,
+                                &format!("{}", deno_core::anyhow::Error::from(arg0_err)),
+                            )
+                            .unwrap();
+                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                        scope.throw_exception(exc);
+                        return 1;
+                    }
+                };
+                Self::call(arg0)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_slow(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+    }
+    impl op_from_v8_arg {
+        #[inline(always)]
+        pub fn call(foo: Foo) {
+            let _ = foo;
+        }
+    }
+    <op_from_v8_arg as ::deno_core::_ops::Op>::DECL
+}

--- a/ops/op2/test_cases/sync/from_v8.rs
+++ b/ops/op2/test_cases/sync/from_v8.rs
@@ -1,0 +1,23 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+#![deny(warnings)]
+deno_ops_compile_test_runner::prelude!();
+use deno_core::v8;
+use deno_core::FromV8;
+
+struct Foo;
+
+impl<'a> FromV8<'a> for Foo {
+  type Error = std::convert::Infallible;
+  fn from_v8(
+    _scope: &mut v8::HandleScope<'a>,
+    _value: v8::Local<'a, v8::Value>,
+  ) -> Result<Self, Self::Error> {
+    Ok(Foo)
+  }
+}
+
+#[op2]
+#[from_v8]
+pub fn op_from_v8_arg(#[from_v8] foo: Foo) {
+  let _ = foo;
+}

--- a/ops/op2/test_cases/sync/to_v8.out
+++ b/ops/op2/test_cases/sync/to_v8.out
@@ -1,0 +1,99 @@
+#[allow(non_camel_case_types)]
+pub const fn op_to_v8_return() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    pub struct op_to_v8_return {
+        _unconstructable: ::std::marker::PhantomData<()>,
+    }
+    impl ::deno_core::_ops::Op for op_to_v8_return {
+        const NAME: &'static str = stringify!(op_to_v8_return);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_to_v8_return),
+            false,
+            false,
+            0usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            None,
+            None,
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
+    }
+    impl op_to_v8_return {
+        pub const fn name() -> &'static str {
+            stringify!(op_to_v8_return)
+        }
+        #[inline(always)]
+        fn slow_function_impl(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
+                &*info
+            });
+            let result = { Self::call() };
+            match deno_core::_ops::RustToV8Fallible::to_v8_fallible(
+                deno_core::_ops::RustToV8Marker::<
+                    deno_core::_ops::ToV8Marker,
+                    _,
+                >::from(result),
+                &mut scope,
+            ) {
+                Ok(v) => rv.set(v),
+                Err(rv_err) => {
+                    let msg = deno_core::v8::String::new(
+                            &mut scope,
+                            &format!("{}", deno_core::anyhow::Error::from(rv_err)),
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                }
+            };
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
+                &*info
+            });
+            let opctx = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_slow(
+                &opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    &opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+    }
+    impl op_to_v8_return {
+        #[inline(always)]
+        pub fn call() -> Foo {
+            Foo
+        }
+    }
+    <op_to_v8_return as ::deno_core::_ops::Op>::DECL
+}

--- a/ops/op2/test_cases/sync/to_v8.rs
+++ b/ops/op2/test_cases/sync/to_v8.rs
@@ -1,0 +1,23 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+#![deny(warnings)]
+deno_ops_compile_test_runner::prelude!();
+use deno_core::v8;
+use deno_core::ToV8;
+
+struct Foo;
+
+impl<'a> ToV8<'a> for Foo {
+  type Error = std::convert::Infallible;
+  fn to_v8(
+    self,
+    scope: &mut v8::HandleScope<'a>,
+  ) -> Result<v8::Local<'a, v8::Value>, Self::Error> {
+    Ok(v8::null().into())
+  }
+}
+
+#[op2]
+#[to_v8]
+pub fn op_to_v8_return() -> Foo {
+  Foo
+}

--- a/ops/op2/test_cases/sync/to_v8.rs
+++ b/ops/op2/test_cases/sync/to_v8.rs
@@ -12,7 +12,7 @@ impl<'a> ToV8<'a> for Foo {
     self,
     scope: &mut v8::HandleScope<'a>,
   ) -> Result<v8::Local<'a, v8::Value>, Self::Error> {
-    Ok(v8::null().into())
+    Ok(v8::null(scope).into())
   }
 }
 

--- a/serde_v8/error.rs
+++ b/serde_v8/error.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
   #[error("{0}")]
@@ -58,6 +58,9 @@ pub enum Error {
 
   #[error("serde_v8 error: can't create slice from resizable ArrayBuffer")]
   ResizableBackingStoreNotSupported,
+
+  #[error("{0}")]
+  Custom(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
 impl serde::ser::Error for Error {

--- a/serde_v8/tests/de.rs
+++ b/serde_v8/tests/de.rs
@@ -115,13 +115,13 @@ defail!(
   de_tuple_wrong_len_short,
   (u64, bool, ()),
   "[123, true]",
-  |e| e == Err(Error::LengthMismatch(2, 3))
+  |e| matches!(e, Err(Error::LengthMismatch(2, 3)))
 );
 defail!(
   de_tuple_wrong_len_long,
   (u64, bool, ()),
   "[123, true, null, 'extra']",
-  |e| e == Err(Error::LengthMismatch(4, 3))
+  |e| matches!(e, Err(Error::LengthMismatch(4, 3)))
 );
 detest!(
   de_mathop,
@@ -417,8 +417,10 @@ detest!(
   serde_json::json!({})
 );
 
-defail!(defail_struct, MathOp, "123", |e| e
-  == Err(Error::ExpectedObject("Number")));
+defail!(defail_struct, MathOp, "123", |e| matches!(
+  e,
+  Err(Error::ExpectedObject("Number"))
+));
 
 #[derive(Eq, PartialEq, Debug, Deserialize)]
 pub struct SomeThing {
@@ -437,8 +439,10 @@ detest!(
 );
 
 detest!(de_bstr, ByteString, "'hello'", "hello".into());
-defail!(defail_bstr, ByteString, "'👋bye'", |e| e
-  == Err(Error::ExpectedLatin1));
+defail!(defail_bstr, ByteString, "'👋bye'", |e| matches!(
+  e,
+  Err(Error::ExpectedLatin1)
+));
 
 #[derive(Eq, PartialEq, Debug, Deserialize)]
 pub struct StructWithBytes {


### PR DESCRIPTION
Adds support for

```rust
// calls `Foo`'s `ToV8` impl
#[op2]
#[to_v8]
fn op_foo() -> Foo {
  todo!()
}

// calls `Bar`'s `FromV8` impl
#[op2]
fn op_bar(#[from_v8] bar: Bar) { }
```