### PR TITLE
manually drop magic

### DIFF
--- a/serde_v8/magic/transl8.rs
+++ b/serde_v8/magic/transl8.rs
@@ -87,8 +87,8 @@ where
   V: serde::de::Visitor<'de>,
   E: serde::de::Error,
 {
-  let y = visitor.visit_u64::<E>(opaque_send(&x));
-  std::mem::forget(x);
+  let x = ManuallyDrop::new(x);
+  let y = visitor.visit_u64::<E>(opaque_send(&*x));
   y
 }
 
@@ -140,4 +140,6 @@ macro_rules! impl_magic {
     }
   };
 }
+use std::mem::ManuallyDrop;
+
 pub(crate) use impl_magic;


### PR DESCRIPTION
i currently get crashes from `op_fetch` using `ByteString` for params, as the method and headers become invalid. using `ManuallyDrop` instead of `mem::forget` on the `ByteString` in `from_v8` seems to fix it.

i don't know why exactly, and it's possible this isn't actually a fix, just changing stuff enough to stop it breaking, but the forget man page [error example](https://doc.rust-lang.org/std/mem/fn.forget.html#relationship-with-manuallydrop) is very similar to the usage here.

(i note that SmallVec itself has the [exact same pattern](https://github.com/servo/rust-smallvec/blob/0089d0a15bee4792a575b9c51e9d7ace39b3957c/src/lib.rs#L842) ...)