### PR TITLE
feat: Add `ToV8`/`FromV8` impls for bool and numeric types

### DIFF
--- a/core/convert.rs
+++ b/core/convert.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use crate::{error::StdAnyError, runtime::ops};
+use crate::error::StdAnyError;
+use crate::runtime::ops;
 use std::convert::Infallible;
 
 /// A conversion from a rust value to a v8 value.

--- a/core/convert.rs
+++ b/core/convert.rs
@@ -25,7 +25,7 @@ use std::convert::Infallible;
 ///
 /// # Example
 ///
-/// ```
+/// ```ignore
 /// use deno_core::ToV8;
 /// use deno_core::convert::Smi;
 /// use deno_core::op2;
@@ -85,7 +85,7 @@ pub trait ToV8<'a> {
 ///
 /// # Example
 ///
-/// ```
+/// ```ignore
 /// use deno_core::FromV8;
 /// use deno_core::convert::Smi;
 /// use deno_core::op2;

--- a/core/convert.rs
+++ b/core/convert.rs
@@ -25,6 +25,10 @@ use std::convert::Infallible;
 /// # Example
 ///
 /// ```
+/// use deno_core::ToV8;
+/// use deno_core::convert::Smi;
+/// use deno_core::op2;
+///
 /// struct Foo(i32);
 ///
 /// impl<'a> ToV8<'a> for Foo {
@@ -81,6 +85,10 @@ pub trait ToV8<'a> {
 /// # Example
 ///
 /// ```
+/// use deno_core::FromV8;
+/// use deno_core::convert::Smi;
+/// use deno_core::op2;
+///
 /// struct Foo(i32);
 ///
 /// impl<'a> FromV8<'a> for Foo {

--- a/core/convert.rs
+++ b/core/convert.rs
@@ -89,7 +89,7 @@ pub trait ToV8<'a> {
 ///   type Error = deno_core::error::StdAnyError;
 ///
 ///   fn from_v8(scope: &mut v8::HandleScope<'a>, value: v8::Local<'a, v8::Value>) -> Result<Self, Self::Error> {
-///     /// We expect this value to be a `v8::Integer`, so we use the [`Smi`][deno_core::to_from_v8::Smi] wrapper type to convert it.
+///     /// We expect this value to be a `v8::Integer`, so we use the [`Smi`][deno_core::convert::Smi] wrapper type to convert it.
 ///     Smi::from_v8(scope, value).map(|Smi(v)| Foo(v))
 ///   }
 /// }

--- a/core/error.rs
+++ b/core/error.rs
@@ -96,6 +96,33 @@ pub fn get_custom_error_class(error: &Error) -> Option<&'static str> {
   error.downcast_ref::<CustomError>().map(|e| e.class)
 }
 
+/// A wrapper around `anyhow::Error` that implements `std::error::Error`
+#[repr(transparent)]
+pub struct StdAnyError(pub Error);
+impl std::fmt::Debug for StdAnyError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{:?}", self.0)
+  }
+}
+
+impl std::fmt::Display for StdAnyError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}", self.0)
+  }
+}
+
+impl std::error::Error for StdAnyError {
+  fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+    self.0.source()
+  }
+}
+
+impl From<Error> for StdAnyError {
+  fn from(err: Error) -> Self {
+    Self(err)
+  }
+}
+
 pub fn to_v8_error<'a>(
   scope: &mut v8::HandleScope<'a>,
   get_class: GetErrorClassFn,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -2,6 +2,7 @@
 pub mod arena;
 mod async_cancel;
 mod async_cell;
+pub mod convert;
 pub mod cppgc;
 pub mod error;
 mod error_codes;
@@ -26,7 +27,6 @@ mod path;
 mod runtime;
 mod source_map;
 mod tasks;
-pub mod to_from_v8;
 mod web_timeout;
 
 // Re-exports
@@ -62,6 +62,8 @@ pub use crate::async_cell::AsyncRefCell;
 pub use crate::async_cell::AsyncRefFuture;
 pub use crate::async_cell::RcLike;
 pub use crate::async_cell::RcRef;
+pub use crate::convert::FromV8;
+pub use crate::convert::ToV8;
 pub use crate::error::GetErrorClassFn;
 pub use crate::error::JsErrorCreateFn;
 pub use crate::extensions::Extension;
@@ -151,8 +153,6 @@ pub use crate::source_map::SourceMapData;
 pub use crate::source_map::SourceMapGetter;
 pub use crate::tasks::V8CrossThreadTaskSpawner;
 pub use crate::tasks::V8TaskSpawner;
-pub use crate::to_from_v8::FromV8;
-pub use crate::to_from_v8::ToV8;
 
 // Ensure we can use op2 in deno_core without any hackery.
 extern crate self as deno_core;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -26,7 +26,7 @@ mod path;
 mod runtime;
 mod source_map;
 mod tasks;
-mod to_from_v8;
+pub mod to_from_v8;
 mod web_timeout;
 
 // Re-exports

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -514,6 +514,8 @@ pub fn to_v8_slice_any(
 
 #[cfg(all(test, not(miri)))]
 mod tests {
+  use crate::convert::Number;
+  use crate::convert::Smi;
   use crate::error::generic_error;
   use crate::error::AnyError;
   use crate::error::JsError;
@@ -521,8 +523,6 @@ mod tests {
   use crate::external::ExternalPointer;
   use crate::op2;
   use crate::runtime::JsRuntimeState;
-  use crate::to_from_v8::Number;
-  use crate::to_from_v8::Smi;
   use crate::FromV8;
   use crate::JsRuntime;
   use crate::OpState;

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -521,9 +521,13 @@ mod tests {
   use crate::external::ExternalPointer;
   use crate::op2;
   use crate::runtime::JsRuntimeState;
+  use crate::to_from_v8::Number;
+  use crate::to_from_v8::Smi;
+  use crate::FromV8;
   use crate::JsRuntime;
   use crate::OpState;
   use crate::RuntimeOptions;
+  use crate::ToV8;
   use anyhow::bail;
   use anyhow::Error;
   use bytes::BytesMut;
@@ -631,6 +635,10 @@ mod tests {
       op_async_buffer_impl,
       op_async_external,
       op_async_serde_option_v8,
+
+      op_smi_to_from_v8,
+      op_number_to_from_v8,
+      op_bool_to_from_v8,
     ],
     state = |state| {
       state.put(1234u32);
@@ -2314,6 +2322,105 @@ mod tests {
       "assert((await op_async_serde_option_v8({s: 'abc'})).s == 'abc!')",
     )
     .await?;
+    Ok(())
+  }
+
+  #[op2]
+  #[to_v8]
+  pub fn op_smi_to_from_v8(#[from_v8] value: Smi<i32>) -> Smi<i32> {
+    value
+  }
+
+  #[tokio::test]
+  pub async fn test_op_smi_to_from_v8() -> Result<(), Box<dyn std::error::Error>>
+  {
+    run_test2(
+      JIT_ITERATIONS,
+      "op_smi_to_from_v8",
+      r"
+        for (const n of [-Math.pow(2, 31), -1, 0, 1, Math.pow(2, 31) - 1]) {
+          assert(op_smi_to_from_v8(n) == n);
+        }",
+    )?;
+    Ok(())
+  }
+
+  #[op2]
+  #[to_v8]
+  pub fn op_number_to_from_v8(#[from_v8] value: Number<f64>) -> Number<f64> {
+    value
+  }
+
+  #[tokio::test]
+  pub async fn test_op_number_to_from_v8(
+  ) -> Result<(), Box<dyn std::error::Error>> {
+    run_test2(
+      JIT_ITERATIONS,
+      "op_number_to_from_v8",
+      r"
+      for (
+        const n of [
+          Number.MIN_VALUE,
+          Number.MIN_SAFE_INTEGER,
+          -1,
+          0,
+          1,
+          Number.MAX_SAFE_INTEGER,
+          Number.MAX_VALUE,
+          Number.POSITIVE_INFINITY,
+          Number.NEGATIVE_INFINITY,
+        ]
+      ) {
+        assert(op_number_to_from_v8(n) === n);
+      }
+
+      assert(isNaN(op_number_to_from_v8(Number.NaN)));
+    ",
+    )?;
+    Ok(())
+  }
+
+  struct Bool(bool);
+
+  impl<'a> ToV8<'a> for Bool {
+    type Error = std::convert::Infallible;
+
+    fn to_v8(
+      self,
+      scope: &mut v8::HandleScope<'a>,
+    ) -> Result<v8::Local<'a, v8::Value>, Self::Error> {
+      self.0.to_v8(scope)
+    }
+  }
+
+  impl<'a> FromV8<'a> for Bool {
+    type Error = std::convert::Infallible;
+
+    fn from_v8(
+      scope: &mut v8::HandleScope<'a>,
+      value: v8::Local<'a, v8::Value>,
+    ) -> Result<Self, Self::Error> {
+      bool::from_v8(scope, value).map(Bool)
+    }
+  }
+
+  #[op2]
+  #[to_v8]
+  fn op_bool_to_from_v8(#[from_v8] value: Bool) -> Bool {
+    value
+  }
+
+  #[tokio::test]
+  pub async fn test_op_bool_to_from_v8(
+  ) -> Result<(), Box<dyn std::error::Error>> {
+    run_test2(
+      JIT_ITERATIONS,
+      "op_bool_to_from_v8",
+      r"
+        for (const v of [true, false]) {
+          assert(op_bool_to_from_v8(v) == v);
+        }",
+    )?;
     Ok(())
   }
 }

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -94,7 +94,7 @@ pub fn opstate_borrow_mut<T: 'static>(state: &mut OpState) -> &mut T {
   state.borrow_mut()
 }
 
-pub fn to_u32_option(number: &v8::Value) -> Option<i32> {
+pub fn to_u32_option(number: &v8::Value) -> Option<u32> {
   try_number_some!(number Integer is_uint32);
   try_number_some!(number Int32 is_int32);
   try_number_some!(number Number is_number);

--- a/core/to_from_v8.rs
+++ b/core/to_from_v8.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use crate::runtime::ops;
+use crate::{error::StdAnyError, runtime::ops};
 use std::convert::Infallible;
 
 pub trait ToV8<'a> {
@@ -28,6 +28,7 @@ pub trait FromV8<'a>: Sized {
 pub struct Smi<T: SmallInt>(pub T);
 
 pub trait SmallInt {
+  const NAME: &'static str;
   fn as_i32(self) -> i32;
   fn from_i32(value: i32) -> Self;
 }
@@ -36,6 +37,7 @@ macro_rules! impl_smallint {
     (for $($t:ty),*) => {
         $(
             impl SmallInt for $t {
+                const NAME: &'static str = stringify!($t);
                 #[inline(always)]
                 fn as_i32(self) -> i32 {
                   self as _
@@ -55,6 +57,7 @@ impl_smallint!(for u8, u16, u32, u64, usize, i8, i16, i32, i64, isize);
 impl<'a, T: SmallInt> ToV8<'a> for Smi<T> {
   type Error = Infallible;
 
+  #[inline]
   fn to_v8(
     self,
     scope: &mut v8::HandleScope<'a>,
@@ -64,13 +67,15 @@ impl<'a, T: SmallInt> ToV8<'a> for Smi<T> {
 }
 
 impl<'a, T: SmallInt> FromV8<'a> for Smi<T> {
-  type Error = Infallible;
+  type Error = StdAnyError;
 
+  #[inline]
   fn from_v8(
     _scope: &mut v8::HandleScope<'a>,
     value: v8::Local<'a, v8::Value>,
   ) -> Result<Self, Self::Error> {
-    let v = crate::runtime::ops::to_i32_option(&value).unwrap_or_default();
+    let v = crate::runtime::ops::to_i32_option(&value)
+      .ok_or_else(|| crate::error::type_error(format!("{}", T::NAME)))?;
     Ok(Smi(T::from_i32(v)))
   }
 }
@@ -78,7 +83,8 @@ impl<'a, T: SmallInt> FromV8<'a> for Smi<T> {
 pub struct Number<T: Numeric>(pub T);
 
 pub trait Numeric: Sized {
-  fn from_value(value: &v8::Value) -> Self;
+  const NAME: &'static str;
+  fn from_value(value: &v8::Value) -> Option<Self>;
   fn as_f64(self) -> f64;
 }
 
@@ -86,9 +92,10 @@ macro_rules! impl_numeric {
   ($($t:ty : $from: path ),*) => {
       $(
           impl Numeric for $t {
+              const NAME: &'static str = stringify!($t);
               #[inline(always)]
-              fn from_value(value: &v8::Value) -> Self {
-                $from(value).unwrap_or_default() as _
+              fn from_value(value: &v8::Value) -> Option<Self> {
+                $from(value).map(|v| v as _)
               }
 
               #[inline(always)]
@@ -123,13 +130,15 @@ impl<'a, T: Numeric> ToV8<'a> for Number<T> {
 }
 
 impl<'a, T: Numeric> FromV8<'a> for Number<T> {
-  type Error = Infallible;
+  type Error = StdAnyError;
   #[inline]
   fn from_v8(
     _scope: &mut v8::HandleScope<'a>,
     value: v8::Local<'a, v8::Value>,
   ) -> Result<Self, Self::Error> {
-    Ok(Number(T::from_value(&value)))
+    T::from_value(&value).map(Number).ok_or_else(|| {
+      crate::error::type_error(format!("Expected {}", T::NAME)).into()
+    })
   }
 }
 

--- a/core/to_from_v8.rs
+++ b/core/to_from_v8.rs
@@ -132,3 +132,25 @@ impl<'a, T: Numeric> FromV8<'a> for Number<T> {
     Ok(Number(T::from_value(&value)))
   }
 }
+
+impl<'a> ToV8<'a> for bool {
+  type Error = Infallible;
+  #[inline]
+  fn to_v8(
+    self,
+    scope: &mut v8::HandleScope<'a>,
+  ) -> Result<v8::Local<'a, v8::Value>, Self::Error> {
+    Ok(v8::Boolean::new(scope, self).into())
+  }
+}
+
+impl<'a> FromV8<'a> for bool {
+  type Error = Infallible;
+  #[inline]
+  fn from_v8(
+    _scope: &mut v8::HandleScope<'a>,
+    value: v8::Local<'a, v8::Value>,
+  ) -> Result<Self, Self::Error> {
+    Ok(value.is_true())
+  }
+}

--- a/core/to_from_v8.rs
+++ b/core/to_from_v8.rs
@@ -29,6 +29,8 @@ pub struct Smi<T: SmallInt>(pub T);
 
 pub trait SmallInt {
   const NAME: &'static str;
+
+  #[allow(clippy::wrong_self_convention)]
   fn as_i32(self) -> i32;
   fn from_i32(value: i32) -> Self;
 }
@@ -38,6 +40,7 @@ macro_rules! impl_smallint {
     $(
       impl SmallInt for $t {
         const NAME: &'static str = stringify!($t);
+        #[allow(clippy::wrong_self_convention)]
         #[inline(always)]
         fn as_i32(self) -> i32 {
           self as _
@@ -74,8 +77,9 @@ impl<'a, T: SmallInt> FromV8<'a> for Smi<T> {
     _scope: &mut v8::HandleScope<'a>,
     value: v8::Local<'a, v8::Value>,
   ) -> Result<Self, Self::Error> {
-    let v = crate::runtime::ops::to_i32_option(&value)
-      .ok_or_else(|| crate::error::type_error(format!("{}", T::NAME)))?;
+    let v = crate::runtime::ops::to_i32_option(&value).ok_or_else(|| {
+      crate::error::type_error(format!("Expected {}", T::NAME))
+    })?;
     Ok(Smi(T::from_i32(v)))
   }
 }
@@ -84,8 +88,9 @@ pub struct Number<T: Numeric>(pub T);
 
 pub trait Numeric: Sized {
   const NAME: &'static str;
-  fn from_value(value: &v8::Value) -> Option<Self>;
+  #[allow(clippy::wrong_self_convention)]
   fn as_f64(self) -> f64;
+  fn from_value(value: &v8::Value) -> Option<Self>;
 }
 
 macro_rules! impl_numeric {
@@ -98,6 +103,7 @@ macro_rules! impl_numeric {
           $from(value).map(|v| v as _)
         }
 
+        #[allow(clippy::wrong_self_convention)]
         #[inline(always)]
         fn as_f64(self) -> f64 {
             self as _

--- a/core/to_from_v8.rs
+++ b/core/to_from_v8.rs
@@ -34,22 +34,22 @@ pub trait SmallInt {
 }
 
 macro_rules! impl_smallint {
-    (for $($t:ty),*) => {
-        $(
-            impl SmallInt for $t {
-                const NAME: &'static str = stringify!($t);
-                #[inline(always)]
-                fn as_i32(self) -> i32 {
-                  self as _
-                }
+  (for $($t:ty),*) => {
+    $(
+      impl SmallInt for $t {
+        const NAME: &'static str = stringify!($t);
+        #[inline(always)]
+        fn as_i32(self) -> i32 {
+          self as _
+        }
 
-                #[inline(always)]
-                fn from_i32(value: i32) -> Self {
-                    value as _
-                }
-            }
-        )*
-    };
+        #[inline(always)]
+        fn from_i32(value: i32) -> Self {
+            value as _
+        }
+      }
+    )*
+  };
 }
 
 impl_smallint!(for u8, u16, u32, u64, usize, i8, i16, i32, i64, isize);
@@ -90,20 +90,20 @@ pub trait Numeric: Sized {
 
 macro_rules! impl_numeric {
   ($($t:ty : $from: path ),*) => {
-      $(
-          impl Numeric for $t {
-              const NAME: &'static str = stringify!($t);
-              #[inline(always)]
-              fn from_value(value: &v8::Value) -> Option<Self> {
-                $from(value).map(|v| v as _)
-              }
+    $(
+      impl Numeric for $t {
+        const NAME: &'static str = stringify!($t);
+        #[inline(always)]
+        fn from_value(value: &v8::Value) -> Option<Self> {
+          $from(value).map(|v| v as _)
+        }
 
-              #[inline(always)]
-              fn as_f64(self) -> f64 {
-                  self as _
-              }
-          }
-      )*
+        #[inline(always)]
+        fn as_f64(self) -> f64 {
+            self as _
+        }
+      }
+    )*
   };
 }
 

--- a/core/to_from_v8.rs
+++ b/core/to_from_v8.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+use std::convert::Infallible;
+
 pub trait ToV8<'a> {
   type Error: std::error::Error + Send + Sync + 'static;
 
@@ -17,3 +19,58 @@ pub trait FromV8<'a>: Sized {
     value: v8::Local<'a, v8::Value>,
   ) -> Result<Self, Self::Error>;
 }
+
+// impls
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct Smi<T: SmallInt>(pub T);
+
+pub trait SmallInt {
+  fn as_i32(self) -> i32;
+  fn from_i32(value: i32) -> Self;
+}
+
+macro_rules! impl_smallint {
+    (for $($t:ty),*) => {
+        $(
+            impl SmallInt for $t {
+                #[inline(always)]
+                fn as_i32(self) -> i32 {
+                  self as _
+                }
+
+                #[inline(always)]
+                fn from_i32(value: i32) -> Self {
+                    value as _
+                }
+            }
+        )*
+    };
+}
+
+impl_smallint!(for u8, u16, u32, u64, usize, i8, i16, i32, i64, isize);
+
+impl<'a, T: SmallInt> ToV8<'a> for Smi<T> {
+  type Error = Infallible;
+
+  fn to_v8(
+    self,
+    scope: &mut v8::HandleScope<'a>,
+  ) -> Result<v8::Local<'a, v8::Value>, Self::Error> {
+    Ok(v8::Integer::new(scope, self.0.as_i32()).into())
+  }
+}
+
+impl<'a, T: SmallInt> FromV8<'a> for Smi<T> {
+  type Error = Infallible;
+
+  fn from_v8(
+    _scope: &mut v8::HandleScope<'a>,
+    value: v8::Local<'a, v8::Value>,
+  ) -> Result<Self, Self::Error> {
+    let v = crate::runtime::ops::to_i32_option(&value).unwrap_or_default();
+    Ok(Smi(T::from_i32(v)))
+  }
+}
+


### PR DESCRIPTION
Adds two wrapper structs which implement two different modes of serializing/deserializing numeric types:

```rust
pub struct Smi<T: SmallInt>(pub T);

// serializes like #[smi] (but without fast call support)
#[op2]
#[to_v8]
fn op_returns_smi() -> Smi<u32> {
  Smi(1)
}

pub struct Number<T: Numeric>(pub T);

// serializes like #[number]
#[op2]
#[to_v8]
fn op_returns_number() -> Number<u64> {
  Number(2)
}
```

Also adds an impl for `bool` itself, which is fairly uncontroversial I think.

TODO:
- [x] add tests