### PR TITLE
store `ContextState` and `ModuleMap` in embedder slots

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -154,6 +154,8 @@ pub use crate::runtime::JsRuntimeForSnapshot;
 pub use crate::runtime::PollEventLoopOptions;
 pub use crate::runtime::RuntimeOptions;
 pub use crate::runtime::SharedArrayBufferStore;
+pub use crate::runtime::CONTEXT_STATE_SLOT_INDEX;
+pub use crate::runtime::MODULE_MAP_SLOT_INDEX;
 pub use crate::runtime::V8_WRAPPER_OBJECT_INDEX;
 pub use crate::runtime::V8_WRAPPER_TYPE_INDEX;
 pub use crate::source_map::SourceMapData;

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -235,7 +235,7 @@ impl JsRealm {
     let context = scope.get_current_context();
     // SAFETY: slot is valid and set during realm creation
     unsafe {
-      let rc = context.get_aligned_pointer_from_embedder_data(2);
+      let rc = context.get_aligned_pointer_from_embedder_data(MODULE_MAP_SLOT_INDEX);
       let rc = &*(rc as *const Rc<ModuleMap>);
       rc.clone()
     }

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -27,6 +27,9 @@ use std::rc::Rc;
 use std::sync::Arc;
 use v8::Handle;
 
+pub const CONTEXT_STATE_SLOT_INDEX: i32 = 1;
+pub const MODULE_MAP_SLOT_INDEX: i32 = 2;
+
 // Hasher used for `unrefed_ops`. Since these are rolling i32, there's no
 // need to actually hash them.
 #[derive(Default)]
@@ -181,7 +184,26 @@ impl JsRealmInner {
     std::mem::take(&mut *state.js_event_loop_tick_cb.borrow_mut());
     std::mem::take(&mut *state.js_wasm_streaming_cb.borrow_mut());
 
-    self.context().open(isolate).clear_all_slots(isolate);
+    let ctx = self.context().open(isolate);
+    // SAFETY: Clear all embedder data
+    unsafe {
+      let ctx_state =
+        ctx.get_aligned_pointer_from_embedder_data(CONTEXT_STATE_SLOT_INDEX);
+      let _ = Box::from_raw(ctx_state as *mut Rc<ContextState>);
+
+      let module_map =
+        ctx.get_aligned_pointer_from_embedder_data(MODULE_MAP_SLOT_INDEX);
+      let _ = Box::from_raw(module_map as *mut Rc<ModuleMap>);
+      ctx.set_aligned_pointer_in_embedder_data(
+        CONTEXT_STATE_SLOT_INDEX,
+        std::ptr::null_mut(),
+      );
+      ctx.set_aligned_pointer_in_embedder_data(
+        MODULE_MAP_SLOT_INDEX,
+        std::ptr::null_mut(),
+      );
+    }
+    ctx.clear_all_slots(isolate);
 
     // Expect that this context is dead (we only check this in debug mode)
     // TODO(mmastrac): This check fails for some tests, will need to fix this
@@ -199,29 +221,31 @@ impl JsRealm {
     scope: &mut v8::HandleScope,
   ) -> Rc<ContextState> {
     let context = scope.get_current_context();
+    // SAFETY: slot is valid and set during realm creation
     unsafe {
-    let rc = context.get_aligned_pointer_from_embedder_data(1);
-    let rc = &*(rc as *const Rc<ContextState>);
-    rc.clone()
+      let rc = context
+        .get_aligned_pointer_from_embedder_data(CONTEXT_STATE_SLOT_INDEX);
+      let rc = &*(rc as *const Rc<ContextState>);
+      rc.clone()
     }
   }
 
   #[inline(always)]
   pub(crate) fn module_map_from(scope: &mut v8::HandleScope) -> Rc<ModuleMap> {
     let context = scope.get_current_context();
-    context.get_slot::<Rc<ModuleMap>>(scope).unwrap().clone()
+    // SAFETY: slot is valid and set during realm creation
+    unsafe {
+      let rc = context.get_aligned_pointer_from_embedder_data(2);
+      let rc = &*(rc as *const Rc<ModuleMap>);
+      rc.clone()
+    }
   }
 
   #[inline(always)]
   pub(crate) fn exception_state_from_scope(
     scope: &mut v8::HandleScope,
   ) -> Rc<ExceptionState> {
-    let context = scope.get_current_context();
-    unsafe {
-    let rc = context.get_aligned_pointer_from_embedder_data(1);
-    let rc = &*(rc as *const Rc<ContextState>);
-    rc.exception_state.clone()
-    }
+    Self::state_from_scope(scope).exception_state.clone()
   }
 
   #[cfg(test)]

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -199,7 +199,11 @@ impl JsRealm {
     scope: &mut v8::HandleScope,
   ) -> Rc<ContextState> {
     let context = scope.get_current_context();
-    context.get_slot::<Rc<ContextState>>(scope).unwrap().clone()
+    unsafe {
+    let rc = context.get_aligned_pointer_from_embedder_data(1);
+    let rc = &*(rc as *const Rc<ContextState>);
+    rc.clone()
+    }
   }
 
   #[inline(always)]
@@ -213,11 +217,11 @@ impl JsRealm {
     scope: &mut v8::HandleScope,
   ) -> Rc<ExceptionState> {
     let context = scope.get_current_context();
-    context
-      .get_slot::<Rc<ContextState>>(scope)
-      .unwrap()
-      .exception_state
-      .clone()
+    unsafe {
+    let rc = context.get_aligned_pointer_from_embedder_data(1);
+    let rc = &*(rc as *const Rc<ContextState>);
+    rc.exception_state.clone()
+    }
   }
 
   #[cfg(test)]

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -235,7 +235,8 @@ impl JsRealm {
     let context = scope.get_current_context();
     // SAFETY: slot is valid and set during realm creation
     unsafe {
-      let rc = context.get_aligned_pointer_from_embedder_data(MODULE_MAP_SLOT_INDEX);
+      let rc =
+        context.get_aligned_pointer_from_embedder_data(MODULE_MAP_SLOT_INDEX);
       let rc = &*(rc as *const Rc<ModuleMap>);
       rc.clone()
     }

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -861,7 +861,9 @@ impl JsRuntime {
       );
     }
 
-    context.set_slot(scope, context_state.clone());
+    unsafe {
+    context.set_aligned_pointer_in_embedder_data(1, Rc::into_raw(context_state.clone()) as *mut c_void);
+    }
 
     let inspector = if options.inspector {
       Some(JsRuntimeInspector::new(scope, context, options.is_main))
@@ -1866,6 +1868,8 @@ fn create_context<'a>(
   for middleware in global_template_middlewares {
     global_object_template = middleware(scope, global_object_template);
   }
+
+  global_object_template.set_internal_field_count(2);
   let context = v8::Context::new_from_template(scope, global_object_template);
   let scope = &mut v8::ContextScope::new(scope, context);
 

--- a/core/runtime/mod.rs
+++ b/core/runtime/mod.rs
@@ -21,6 +21,8 @@ pub const V8_WRAPPER_OBJECT_INDEX: i32 = 1;
 pub use jsrealm::ContextState;
 pub(crate) use jsrealm::JsRealm;
 pub(crate) use jsrealm::OpDriverImpl;
+pub use jsrealm::CONTEXT_STATE_SLOT_INDEX;
+pub use jsrealm::MODULE_MAP_SLOT_INDEX;
 pub use jsruntime::CompiledWasmModuleStore;
 pub use jsruntime::CreateRealmOptions;
 pub use jsruntime::CrossIsolateStore;


### PR DESCRIPTION
Remove usage of rusty_v8 annex slots for storing `ContextState` and `ModuleMap` and instead store them directly in a dedicated embedder field.

Needed for https://github.com/denoland/deno/pull/23976