### PR TITLE
feat: `ModuleSourceCode` - `as_bytes()`

### DIFF
--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -47,6 +47,15 @@ pub enum ModuleSourceCode {
   Bytes(ModuleCodeBytes),
 }
 
+impl ModuleSourceCode {
+  pub fn as_bytes(&self) -> &[u8] {
+    match self {
+      Self::String(s) => s.as_bytes(),
+      Self::Bytes(b) => b.as_bytes(),
+    }
+  }
+}
+
 pub type ModuleCodeString = FastString;
 pub type ModuleName = FastString;
 


### PR DESCRIPTION
Helper for getting the bytes from one of these.