### PR TITLE
Reland "store ContextState and ModuleMap in embedder slots"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2648,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.93.0"
+version = "0.93.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc3ff12243d345cc697c151b29fbb8ad1f898e3f8b7aa1386701ff9f2c7cbbf"
+checksum = "82943fec029559cb43f9d7fc36e2bb85121534702d6f893554e737d1b147d140"
 dependencies = [
  "bitflags",
  "fslock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ deno_ops = { version = "0.163.0", path = "./ops" }
 serde_v8 = { version = "0.196.0", path = "./serde_v8" }
 deno_core_testing = { path = "./testing" }
 
-v8 = { version = "0.93.0", default-features = false }
+v8 = { version = "0.93.1", default-features = false }
 deno_ast = { version = "=0.35.3", features = ["transpiling"] }
 deno_unsync = "0.3.2"
 deno_core_icudata = "0.0.73"

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -155,6 +155,8 @@ pub use crate::runtime::JsRuntimeForSnapshot;
 pub use crate::runtime::PollEventLoopOptions;
 pub use crate::runtime::RuntimeOptions;
 pub use crate::runtime::SharedArrayBufferStore;
+pub use crate::runtime::CONTEXT_STATE_SLOT_INDEX;
+pub use crate::runtime::MODULE_MAP_SLOT_INDEX;
 pub use crate::runtime::V8_WRAPPER_OBJECT_INDEX;
 pub use crate::runtime::V8_WRAPPER_TYPE_INDEX;
 pub use crate::source_map::SourceMapData;

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -220,9 +220,9 @@ impl JsRealmInner {
   }
 }
 
-fn clone_rc_raw<T>(raw: *const T) -> Rc<T> {
-  unsafe { Rc::increment_strong_count(raw) };
-  unsafe { Rc::from_raw(raw) }
+unsafe fn clone_rc_raw<T>(raw: *const T) -> Rc<T> {
+  Rc::increment_strong_count(raw);
+  Rc::from_raw(raw)
 }
 
 impl JsRealm {

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -28,6 +28,9 @@ use std::rc::Rc;
 use std::sync::Arc;
 use v8::Handle;
 
+pub const CONTEXT_STATE_SLOT_INDEX: i32 = 1;
+pub const MODULE_MAP_SLOT_INDEX: i32 = 2;
+
 // Hasher used for `unrefed_ops`. Since these are rolling i32, there's no
 // need to actually hash them.
 #[derive(Default)]
@@ -186,21 +189,34 @@ impl JsRealmInner {
     std::mem::take(&mut *state.js_wasm_streaming_cb.borrow_mut());
 
     {
-      let context = self.context().open(isolate);
-      let module_map =
-        context.get_slot::<Rc<ModuleMap>>(isolate).unwrap().clone();
-      context.clear_all_slots(isolate);
-      // Explcitly destroy data in the module map, as there might be some pending
-      // futures there and we want them dropped.
-      module_map.destroy();
+      let ctx = self.context().open(isolate);
+      // SAFETY: Clear all embedder data
+      unsafe {
+        let ctx_state =
+          ctx.get_aligned_pointer_from_embedder_data(CONTEXT_STATE_SLOT_INDEX);
+        let _ = Box::from_raw(ctx_state as *mut Rc<ContextState>);
+
+        let module_map =
+          ctx.get_aligned_pointer_from_embedder_data(MODULE_MAP_SLOT_INDEX);
+        // Explcitly destroy data in the module map, as there might be some pending
+        // futures there and we want them dropped.
+        let map = Box::from_raw(module_map as *mut Rc<ModuleMap>);
+        map.destroy();
+
+        ctx.set_aligned_pointer_in_embedder_data(
+          CONTEXT_STATE_SLOT_INDEX,
+          std::ptr::null_mut(),
+        );
+        ctx.set_aligned_pointer_in_embedder_data(
+          MODULE_MAP_SLOT_INDEX,
+          std::ptr::null_mut(),
+        );
+      }
+      ctx.clear_all_slots(isolate);
       // Expect that this context is dead (we only check this in debug mode)
       // TODO(bartlomieju): This check fails for some tests, will need to fix this
       // debug_assert_eq!(Rc::strong_count(&module_map), 1, "ModuleMap still in use.");
     }
-
-    // Expect that this context is dead (we only check this in debug mode)
-    // TODO(mmastrac): This check fails for some tests, will need to fix this
-    // debug_assert_eq!(Rc::strong_count(&self.context), 1, "Realm was still alive when we wanted to destroy it. Not dropped?");
   }
 }
 
@@ -214,25 +230,32 @@ impl JsRealm {
     scope: &mut v8::HandleScope,
   ) -> Rc<ContextState> {
     let context = scope.get_current_context();
-    context.get_slot::<Rc<ContextState>>(scope).unwrap().clone()
+    // SAFETY: slot is valid and set during realm creation
+    unsafe {
+      let rc = context
+        .get_aligned_pointer_from_embedder_data(CONTEXT_STATE_SLOT_INDEX);
+      let rc = &*(rc as *const Rc<ContextState>);
+      rc.clone()
+    }
   }
 
   #[inline(always)]
   pub(crate) fn module_map_from(scope: &mut v8::HandleScope) -> Rc<ModuleMap> {
     let context = scope.get_current_context();
-    context.get_slot::<Rc<ModuleMap>>(scope).unwrap().clone()
+    // SAFETY: slot is valid and set during realm creation
+    unsafe {
+      let rc =
+        context.get_aligned_pointer_from_embedder_data(MODULE_MAP_SLOT_INDEX);
+      let rc = &*(rc as *const Rc<ModuleMap>);
+      rc.clone()
+    }
   }
 
   #[inline(always)]
   pub(crate) fn exception_state_from_scope(
     scope: &mut v8::HandleScope,
   ) -> Rc<ExceptionState> {
-    let context = scope.get_current_context();
-    context
-      .get_slot::<Rc<ContextState>>(scope)
-      .unwrap()
-      .exception_state
-      .clone()
+    Self::state_from_scope(scope).exception_state.clone()
   }
 
   #[cfg(test)]

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -217,6 +217,10 @@ impl JsRealmInner {
       // TODO(bartlomieju): This check fails for some tests, will need to fix this
       // debug_assert_eq!(Rc::strong_count(&module_map), 1, "ModuleMap still in use.");
     }
+
+    // Expect that this context is dead (we only check this in debug mode)
+    // TODO(mmastrac): This check fails for some tests, will need to fix this
+    // debug_assert_eq!(Rc::strong_count(&self.context), 1, "Realm was still alive when we wanted to destroy it. Not dropped?");
   }
 }
 

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -869,10 +869,8 @@ impl JsRuntime {
       );
     }
 
-    // SAFETY: We need to initialize the slot. rusty_v8 currently segfaults
-    // when call `clear_all_slots`.
+    // SAFETY: Initialize the context state slot.
     unsafe {
-      context.set_slot(scope, ());
       context.set_aligned_pointer_in_embedder_data(
         super::jsrealm::CONTEXT_STATE_SLOT_INDEX,
         Rc::into_raw(context_state.clone()) as *mut c_void,

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -875,7 +875,7 @@ impl JsRuntime {
       context.set_slot(scope, ());
       context.set_aligned_pointer_in_embedder_data(
         super::jsrealm::CONTEXT_STATE_SLOT_INDEX,
-        Box::into_raw(Box::new(context_state.clone())) as *mut c_void,
+        Rc::into_raw(context_state.clone()) as *mut c_void,
       );
     }
 
@@ -922,7 +922,7 @@ impl JsRuntime {
     unsafe {
       context.set_aligned_pointer_in_embedder_data(
         super::jsrealm::MODULE_MAP_SLOT_INDEX,
-        Box::into_raw(Box::new(module_map.clone())) as *mut c_void,
+        Rc::into_raw(module_map.clone()) as *mut c_void,
       );
     }
 

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -869,7 +869,15 @@ impl JsRuntime {
       );
     }
 
-    context.set_slot(scope, context_state.clone());
+    // SAFETY: We need to initialize the slot. rusty_v8 currently segfaults
+    // when call `clear_all_slots`.
+    unsafe {
+      context.set_slot(scope, ());
+      context.set_aligned_pointer_in_embedder_data(
+        super::jsrealm::CONTEXT_STATE_SLOT_INDEX,
+        Box::into_raw(Box::new(context_state.clone())) as *mut c_void,
+      );
+    }
 
     let inspector = if options.inspector {
       Some(JsRuntimeInspector::new(scope, context, options.is_main))
@@ -910,7 +918,13 @@ impl JsRuntime {
       }
     }
 
-    context.set_slot(scope, module_map.clone());
+    // SAFETY: Set the module map slot in the context
+    unsafe {
+      context.set_aligned_pointer_in_embedder_data(
+        super::jsrealm::MODULE_MAP_SLOT_INDEX,
+        Box::into_raw(Box::new(module_map.clone())) as *mut c_void,
+      );
+    }
 
     // ...we are ready to create a "realm" for the context...
     let main_realm = {
@@ -1876,6 +1890,8 @@ fn create_context<'a>(
   for middleware in global_template_middlewares {
     global_object_template = middleware(scope, global_object_template);
   }
+
+  global_object_template.set_internal_field_count(2);
   let context = v8::Context::new_from_template(scope, global_object_template);
   let scope = &mut v8::ContextScope::new(scope, context);
 

--- a/core/runtime/mod.rs
+++ b/core/runtime/mod.rs
@@ -21,6 +21,8 @@ pub const V8_WRAPPER_OBJECT_INDEX: i32 = 1;
 pub use jsrealm::ContextState;
 pub(crate) use jsrealm::JsRealm;
 pub(crate) use jsrealm::OpDriverImpl;
+pub use jsrealm::CONTEXT_STATE_SLOT_INDEX;
+pub use jsrealm::MODULE_MAP_SLOT_INDEX;
 pub use jsruntime::CompiledWasmModuleStore;
 pub use jsruntime::CreateRealmOptions;
 pub use jsruntime::CrossIsolateStore;


### PR DESCRIPTION
Verified that `node::unit_vm` tests pass in Deno