### PR TITLE
fix: Wake event loop when dynamic import promise resolves

### DIFF
--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -1170,7 +1170,7 @@ impl ModuleMap {
   }
 
   fn dynamic_import_module_evaluate(
-    self: &Rc<Self>,
+    &self,
     scope: &mut v8::HandleScope,
     load_id: ModuleLoadId,
     id: ModuleId,
@@ -1363,7 +1363,7 @@ impl ModuleMap {
   /// Poll for progress in the module loading logic. Note that this takes a waker but
   /// doesn't act like a normal polling method.
   pub(crate) fn poll_progress(
-    self: &Rc<Self>,
+    &self,
     cx: &mut Context,
     scope: &mut v8::HandleScope,
   ) -> Result<(), Error> {
@@ -1458,7 +1458,7 @@ impl ModuleMap {
   }
 
   fn poll_dyn_imports(
-    self: &Rc<Self>,
+    &self,
     cx: &mut Context,
     scope: &mut v8::HandleScope,
   ) -> Poll<Result<(), Error>> {

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -54,9 +54,6 @@ pub(crate) fn create_external_references(
     function: catch_dynamic_import_promise_error.map_fn_to(),
   });
   references.push(v8::ExternalReference {
-    function: empty_fn.map_fn_to(),
-  });
-  references.push(v8::ExternalReference {
     function: op_disabled_fn.map_fn_to(),
   });
   let syn_module_eval_fn: v8::SyntheticModuleEvaluationSteps =
@@ -589,14 +586,6 @@ fn import_meta_resolve(
   };
 }
 
-fn empty_fn(
-  _scope: &mut v8::HandleScope,
-  _args: v8::FunctionCallbackArguments,
-  _rv: v8::ReturnValue,
-) {
-  //Do Nothing
-}
-
 pub(crate) fn op_disabled_fn(
   scope: &mut v8::HandleScope,
   _args: v8::FunctionCallbackArguments,
@@ -605,14 +594,6 @@ pub(crate) fn op_disabled_fn(
   let message = v8::String::new(scope, "op is disabled").unwrap();
   let exception = v8::Exception::error(scope, message);
   scope.throw_exception(exception);
-}
-
-//It creates a reference to an empty function which can be mantained after the snapshots
-pub fn create_empty_fn<'s>(
-  scope: &mut v8::HandleScope<'s>,
-) -> Option<v8::Local<'s, v8::Function>> {
-  let empty_fn = v8::FunctionTemplate::new(scope, empty_fn);
-  empty_fn.get_function(scope)
 }
 
 fn catch_dynamic_import_promise_error(

--- a/testing/checkin/runner/extensions.rs
+++ b/testing/checkin/runner/extensions.rs
@@ -32,6 +32,7 @@ deno_core::extension!(
     ops_async::op_async_spin_on_state,
     ops_async::op_async_make_cppgc_resource,
     ops_async::op_async_get_cppgc_resource,
+    ops_async::op_async_never_resolves,
     ops_error::op_async_throw_error_eager,
     ops_error::op_async_throw_error_lazy,
     ops_error::op_async_throw_error_deferred,

--- a/testing/checkin/runner/ops_async.rs
+++ b/testing/checkin/runner/ops_async.rs
@@ -78,3 +78,8 @@ pub async fn op_async_get_cppgc_resource(
 ) -> u32 {
   resource.value
 }
+
+#[op2(async)]
+pub fn op_async_never_resolves() -> impl Future<Output = ()> {
+  futures::future::pending::<()>()
+}

--- a/testing/checkin/runtime/async.ts
+++ b/testing/checkin/runtime/async.ts
@@ -8,6 +8,7 @@ const {
   op_stats_diff,
   op_stats_dump,
   op_stats_delete,
+  op_async_never_resolves,
 } = Deno
   .core
   .ops;
@@ -27,6 +28,12 @@ export async function asyncYield() {
 // This function never returns.
 export async function asyncSpin() {
   await op_async_spin_on_state();
+}
+
+export function asyncNeverResolves() {
+  const prom = op_async_never_resolves();
+  Deno.core.refOpPromise(prom);
+  return prom;
 }
 
 let nextStats = 0;

--- a/testing/integration/dyn_import_no_hang/dyn_import_no_hang.js
+++ b/testing/integration/dyn_import_no_hang/dyn_import_no_hang.js
@@ -1,0 +1,15 @@
+import { asyncNeverResolves } from "checkin:async";
+
+// make a promise that never resolves to keep the event loop
+// alive without scheduling it to be woken up
+// for polling
+const prom = asyncNeverResolves();
+
+// import a module, with the key being that
+// this module promise doesn't resolve until a later
+// tick of the event loop
+await import("./dynamic.js");
+console.log("module imported");
+
+// unref to let the event loop exit
+Deno.core.unrefOpPromise(prom);

--- a/testing/integration/dyn_import_no_hang/dyn_import_no_hang.js
+++ b/testing/integration/dyn_import_no_hang/dyn_import_no_hang.js
@@ -1,8 +1,7 @@
 import { asyncNeverResolves } from "checkin:async";
 
-// make a promise that never resolves to keep the event loop
-// alive without scheduling it to be woken up
-// for polling
+// make a promise that never resolves so we have
+// a pending op outstanding
 const prom = asyncNeverResolves();
 
 // import a module, with the key being that

--- a/testing/integration/dyn_import_no_hang/dyn_import_no_hang.js
+++ b/testing/integration/dyn_import_no_hang/dyn_import_no_hang.js
@@ -1,3 +1,4 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { asyncNeverResolves } from "checkin:async";
 
 // make a promise that never resolves so we have

--- a/testing/integration/dyn_import_no_hang/dyn_import_no_hang.out
+++ b/testing/integration/dyn_import_no_hang/dyn_import_no_hang.out
@@ -1,0 +1,2 @@
+module executed
+module imported

--- a/testing/integration/dyn_import_no_hang/dynamic.js
+++ b/testing/integration/dyn_import_no_hang/dynamic.js
@@ -1,3 +1,4 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 await new Promise((resolve) => {
   // Resolve the promise after one tick of the event loop.
   setTimeout(() => {

--- a/testing/integration/dyn_import_no_hang/dynamic.js
+++ b/testing/integration/dyn_import_no_hang/dynamic.js
@@ -1,0 +1,7 @@
+await new Promise((resolve) => {
+  // Resolve the promise after one tick of the event loop.
+  setTimeout(() => {
+    resolve();
+  }, 0);
+});
+console.log("module executed");

--- a/testing/lib.rs
+++ b/testing/lib.rs
@@ -55,6 +55,7 @@ integration_test!(
   builtin_console_test,
   dyn_import_circular,
   dyn_import_op,
+  dyn_import_no_hang,
   error_async_stack,
   error_rejection_catch,
   error_rejection_order,


### PR DESCRIPTION
Fixes a hang that could occur when a module contained a dynamic import that doesn't resolve immediately, and there was a pending op outstanding.

The original reproduction (ref  https://github.com/denoland/deno/issues/24098) effectively boiled down to this:

```ts
// main.ts
Deno.serve(async function (_req: Request): Promise<Response> {
    await import("./repro.ts");
    console.log("imported module");
    return new Response("done");
});

// repro.ts
await new Promise<void>((resolve) => setTimeout(resolve, 0));
console.log("module executed");
```

Upon getting a request, it would hang when trying to import `"repro.ts"`. What was happening here was that `Deno.serve` created an op (`op_http_serve`) that stayed pending indefinitely, so we [assumed](https://github.com/denoland/deno_core/blob/4beb54e862805be6b2c4d8fb2bfc49ea72705799/core/runtime/jsruntime.rs#L1816C6-L1822C9) that we would poll again, but that didn't actually hold. Unlike non-dynamic module evaluation, we weren't waking the event loop for polling when the dynamic import evaluation promise resolved.

The fix here is to attaching callbacks to the dynamic import promise to wake the event loop when it resolves, similar to what we do for normal module evaluation.