### PR TITLE
perf: Batch calls to `ModuleLoader::prepare_load` for dynamic imports

### DIFF
--- a/core/modules/loaders.rs
+++ b/core/modules/loaders.rs
@@ -76,7 +76,7 @@ pub trait ModuleLoader {
   /// It's not required to implement this method.
   fn prepare_load(
     &self,
-    _module_specifier: &ModuleSpecifier,
+    _module_specifiers: &[ModuleSpecifier],
     _maybe_referrer: Option<String>,
     _is_dyn_import: bool,
   ) -> Pin<Box<dyn Future<Output = Result<(), Error>>>> {
@@ -220,7 +220,7 @@ impl ModuleLoader for ExtModuleLoader {
 
   fn prepare_load(
     &self,
-    _specifier: &ModuleSpecifier,
+    _specifiers: &[ModuleSpecifier],
     _maybe_referrer: Option<String>,
     _is_dyn_import: bool,
   ) -> Pin<Box<dyn Future<Output = Result<(), Error>>>> {
@@ -275,7 +275,7 @@ impl ModuleLoader for LazyEsmModuleLoader {
 
   fn prepare_load(
     &self,
-    _specifier: &ModuleSpecifier,
+    _specifiers: &[ModuleSpecifier],
     _maybe_referrer: Option<String>,
     _is_dyn_import: bool,
   ) -> Pin<Box<dyn Future<Output = Result<(), Error>>>> {
@@ -464,14 +464,14 @@ impl<L: ModuleLoader> ModuleLoader for TestingModuleLoader<L> {
 
   fn prepare_load(
     &self,
-    module_specifier: &ModuleSpecifier,
+    module_specifiers: &[ModuleSpecifier],
     maybe_referrer: Option<String>,
     is_dyn_import: bool,
   ) -> Pin<Box<dyn Future<Output = Result<(), Error>>>> {
     self.prepare_count.set(self.prepare_count.get() + 1);
     self
       .loader
-      .prepare_load(module_specifier, maybe_referrer, is_dyn_import)
+      .prepare_load(module_specifiers, maybe_referrer, is_dyn_import)
   }
 
   fn load(

--- a/core/modules/recursive_load.rs
+++ b/core/modules/recursive_load.rs
@@ -172,7 +172,11 @@ impl RecursiveModuleLoad {
 
     self
       .loader
-      .prepare_load(&module_specifier, maybe_referrer, self.is_dynamic_import())
+      .prepare_load(
+        &[module_specifier],
+        maybe_referrer,
+        self.is_dynamic_import(),
+      )
       .await
   }
 

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -988,7 +988,7 @@ async fn dyn_import_err() {
     // We should get an error here.
     let result = runtime.poll_event_loop(cx, Default::default());
     assert!(matches!(result, Poll::Ready(Err(_))));
-    assert_eq!(loader.counts(), ModuleLoadEventCounts::new(4, 1, 1));
+    assert_eq!(loader.counts(), ModuleLoadEventCounts::new(3, 1, 1));
     Poll::Ready(())
   })
   .await;
@@ -1029,12 +1029,12 @@ async fn dyn_import_ok() {
       runtime.poll_event_loop(cx, Default::default()),
       Poll::Ready(Ok(_))
     ));
-    assert_eq!(loader.counts(), ModuleLoadEventCounts::new(7, 1, 1));
+    assert_eq!(loader.counts(), ModuleLoadEventCounts::new(6, 1, 1));
     assert!(matches!(
       runtime.poll_event_loop(cx, Default::default()),
       Poll::Ready(Ok(_))
     ));
-    assert_eq!(loader.counts(), ModuleLoadEventCounts::new(7, 1, 1));
+    assert_eq!(loader.counts(), ModuleLoadEventCounts::new(6, 1, 1));
     Poll::Ready(())
   })
   .await;
@@ -1072,10 +1072,10 @@ async fn dyn_import_borrow_mut_error() {
     // Old comments that are likely wrong:
     // First poll runs `prepare_load` hook.
     let _ = runtime.poll_event_loop(cx, Default::default());
-    assert_eq!(loader.counts(), ModuleLoadEventCounts::new(4, 1, 1));
+    assert_eq!(loader.counts(), ModuleLoadEventCounts::new(3, 1, 1));
     // Second poll triggers error
     let _ = runtime.poll_event_loop(cx, Default::default());
-    assert_eq!(loader.counts(), ModuleLoadEventCounts::new(4, 1, 1));
+    assert_eq!(loader.counts(), ModuleLoadEventCounts::new(3, 1, 1));
     Poll::Ready(())
   })
   .await;


### PR DESCRIPTION
Collects dynamic imports between event loop ticks and then calls `prepare_load` with the collected imports. This reduces the number of calls to `prepare_load`.
Performance impact on deno is noticeable but relatively modest, around 6-7%:

```
❯ hyperfine --warmup 10 "deno run -A repro.ts" "devdeno run -A repro.ts"
Benchmark 1: deno run -A repro.ts
  Time (mean ± σ):     211.8 ms ±   2.0 ms    [User: 212.7 ms, System: 85.8 ms]
  Range (min … max):   209.3 ms … 217.4 ms    14 runs

Benchmark 2: devdeno run -A repro.ts
  Time (mean ± σ):     197.3 ms ±   1.2 ms    [User: 189.9 ms, System: 84.5 ms]
  Range (min … max):   195.9 ms … 200.7 ms    14 runs

Summary
  devdeno run -A repro.ts ran
    1.07 ± 0.01 times faster than deno run -A repro.ts

❯ hyperfine --warmup 10 "deno run -A repro2.ts" "devdeno run -A repro2.ts"
Benchmark 1: deno run -A repro2.ts
  Time (mean ± σ):     146.3 ms ±   1.0 ms    [User: 180.9 ms, System: 51.6 ms]
  Range (min … max):   144.5 ms … 148.0 ms    20 runs

Benchmark 2: devdeno run -A repro2.ts
  Time (mean ± σ):     137.8 ms ±   0.8 ms    [User: 160.7 ms, System: 51.7 ms]
  Range (min … max):   136.5 ms … 139.9 ms    21 runs

Summary
  devdeno run -A repro2.ts ran
    1.06 ± 0.01 times faster than deno run -A repro2.ts
```

My main concern here is the loss of granularity in errors that occur during `prepare_load`. Since we now are calling `prepare_load` with multiple specifiers, if the loader returns an error we can't really tell which specifier the error applies to. That causes a behavior change.