### PR TITLE
Add non-panic constructor for runtimes

### DIFF
--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1903,7 +1903,7 @@ impl JsRuntimeForSnapshot {
 
   /// Try to create a new runtime, returning an error if the process fails.
   pub fn try_new(
-    options: RuntimeOptions,
+    mut options: RuntimeOptions,
   ) -> Result<JsRuntimeForSnapshot, Error> {
     setup::init_v8(
       options.v8_platform.take(),

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1903,7 +1903,7 @@ impl JsRuntimeForSnapshot {
 
   /// Try to create a new runtime, returning an error if the process fails.
   pub fn try_new(
-    options: RuntimeOptions
+    options: RuntimeOptions,
   ) -> Result<JsRuntimeForSnapshot, Error> {
     setup::init_v8(
       options.v8_platform.clone(),

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1906,7 +1906,7 @@ impl JsRuntimeForSnapshot {
     options: RuntimeOptions,
   ) -> Result<JsRuntimeForSnapshot, Error> {
     setup::init_v8(
-      options.v8_platform.clone(),
+      options.v8_platform.take(),
       true,
       options.unsafe_expose_natives_and_gc(),
     );

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1902,7 +1902,9 @@ impl JsRuntimeForSnapshot {
   }
 
   /// Try to create a new runtime, returning an error if the process fails.
-  pub fn try_new(options: RuntimeOptions) -> Result<JsRuntimeForSnapshot, Error> {
+  pub fn try_new(
+    options: RuntimeOptions
+  ) -> Result<JsRuntimeForSnapshot, Error> {
     setup::init_v8(
       options.v8_platform.clone(),
       true,


### PR DESCRIPTION
Added a new constructor variant that does not panic
Existing constructor can then simply take in the returned error and panic