### PR TITLE
fix: panic, unwrap to unwrap_or

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -444,7 +444,7 @@ impl JsError {
 
       // Convert them into Vec<JsStackFrame>
       let mut frames: Vec<JsStackFrame> = match frames_v8 {
-        Some(frames_v8) => serde_v8::from_v8(scope, frames_v8.into()).unwrap(),
+        Some(frames_v8) => serde_v8::from_v8(scope, frames_v8.into()).unwrap_or(Vec::new()),
         None => vec![],
       };
       let mut source_line = None;


### PR DESCRIPTION
I created a PR in `deno_core` to correct the issue.

> https://github.com/denoland/deno/issues/23805

Sometimes `panic` occurs with `unwrap()`.
So I set the default value.

Do I need to write test code?
I'm reading the code right now,  it's going to take some time.