### PR TITLE
fix UB in bytestring::from_v8

### DIFF
--- a/serde_v8/magic/bytestring.rs
+++ b/serde_v8/magic/bytestring.rs
@@ -73,20 +73,16 @@ impl FromV8 for ByteString {
       return Err(Error::ExpectedLatin1);
     }
     let len = v8str.length();
-    let mut buffer = SmallVec::with_capacity(len);
-    #[allow(clippy::uninit_vec)]
-    // SAFETY: we set length == capacity (see previous line),
-    // before immediately writing into that buffer and sanity check with an assert
-    unsafe {
-      buffer.set_len(len);
-      let written = v8str.write_one_byte(
-        scope,
-        &mut buffer,
-        0,
-        v8::WriteOptions::NO_NULL_TERMINATION,
-      );
-      assert!(written == len);
-    }
+
+    let mut buffer = SmallVec::new();
+    buffer.resize_with(len, Default::default);
+    v8str.write_one_byte(
+      scope,
+      &mut buffer,
+      0,
+      v8::WriteOptions::NO_NULL_TERMINATION,
+    );
+
     Ok(Self(buffer))
   }
 }


### PR DESCRIPTION
reliably on rust 1.78 (and i think maybe occasionally previously) `ByteString::from_v8`'s strategy of `set_len`ing a smallvec seems to be UB and results in bad memory accesses in `op_fetch` (and probably `op_node_http_request` as well).

i don't have a minimal repro but i do have a project with deno embedded which reliably fails on different architectures, just from calling fetch() - the `method` param ends up holding garbage.

not sure if the approach i took is the fastest safe strategy - please let me know if there's a better way. but actually this type is rarely used in v8->deno direction anyway so maybe it doesn't matter much.