### PR TITLE
Revert "store `ContextState` and `ModuleMap` in embedder slots (#772)"

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -155,8 +155,6 @@ pub use crate::runtime::JsRuntimeForSnapshot;
 pub use crate::runtime::PollEventLoopOptions;
 pub use crate::runtime::RuntimeOptions;
 pub use crate::runtime::SharedArrayBufferStore;
-pub use crate::runtime::CONTEXT_STATE_SLOT_INDEX;
-pub use crate::runtime::MODULE_MAP_SLOT_INDEX;
 pub use crate::runtime::V8_WRAPPER_OBJECT_INDEX;
 pub use crate::runtime::V8_WRAPPER_TYPE_INDEX;
 pub use crate::source_map::SourceMapData;

--- a/core/runtime/mod.rs
+++ b/core/runtime/mod.rs
@@ -21,8 +21,6 @@ pub const V8_WRAPPER_OBJECT_INDEX: i32 = 1;
 pub use jsrealm::ContextState;
 pub(crate) use jsrealm::JsRealm;
 pub(crate) use jsrealm::OpDriverImpl;
-pub use jsrealm::CONTEXT_STATE_SLOT_INDEX;
-pub use jsrealm::MODULE_MAP_SLOT_INDEX;
 pub use jsruntime::CompiledWasmModuleStore;
 pub use jsruntime::CreateRealmOptions;
 pub use jsruntime::CrossIsolateStore;


### PR DESCRIPTION
This reverts commit 98d52cf97c1574b3ae642b8b4745590d72da7d0c.

CC @littledivy I had trouble updating `deno_core` in Deno as it died on `node_unit_tests::vm_test`
with signal 11 during `vm context promise rejection` test. Also `Box<Rc<...>>` seems fishy as pointed
as by @dsherret in https://github.com/denoland/deno_core/pull/775#discussion_r1631733833