### PR TITLE
chore: enable clippy::unused_async, print_stdout, and print_stderr

### DIFF
--- a/core/feature_checker.rs
+++ b/core/feature_checker.rs
@@ -7,7 +7,12 @@ pub type ExitCb = Box<dyn Fn(&str, &str) + Send + Sync>;
 pub type WarnCb = Box<dyn Fn(&str, &str) + Send + Sync>;
 
 fn exit(feature: &str, api_name: &str) {
-  eprintln!("Feature '{feature}' for '{api_name}' was not specified, exiting.");
+  #[allow(clippy::print_stderr)]
+  {
+    eprintln!(
+      "Feature '{feature}' for '{api_name}' was not specified, exiting."
+    );
+  }
   std::process::exit(70);
 }
 

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1,4 +1,9 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+#![deny(clippy::print_stderr)]
+#![deny(clippy::print_stdout)]
+#![deny(clippy::unused_async)]
+
 pub mod arena;
 mod async_cancel;
 mod async_cell;
@@ -243,7 +248,10 @@ mod tests {
       .stdout(Stdio::null())
       .status()
     {
-      eprintln!("Ignoring test because we couldn't find deno: {e:?}");
+      #[allow(clippy::print_stderr)]
+      {
+        eprintln!("Ignoring test because we couldn't find deno: {e:?}");
+      }
     }
     let status = Command::new("deno")
       .args(["run", "-A", "rebuild_async_stubs.js", "--check"])

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -1,4 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+#![allow(clippy::print_stderr)]
+
 use crate::ascii_str;
 use crate::error::exception_to_err_result;
 use crate::error::generic_error;

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -131,7 +131,10 @@ builtin_ops! {
 
 #[op2(fast)]
 pub fn op_panic(#[string] message: String) {
-  eprintln!("JS PANIC: {}", message);
+  #[allow(clippy::print_stderr)]
+  {
+    eprintln!("JS PANIC: {}", message);
+  }
   panic!("JS PANIC: {}", message);
 }
 
@@ -152,6 +155,7 @@ fn op_add(a: i32, b: i32) -> i32 {
   a + b
 }
 
+#[allow(clippy::unused_async)]
 #[op2(async)]
 pub async fn op_add_async(a: i32, b: i32) -> i32 {
   a + b
@@ -160,19 +164,23 @@ pub async fn op_add_async(a: i32, b: i32) -> i32 {
 #[op2(fast)]
 pub fn op_void_sync() {}
 
+#[allow(clippy::unused_async)]
 #[op2(async)]
 pub async fn op_void_async() {}
 
+#[allow(clippy::unused_async)]
 #[op2(async)]
 pub async fn op_error_async() -> Result<(), Error> {
   Err(Error::msg("error"))
 }
 
+#[allow(clippy::unused_async)]
 #[op2(async(deferred), fast)]
 pub async fn op_error_async_deferred() -> Result<(), Error> {
   Err(Error::msg("error"))
 }
 
+#[allow(clippy::unused_async)]
 #[op2(async(deferred), fast)]
 pub async fn op_void_async_deferred() {}
 

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -211,7 +211,10 @@ impl Drop for InnerIsolateState {
       ManuallyDrop::drop(&mut self.state.0);
       if self.will_snapshot {
         // Create the snapshot and just drop it.
-        eprintln!("WARNING: v8::OwnedIsolate for snapshot was leaked");
+        #[allow(clippy::print_stderr)]
+        {
+          eprintln!("WARNING: v8::OwnedIsolate for snapshot was leaked");
+        }
       } else {
         ManuallyDrop::drop(&mut self.cpp_heap);
         ManuallyDrop::drop(&mut self.v8_isolate);

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -512,6 +512,7 @@ pub fn to_v8_slice_any(
   Err("expected ArrayBuffer or ArrayBufferView")
 }
 
+#[allow(clippy::print_stdout, clippy::print_stderr, clippy::unused_async)]
 #[cfg(all(test, not(miri)))]
 mod tests {
   use crate::error::generic_error;

--- a/core/runtime/snapshot.rs
+++ b/core/runtime/snapshot.rs
@@ -130,7 +130,10 @@ pub fn create_snapshot(
   warmup_script: Option<&'static str>,
 ) -> Result<CreateSnapshotOutput, Error> {
   let mut mark = Instant::now();
-  println!("Creating a snapshot...",);
+  #[allow(clippy::print_stdout)]
+  {
+    println!("Creating a snapshot...",);
+  }
 
   // Get the extensions for a second pass if we want to warm up the snapshot.
   let warmup_exts = warmup_script.map(|_| {
@@ -149,7 +152,10 @@ pub fn create_snapshot(
     ..Default::default()
   });
 
-  println!("JsRuntimeForSnapshot prepared, took {:#?}", mark.elapsed(),);
+  #[allow(clippy::print_stdout)]
+  {
+    println!("JsRuntimeForSnapshot prepared, took {:#?}", mark.elapsed(),);
+  }
   mark = Instant::now();
 
   let files_loaded_during_snapshot = js_runtime
@@ -188,17 +194,23 @@ pub fn create_snapshot(
     snapshot = js_runtime.snapshot();
   }
 
-  println!(
-    "Snapshot size: {}, took {:#?}",
-    snapshot.len(),
-    mark.elapsed(),
-  );
+  #[allow(clippy::print_stdout)]
+  {
+    println!(
+      "Snapshot size: {}, took {:#?}",
+      snapshot.len(),
+      mark.elapsed(),
+    );
+  }
   mark = Instant::now();
 
-  println!(
-    "Snapshot written, took: {:#?}",
-    Instant::now().saturating_duration_since(mark),
-  );
+  #[allow(clippy::print_stdout)]
+  {
+    println!(
+      "Snapshot written, took: {:#?}",
+      Instant::now().saturating_duration_since(mark),
+    );
+  }
 
   Ok(CreateSnapshotOutput {
     files_loaded_during_snapshot,

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -1,4 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+#![allow(clippy::print_stdout, clippy::print_stderr, clippy::unused_async)]
+
 use crate::error::AnyError;
 use crate::extensions::OpDecl;
 use crate::modules::StaticModuleLoader;

--- a/core/web_timeout.rs
+++ b/core/web_timeout.rs
@@ -604,12 +604,15 @@ mod tests {
       })
       .await;
       v.append(&mut batch);
-      eprintln!(
-        "{} ({} {})",
-        v.len(),
-        timers.len(),
-        timers.data_map.borrow().len(),
-      );
+      #[allow(clippy::print_stderr)]
+      {
+        eprintln!(
+          "{} ({} {})",
+          v.len(),
+          timers.len(),
+          timers.data_map.borrow().len(),
+        );
+      }
       timers.assert_consistent();
     }
     assert_eq!(v.len(), len);
@@ -833,7 +836,10 @@ mod tests {
         timers.assert_consistent();
       }
 
-      eprintln!("count={count} ref_count={ref_count}");
+      #[allow(clippy::print_stderr)]
+      {
+        eprintln!("count={count} ref_count={ref_count}");
+      }
 
       let v = poll_all(&timers).await;
       assert_eq!(v.len(), count);


### PR DESCRIPTION
Didn't catch anything, but these lint rules are useful imo.