### PR TITLE
fix: root cppgc objects during async ops

### DIFF
--- a/core/cppgc.rs
+++ b/core/cppgc.rs
@@ -41,6 +41,7 @@ pub fn make_cppgc_object<'a, T: 'static>(
   obj
 }
 
+#[allow(clippy::needless_lifetimes)]
 pub fn try_unwrap_cppgc_object<'sc, T: 'static>(
   val: v8::Local<'sc, v8::Value>,
 ) -> Option<&'sc T> {

--- a/core/cppgc.rs
+++ b/core/cppgc.rs
@@ -42,7 +42,7 @@ pub fn make_cppgc_object<'a, T: 'static>(
 }
 
 pub fn try_unwrap_cppgc_object<'sc, T: 'static>(
-  val: v8::Local<v8::Value>,
+  val: v8::Local<'sc, v8::Value>,
 ) -> Option<&'sc T> {
   let Ok(obj): Result<v8::Local<v8::Object>, _> = val.try_into() else {
     return None;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -180,6 +180,7 @@ pub mod _ops {
   pub use super::extensions::OpDecl;
   #[cfg(debug_assertions)]
   pub use super::ops::reentrancy_check;
+  pub use super::ops::CppGcObjectGuard;
   pub use super::ops::OpCtx;
   pub use super::ops_metrics::dispatch_metrics_async;
   pub use super::ops_metrics::dispatch_metrics_fast;

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -57,6 +57,37 @@ pub fn reentrancy_check(decl: &'static OpDecl) -> Option<ReentrancyGuard> {
   Some(ReentrancyGuard {})
 }
 
+/// A guard for a [`cppgc::Gc`] object that ensures the object is rooted while the guard is alive.
+pub struct CppGcObjectGuard<T: 'static> {
+  _global: v8::Global<v8::Value>,
+  t: &'static T,
+}
+
+impl<T: 'static> CppGcObjectGuard<T> {
+  pub fn try_new_from_cppgc_object(
+    isolate: &mut Isolate,
+    val: v8::Local<v8::Value>,
+  ) -> Option<Self> {
+    crate::cppgc::try_unwrap_cppgc_object(val).map(|t| Self {
+      _global: v8::Global::new(isolate, val),
+      // SAFETY: `global` will keep T rooted. We never expose T to the user with
+      // a 'static lifetime. Only ever a reference to T tied to the lifetime of
+      // the `CppGcObjectGuard`.
+      t: unsafe { &*(t as *const T) },
+    })
+  }
+
+  /// Returns a reference to the inner T value.
+  ///
+  /// # Safety
+  ///
+  /// This is only safe if you have ensured that the `Isolate` that this object
+  /// is stored in, is still alive.
+  pub unsafe fn as_ref(&self) -> &T {
+    self.t
+  }
+}
+
 #[derive(Clone, Copy)]
 pub struct OpMetadata {
   /// A description of the op for use in sanitizer output.

--- a/ops/compile_test_runner/src/lib.rs
+++ b/ops/compile_test_runner/src/lib.rs
@@ -26,6 +26,7 @@ mod tests {
     // run in parallel: https://github.com/dtolnay/trybuild/pull/168)
     let t = trybuild::TestCases::new();
     t.pass("../op2/test_cases/**/*.rs");
+    t.compile_fail("../op2/test_cases_fail/**/*.rs");
   }
 
   #[rustversion::not(nightly)]
@@ -34,6 +35,7 @@ mod tests {
     // Run all the tests if we're in the CI
     if let Ok(true) = std::env::var("CI").map(|s| s == "true") {
       let t = trybuild::TestCases::new();
+      t.compile_fail("../op2/test_cases_fail/**/*.rs");
       t.pass("../op2/test_cases/**/*.rs");
     }
   }

--- a/ops/op2/dispatch_async.rs
+++ b/ops/op2/dispatch_async.rs
@@ -48,7 +48,7 @@ pub(crate) fn generate_dispatch_async(
 
   let with_self = if generator_state.needs_self {
     with_self(generator_state, &signature.ret_val)
-      .map_err(|s| V8SignatureMappingError::NoSelfMapping(s))?
+      .map_err(V8SignatureMappingError::NoSelfMapping)?
   } else {
     quote!()
   };

--- a/ops/op2/dispatch_async.rs
+++ b/ops/op2/dispatch_async.rs
@@ -46,6 +46,13 @@ pub(crate) fn generate_dispatch_async(
 ) -> Result<TokenStream, V8SignatureMappingError> {
   let mut output = TokenStream::new();
 
+  let with_self = if generator_state.needs_self {
+    with_self(generator_state, &signature.ret_val)
+      .map_err(|s| V8SignatureMappingError::NoSelfMapping(s))?
+  } else {
+    quote!()
+  };
+
   // input_index = 1 as promise ID is the first arg
   let args = generate_dispatch_slow_call(generator_state, signature, 1)?;
 
@@ -137,16 +144,10 @@ pub(crate) fn generate_dispatch_async(
     quote!()
   };
 
-  let with_self = if generator_state.needs_self {
-    with_self(generator_state)
-  } else {
-    quote!()
-  };
-
   Ok(
     gs_quote!(generator_state(info, slow_function, slow_function_metrics, opctx) => {
       #[inline(always)]
-      fn slow_function_impl(#info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+      fn slow_function_impl<'s>(info: &'s deno_core::v8::FunctionCallbackInfo) -> usize {
         #[cfg(debug_assertions)]
         let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(&<Self as deno_core::_ops::Op>::DECL);
 
@@ -160,24 +161,24 @@ pub(crate) fn generate_dispatch_async(
         #output
       }
 
-      extern "C" fn #slow_function(#info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(#info);
+      extern "C" fn #slow_function<'s>(#info: *const deno_core::v8::FunctionCallbackInfo) {
+        let info: &'s _ = unsafe { &*#info };
+        Self::slow_function_impl(info);
       }
 
-      extern "C" fn #slow_function_metrics(#info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-          &*info
-        });
-        let #opctx = unsafe {
+      extern "C" fn #slow_function_metrics<'s>(#info: *const deno_core::v8::FunctionCallbackInfo) {
+        let info: &'s _ = unsafe { &*#info };
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(info);
+        let #opctx: &'s _ = unsafe {
           &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
             as *const deno_core::_ops::OpCtx)
         };
-        deno_core::_ops::dispatch_metrics_async(&#opctx, deno_core::_ops::OpMetricsEvent::Dispatched);
-        let res = Self::slow_function_impl(#info);
+        deno_core::_ops::dispatch_metrics_async(#opctx, deno_core::_ops::OpMetricsEvent::Dispatched);
+        let res = Self::slow_function_impl(info);
         if res == 0 {
-          deno_core::_ops::dispatch_metrics_async(&#opctx, deno_core::_ops::OpMetricsEvent::Completed);
+          deno_core::_ops::dispatch_metrics_async(#opctx, deno_core::_ops::OpMetricsEvent::Completed);
         } else if res == 1 {
-          deno_core::_ops::dispatch_metrics_async(&#opctx, deno_core::_ops::OpMetricsEvent::Error);
+          deno_core::_ops::dispatch_metrics_async(#opctx, deno_core::_ops::OpMetricsEvent::Error);
         }
       }
     }),

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -204,7 +204,7 @@ impl V8FastCallType {
         quote!(deno_core::v8::Local<deno_core::v8::Value>)
       }
       V8FastCallType::CallbackOptions => {
-        quote!(*mut deno_core::v8::fast_api::FastApiCallbackOptions)
+        quote!(*mut deno_core::v8::fast_api::FastApiCallbackOptions<'s>)
       }
       V8FastCallType::SeqOneByteString => {
         quote!(*mut deno_core::v8::fast_api::FastApiOneByteString)
@@ -433,7 +433,7 @@ pub(crate) fn generate_dispatch_fast(
   let with_js_runtime_state = if generator_state.needs_fast_js_runtime_state {
     generator_state.needs_fast_opctx = true;
     gs_quote!(generator_state(js_runtime_state, opctx) => {
-      let #js_runtime_state = &#opctx.runtime_state();
+      let #js_runtime_state = #opctx.runtime_state();
     })
   } else {
     quote!()
@@ -442,7 +442,7 @@ pub(crate) fn generate_dispatch_fast(
   let with_opctx = if generator_state.needs_fast_opctx {
     generator_state.needs_fast_api_callback_options = true;
     gs_quote!(generator_state(opctx, fast_api_callback_options) => {
-      let #opctx = unsafe {
+      let #opctx: &'s _ = unsafe {
         &*(deno_core::v8::Local::<deno_core::v8::External>::cast(unsafe { #fast_api_callback_options.data.data }).value()
             as *const deno_core::_ops::OpCtx)
       };
@@ -452,8 +452,13 @@ pub(crate) fn generate_dispatch_fast(
   };
 
   let with_self = if generator_state.needs_self {
-    gs_quote!(generator_state(self_ty) => {
-      let self_: &#self_ty = deno_core::cppgc::try_unwrap_cppgc_object(this.into()).unwrap();
+    generator_state.needs_fast_api_callback_options = true;
+    gs_quote!(generator_state(self_ty, fast_api_callback_options) => {
+      let Some(self_) = deno_core::cppgc::try_unwrap_cppgc_object::<#self_ty>(this.into()) else {
+        #fast_api_callback_options.fallback = true;
+        // SAFETY: All fast return types have zero as a valid value
+        return unsafe { std::mem::zeroed() };
+      };
     })
   } else {
     quote!()
@@ -474,7 +479,7 @@ pub(crate) fn generate_dispatch_fast(
   {
     fastsig.ensure_fast_api_callback_options();
     gs_quote!(generator_state(fast_api_callback_options) => {
-      let #fast_api_callback_options = unsafe { &mut *#fast_api_callback_options };
+      let #fast_api_callback_options: &'s mut _ = unsafe { &mut *#fast_api_callback_options };
     })
   } else {
     quote!()
@@ -500,24 +505,25 @@ pub(crate) fn generate_dispatch_fast(
     fastsig.input_args(generator_state).into_iter().unzip();
   let fast_fn = gs_quote!(generator_state(result, fast_api_callback_options, fast_function, fast_function_metrics) => {
     #[allow(clippy::too_many_arguments)]
-    extern "C" fn #fast_function_metrics(
+    extern "C" fn #fast_function_metrics<'s>(
       this: deno_core::v8::Local<deno_core::v8::Object>,
       #( #fastcall_metrics_names: #fastcall_metrics_types, )*
     ) -> #output_type {
-      let #fast_api_callback_options = unsafe { &mut *#fast_api_callback_options };
-      let opctx = unsafe {
+      let #fast_api_callback_options: &'s mut _ =
+        unsafe { &mut *#fast_api_callback_options };
+      let opctx: &'s _ = unsafe {
           &*(deno_core::v8::Local::<deno_core::v8::External>::cast(
             unsafe { #fast_api_callback_options.data.data }
           ).value() as *const deno_core::_ops::OpCtx)
       };
-      deno_core::_ops::dispatch_metrics_fast(&opctx, deno_core::_ops::OpMetricsEvent::Dispatched);
+      deno_core::_ops::dispatch_metrics_fast(opctx, deno_core::_ops::OpMetricsEvent::Dispatched);
       let res = Self::#fast_function( this, #( #fastcall_names, )* );
-      deno_core::_ops::dispatch_metrics_fast(&opctx, deno_core::_ops::OpMetricsEvent::Completed);
+      deno_core::_ops::dispatch_metrics_fast(opctx, deno_core::_ops::OpMetricsEvent::Completed);
       res
     }
 
     #[allow(clippy::too_many_arguments)]
-    extern "C" fn #fast_function(
+    extern "C" fn #fast_function<'s>(
       this: deno_core::v8::Local<deno_core::v8::Object>,
       #( #fastcall_names: #fastcall_types, )*
     ) -> #output_type {

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -93,7 +93,7 @@ pub(crate) fn generate_dispatch_slow(
 
   let with_self = if generator_state.needs_self {
     with_self(generator_state, &signature.ret_val)
-      .map_err(|s| V8SignatureMappingError::NoSelfMapping(s))?
+      .map_err(V8SignatureMappingError::NoSelfMapping)?
   } else {
     quote!()
   };
@@ -781,10 +781,10 @@ pub fn call(
     {
       tokens.extend(quote!( let #ident = unsafe { #ident.as_ref() }; ));
     }
-    return quote!(async move {
+    quote!(async move {
       #tokens
       #call.await
-    });
+    })
   } else {
     call
   }

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -41,7 +41,7 @@ pub(crate) fn generate_dispatch_slow_call(
   let mut deferred = TokenStream::new();
 
   for (index, arg) in signature.args.iter().enumerate() {
-    let arg_mapped = from_arg(generator_state, index, arg)
+    let arg_mapped = from_arg(generator_state, index, arg, &signature.ret_val)
       .map_err(|s| V8SignatureMappingError::NoArgMapping(s, arg.clone()))?;
     if arg.is_virtual() {
       deferred.extend(arg_mapped);
@@ -53,7 +53,7 @@ pub(crate) fn generate_dispatch_slow_call(
   }
 
   args.extend(deferred);
-  args.extend(call(generator_state));
+  args.extend(call(generator_state, &signature.ret_val));
   Ok(args)
 }
 
@@ -90,6 +90,13 @@ pub(crate) fn generate_dispatch_slow(
   output.extend(return_value(generator_state, &signature.ret_val).map_err(
     |s| V8SignatureMappingError::NoRetValMapping(s, signature.ret_val.clone()),
   )?);
+
+  let with_self = if generator_state.needs_self {
+    with_self(generator_state, &signature.ret_val)
+      .map_err(|s| V8SignatureMappingError::NoSelfMapping(s))?
+  } else {
+    quote!()
+  };
 
   // We only generate the isolate if we need it but don't need a scope. We call it `scope`.
   let with_isolate =
@@ -135,16 +142,10 @@ pub(crate) fn generate_dispatch_slow(
     quote!()
   };
 
-  let with_self = if generator_state.needs_self {
-    with_self(generator_state)
-  } else {
-    quote!()
-  };
-
   Ok(
     gs_quote!(generator_state(opctx, info, slow_function, slow_function_metrics) => {
       #[inline(always)]
-      fn slow_function_impl(#info: *const deno_core::v8::FunctionCallbackInfo) -> usize {
+      fn slow_function_impl<'s>(#info: &'s deno_core::v8::FunctionCallbackInfo) -> usize {
         #[cfg(debug_assertions)]
         let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(&<Self as deno_core::_ops::Op>::DECL);
 
@@ -161,25 +162,25 @@ pub(crate) fn generate_dispatch_slow(
         return 0;
       }
 
-      extern "C" fn #slow_function(#info: *const deno_core::v8::FunctionCallbackInfo) {
-        Self::slow_function_impl(#info);
+      extern "C" fn #slow_function<'s>(#info: *const deno_core::v8::FunctionCallbackInfo) {
+        let info: &'s _ = unsafe { &*#info };
+        Self::slow_function_impl(info);
       }
 
-      extern "C" fn #slow_function_metrics(#info: *const deno_core::v8::FunctionCallbackInfo) {
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-          &*info
-        });
-        let #opctx = unsafe {
+      extern "C" fn #slow_function_metrics<'s>(#info: *const deno_core::v8::FunctionCallbackInfo) {
+        let info: &'s _ = unsafe { &*#info };
+        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(info);
+        let #opctx: &'s _ = unsafe {
           &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data()).value()
               as *const deno_core::_ops::OpCtx)
         };
 
-        deno_core::_ops::dispatch_metrics_slow(&#opctx, deno_core::_ops::OpMetricsEvent::Dispatched);
-        let res = Self::slow_function_impl(#info);
+        deno_core::_ops::dispatch_metrics_slow(#opctx, deno_core::_ops::OpMetricsEvent::Dispatched);
+        let res = Self::slow_function_impl(info);
         if res == 0 {
-          deno_core::_ops::dispatch_metrics_slow(&#opctx, deno_core::_ops::OpMetricsEvent::Completed);
+          deno_core::_ops::dispatch_metrics_slow(#opctx, deno_core::_ops::OpMetricsEvent::Completed);
         } else {
-          deno_core::_ops::dispatch_metrics_slow(&#opctx, deno_core::_ops::OpMetricsEvent::Error);
+          deno_core::_ops::dispatch_metrics_slow(#opctx, deno_core::_ops::OpMetricsEvent::Error);
         }
       }
     }),
@@ -197,13 +198,13 @@ pub(crate) fn with_isolate(
 
 pub(crate) fn with_scope(generator_state: &mut GeneratorState) -> TokenStream {
   gs_quote!(generator_state(info, scope) =>
-    (let mut #scope = unsafe { deno_core::v8::CallbackScope::new(&*#info) };)
+    (let mut #scope = unsafe { deno_core::v8::CallbackScope::new(#info) };)
   )
 }
 
 pub(crate) fn with_retval(generator_state: &mut GeneratorState) -> TokenStream {
   gs_quote!(generator_state(retval, info) =>
-    (let mut #retval = deno_core::v8::ReturnValue::from_function_callback_info(unsafe { &*#info });)
+    (let mut #retval = deno_core::v8::ReturnValue::from_function_callback_info(#info);)
   )
 }
 
@@ -211,14 +212,14 @@ pub(crate) fn with_fn_args(
   generator_state: &mut GeneratorState,
 ) -> TokenStream {
   gs_quote!(generator_state(info, fn_args) =>
-    (let #fn_args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe { &*#info });)
+    (let #fn_args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(#info);)
   )
 }
 
 pub(crate) fn with_opctx(generator_state: &mut GeneratorState) -> TokenStream {
   generator_state.needs_args = true;
   gs_quote!(generator_state(opctx, fn_args) =>
-    (let #opctx = unsafe {
+    (let #opctx: &'s _ = unsafe {
     &*(deno_core::v8::Local::<deno_core::v8::External>::cast(#fn_args.data()).value()
         as *const deno_core::_ops::OpCtx)
     };)
@@ -243,11 +244,35 @@ pub(crate) fn with_js_runtime_state(
   )
 }
 
-pub(crate) fn with_self(generator_state: &mut GeneratorState) -> TokenStream {
+pub(crate) fn with_self(
+  generator_state: &mut GeneratorState,
+  ret_val: &RetVal,
+) -> Result<TokenStream, V8MappingError> {
   generator_state.needs_opctx = true;
-  gs_quote!(generator_state(fn_args, self_ty) =>
-    (let self_: &#self_ty = unsafe { deno_core::cppgc::try_unwrap_cppgc_object(#fn_args.this().into()).unwrap() };)
-  )
+  let throw_exception = throw_type_error(
+    generator_state,
+    format!("expected {}", &generator_state.self_ty),
+  )?;
+  let tokens = if matches!(ret_val, RetVal::Future(_) | RetVal::FutureResult(_))
+  {
+    let tokens = gs_quote!(generator_state(self_ty, fn_args, scope) => {
+      let Some(self_) = deno_core::_ops::CppGcObjectGuard::<#self_ty>::try_new_from_cppgc_object(&mut *#scope, #fn_args.this().into()) else {
+        #throw_exception;
+      };
+    });
+    generator_state.needs_scope = true;
+    generator_state
+      .idents_that_need_to_be_captured_by_future_and_as_refd
+      .push(format_ident!("self_"));
+    tokens
+  } else {
+    gs_quote!(generator_state(self_ty, fn_args) => {
+      let Some(self_) = deno_core::cppgc::try_unwrap_cppgc_object::<#self_ty>(#fn_args.this().into()) else {
+        #throw_exception;
+      };
+    })
+  };
+  Ok(tokens)
 }
 
 pub fn extract_arg(
@@ -267,6 +292,7 @@ pub fn from_arg(
   mut generator_state: &mut GeneratorState,
   index: usize,
   arg: &Arg,
+  ret_val: &RetVal,
 ) -> Result<TokenStream, V8MappingError> {
   let GeneratorState {
     args,
@@ -318,8 +344,12 @@ pub fn from_arg(
       from_arg_option(generator_state, &arg_ident, "f64")?
     }
     Arg::OptionNumeric(numeric, flag) => {
-      let some =
-        from_arg(generator_state, index, &Arg::Numeric(*numeric, *flag))?;
+      let some = from_arg(
+        generator_state,
+        index,
+        &Arg::Numeric(*numeric, *flag),
+        ret_val,
+      )?;
       quote! {
         let #arg_ident = if #arg_ident.is_null_or_undefined() {
           None
@@ -541,10 +571,24 @@ pub fn from_arg(
         throw_type_error(generator_state, format!("expected {}", &ty))?;
       let ty =
         syn::parse_str::<syn::Path>(ty).expect("Failed to reparse state type");
-      quote! {
-        let Some(#arg_ident) = deno_core::cppgc::try_unwrap_cppgc_object::<#ty>(#arg_ident) else {
-          #throw_exception;
+      if matches!(ret_val, RetVal::Future(_) | RetVal::FutureResult(_)) {
+        let scope = &generator_state.scope;
+        let tokens = quote! {
+          let Some(#arg_ident) = deno_core::_ops::CppGcObjectGuard::<#ty>::try_new_from_cppgc_object(&mut *#scope, #arg_ident) else {
+            #throw_exception;
+          };
         };
+        generator_state.needs_scope = true;
+        generator_state
+          .idents_that_need_to_be_captured_by_future_and_as_refd
+          .push(arg_ident.clone());
+        tokens
+      } else {
+        quote! {
+          let Some(#arg_ident) = deno_core::cppgc::try_unwrap_cppgc_object::<#ty>(#arg_ident) else {
+            #throw_exception;
+          };
+        }
       }
     }
     _ => return Err("a slow argument"),
@@ -704,20 +748,46 @@ pub fn from_arg_any_buffer(
   })
 }
 
-pub fn call(generator_state: &mut GeneratorState) -> TokenStream {
+pub fn call(
+  generator_state: &mut GeneratorState,
+  ret_val: &RetVal,
+) -> TokenStream {
   let mut tokens = TokenStream::new();
+  if generator_state.needs_self {
+    tokens.extend(quote!(self_,));
+  }
   for arg in &generator_state.args {
     tokens.extend(quote!( #arg , ));
   }
 
   let name = &generator_state.name;
   let call_ = if generator_state.needs_self {
-    quote!(self_. #name)
+    let self_ty = &generator_state.self_ty;
+    quote!(#self_ty:: #name)
   } else {
     quote!(Self:: #name)
   };
 
-  quote!(#call_ ( #tokens ))
+  let call = quote!(#call_ ( #tokens ));
+
+  if matches!(ret_val, RetVal::Future(_) | RetVal::FutureResult(_))
+    && !generator_state
+      .idents_that_need_to_be_captured_by_future_and_as_refd
+      .is_empty()
+  {
+    let mut tokens = TokenStream::new();
+    for ident in
+      &generator_state.idents_that_need_to_be_captured_by_future_and_as_refd
+    {
+      tokens.extend(quote!( let #ident = unsafe { #ident.as_ref() }; ));
+    }
+    return quote!(async move {
+      #tokens
+      #call.await
+    });
+  } else {
+    call
+  }
 }
 
 pub fn return_value(

--- a/ops/op2/generator_state.rs
+++ b/ops/op2/generator_state.rs
@@ -37,6 +37,10 @@ pub struct GeneratorState {
   /// Type of the self argument
   pub self_ty: Ident,
 
+  /// Idents that need to be moved into the future and have a reference taken
+  /// before being passed to the underlying call.
+  pub idents_that_need_to_be_captured_by_future_and_as_refd: Vec<Ident>,
+
   pub needs_args: bool,
   pub needs_retval: bool,
   pub needs_scope: bool,

--- a/ops/op2/mod.rs
+++ b/ops/op2/mod.rs
@@ -64,6 +64,7 @@ pub enum Op2Error {
 }
 
 #[derive(Debug, Error)]
+#[allow(clippy::enum_variant_names)]
 pub enum V8SignatureMappingError {
   #[error("Unable to map return value {1:?} to {0}")]
   NoRetValMapping(V8MappingError, RetVal),

--- a/ops/op2/mod.rs
+++ b/ops/op2/mod.rs
@@ -69,6 +69,8 @@ pub enum V8SignatureMappingError {
   NoRetValMapping(V8MappingError, RetVal),
   #[error("Unable to map argument {1:?} to {0}")]
   NoArgMapping(V8MappingError, Arg),
+  #[error("Unable to map self")]
+  NoSelfMapping(V8MappingError),
 }
 
 pub type V8MappingError = &'static str;
@@ -172,6 +174,7 @@ fn generate_op2(
     fast_function_metrics,
     promise_id,
     self_ty,
+    idents_that_need_to_be_captured_by_future_and_as_refd: vec![],
     needs_retval: false,
     needs_scope: false,
     needs_isolate: false,

--- a/ops/op2/test_cases/async/async_arg_return.out
+++ b/ops/op2/test_cases/async/async_arg_return.out
@@ -25,27 +25,25 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
             stringify!(op_async)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             let result = {
                 let arg0 = args.get(1usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected i32".as_bytes(),
@@ -74,32 +72,34 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
             }
             return 2;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_async(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else if res == 1 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/async/async_arg_return_result.out
+++ b/ops/op2/test_cases/async/async_arg_return_result.out
@@ -25,27 +25,25 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
             stringify!(op_async)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             let result = {
                 let arg0 = args.get(1usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected i32".as_bytes(),
@@ -75,7 +73,7 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                     }
                     Err(err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let err = err.into();
                         let exception = deno_core::error::to_v8_error(
@@ -91,32 +89,34 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
             }
             return 2;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_async(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else if res == 1 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/async/async_cppgc.out
+++ b/ops/op2/test_cases/async/async_cppgc.out
@@ -8,9 +8,9 @@ const fn op_make_cppgc_object() -> ::deno_core::_ops::OpDecl {
         const NAME: &'static str = stringify!(op_make_cppgc_object);
         const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
             ::deno_core::__op_name_fast!(op_make_cppgc_object),
+            true,
             false,
-            false,
-            0usize as u8,
+            1usize as u8,
             Self::v8_fn_ptr as _,
             Self::v8_fn_ptr_metrics as _,
             None,
@@ -34,15 +34,40 @@ const fn op_make_cppgc_object() -> ::deno_core::_ops::OpDecl {
             );
             let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
             let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
-            let result = { Self::call() };
-            rv.set(
-                deno_core::_ops::RustToV8NoScope::to_v8(
-                    deno_core::v8::Local::<
-                        deno_core::v8::Value,
-                    >::from(deno_core::cppgc::make_cppgc_object(&mut scope, result)),
-                ),
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
             );
-            return 0;
+            let opctx: &'s _ = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            let result = { Self::call() };
+            let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+                .unwrap_or_default();
+            if let Some(result) = deno_core::_ops::map_async_op_infallible(
+                opctx,
+                false,
+                false,
+                promise_id,
+                result,
+                |scope, result| {
+                    Ok(
+                        deno_core::_ops::RustToV8NoScope::to_v8(
+                            deno_core::cppgc::make_cppgc_object(scope, result),
+                        ),
+                    )
+                },
+            ) {
+                rv.set(
+                    deno_core::_ops::RustToV8NoScope::to_v8(
+                        deno_core::v8::Local::<
+                            deno_core::v8::Value,
+                        >::from(deno_core::cppgc::make_cppgc_object(&mut scope, result)),
+                    ),
+                );
+                return 0;
+            }
+            return 2;
         }
         extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
             let info: &'s _ = unsafe { &*info };
@@ -59,18 +84,18 @@ const fn op_make_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
-            deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_async(
                 opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
+                deno_core::_ops::dispatch_metrics_async(
                     opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
+            } else if res == 1 {
+                deno_core::_ops::dispatch_metrics_async(
                     opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
@@ -79,7 +104,7 @@ const fn op_make_cppgc_object() -> ::deno_core::_ops::OpDecl {
     }
     impl op_make_cppgc_object {
         #[inline(always)]
-        fn call() -> Wrap {
+        async fn call() -> Wrap {
             Wrap
         }
     }
@@ -96,29 +121,13 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
         const NAME: &'static str = stringify!(op_use_cppgc_object);
         const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
             ::deno_core::__op_name_fast!(op_use_cppgc_object),
+            true,
             false,
-            false,
-            1usize as u8,
+            2usize as u8,
             Self::v8_fn_ptr as _,
             Self::v8_fn_ptr_metrics as _,
-            Some({
-                use deno_core::v8::fast_api::Type;
-                use deno_core::v8::fast_api::CType;
-                deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                    &[Type::V8Value, Type::V8Value, Type::CallbackOptions],
-                    CType::Void,
-                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
-                )
-            }),
-            Some({
-                use deno_core::v8::fast_api::Type;
-                use deno_core::v8::fast_api::CType;
-                deno_core::v8::fast_api::FastFunction::new_with_bigint(
-                    &[Type::V8Value, Type::V8Value, Type::CallbackOptions],
-                    CType::Void,
-                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
-                )
-            }),
+            None,
+            None,
             ::deno_core::OpMetadata {
                 ..::deno_core::OpMetadata::default()
             },
@@ -128,59 +137,6 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
         pub const fn name() -> &'static str {
             stringify!(op_use_cppgc_object)
         }
-        #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
-            this: deno_core::v8::Local<deno_core::v8::Object>,
-            arg0: deno_core::v8::Local<deno_core::v8::Value>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
-                's,
-            >,
-        ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast(unsafe { fast_api_callback_options.data.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
-        }
-        #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast<'s>(
-            this: deno_core::v8::Local<deno_core::v8::Object>,
-            arg0: deno_core::v8::Local<deno_core::v8::Value>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
-                's,
-            >,
-        ) -> () {
-            #[cfg(debug_assertions)]
-            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
-                &<Self as deno_core::_ops::Op>::DECL,
-            );
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let result = {
-                let Some(arg0) = deno_core::cppgc::try_unwrap_cppgc_object::<Wrap>(arg0)
-                else {
-                    fast_api_callback_options.fallback = true;
-                    return unsafe { std::mem::zeroed() };
-                };
-                Self::call(arg0)
-            };
-            result as _
-        }
         #[inline(always)]
         fn slow_function_impl<'s>(
             info: &'s deno_core::v8::FunctionCallbackInfo,
@@ -189,14 +145,20 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
             let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
                 info,
             );
+            let opctx: &'s _ = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
             let result = {
-                let arg0 = args.get(0usize as i32);
-                let Some(arg0) = deno_core::cppgc::try_unwrap_cppgc_object::<Wrap>(arg0)
-                else {
+                let arg0 = args.get(1usize as i32);
+                let Some(arg0) = deno_core::_ops::CppGcObjectGuard::<
+                    Wrap,
+                >::try_new_from_cppgc_object(&mut *scope, arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
@@ -208,10 +170,25 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
                     scope.throw_exception(exc);
                     return 1;
                 };
-                Self::call(arg0)
+                async move {
+                    let arg0 = unsafe { arg0.as_ref() };
+                    Self::call(arg0).await
+                }
             };
-            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
-            return 0;
+            let promise_id = deno_core::_ops::to_i32_option(&args.get(0))
+                .unwrap_or_default();
+            if let Some(result) = deno_core::_ops::map_async_op_infallible(
+                opctx,
+                false,
+                false,
+                promise_id,
+                result,
+                |scope, result| { Ok(deno_core::_ops::RustToV8::to_v8(result, scope)) },
+            ) {
+                deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+                return 0;
+            }
+            return 2;
         }
         extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
             let info: &'s _ = unsafe { &*info };
@@ -228,18 +205,18 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
-            deno_core::_ops::dispatch_metrics_slow(
+            deno_core::_ops::dispatch_metrics_async(
                 opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
+                deno_core::_ops::dispatch_metrics_async(
                     opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
+            } else if res == 1 {
+                deno_core::_ops::dispatch_metrics_async(
                     opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
@@ -248,7 +225,7 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
     }
     impl op_use_cppgc_object {
         #[inline(always)]
-        fn call(_wrap: &Wrap) {}
+        async fn call(_wrap: &Wrap) {}
     }
     <op_use_cppgc_object as ::deno_core::_ops::Op>::DECL
 }

--- a/ops/op2/test_cases/async/async_cppgc.rs
+++ b/ops/op2/test_cases/async/async_cppgc.rs
@@ -4,11 +4,11 @@ deno_ops_compile_test_runner::prelude!();
 
 struct Wrap;
 
-#[op2]
+#[op2(async)]
 #[cppgc]
-fn op_make_cppgc_object() -> Wrap {
+async fn op_make_cppgc_object() -> Wrap {
   Wrap
 }
 
-#[op2(fast)]
-fn op_use_cppgc_object(#[cppgc] _wrap: &Wrap) {}
+#[op2(async)]
+async fn op_use_cppgc_object(#[cppgc] _wrap: &Wrap) {}

--- a/ops/op2/test_cases/async/async_deferred.out
+++ b/ops/op2/test_cases/async/async_deferred.out
@@ -41,41 +41,49 @@ pub const fn op_async_deferred() -> ::deno_core::_ops::OpDecl {
             stringify!(op_async_deferred)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             promise_id: i32,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, promise_id, fast_api_callback_options);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             promise_id: i32,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
@@ -92,20 +100,18 @@ pub const fn op_async_deferred() -> ::deno_core::_ops::OpDecl {
             );
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -122,32 +128,34 @@ pub const fn op_async_deferred() -> ::deno_core::_ops::OpDecl {
             );
             return 2;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_async(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else if res == 1 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/async/async_jsbuffer.out
+++ b/ops/op2/test_cases/async/async_jsbuffer.out
@@ -25,21 +25,19 @@ pub const fn op_async_v8_buffer() -> ::deno_core::_ops::OpDecl {
             stringify!(op_async_v8_buffer)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -50,7 +48,7 @@ pub const fn op_async_v8_buffer() -> ::deno_core::_ops::OpDecl {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -98,32 +96,34 @@ pub const fn op_async_v8_buffer() -> ::deno_core::_ops::OpDecl {
             }
             return 2;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_async(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else if res == 1 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/async/async_lazy.out
+++ b/ops/op2/test_cases/async/async_lazy.out
@@ -41,41 +41,49 @@ pub const fn op_async_lazy() -> ::deno_core::_ops::OpDecl {
             stringify!(op_async_lazy)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             promise_id: i32,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, promise_id, fast_api_callback_options);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             promise_id: i32,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
@@ -92,20 +100,18 @@ pub const fn op_async_lazy() -> ::deno_core::_ops::OpDecl {
             );
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -122,32 +128,34 @@ pub const fn op_async_lazy() -> ::deno_core::_ops::OpDecl {
             );
             return 2;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_async(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else if res == 1 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/async/async_op_metadata.out
+++ b/ops/op2/test_cases/async/async_op_metadata.out
@@ -27,20 +27,18 @@ const fn op_blob_read_part() -> ::deno_core::_ops::OpDecl {
             stringify!(op_blob_read_part)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -60,32 +58,34 @@ const fn op_blob_read_part() -> ::deno_core::_ops::OpDecl {
             }
             return 2;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_async(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else if res == 1 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -129,20 +129,18 @@ const fn op_broadcast_recv() -> ::deno_core::_ops::OpDecl {
             stringify!(op_broadcast_recv)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -162,32 +160,34 @@ const fn op_broadcast_recv() -> ::deno_core::_ops::OpDecl {
             }
             return 2;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_async(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else if res == 1 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/async/async_opstate.out
+++ b/ops/op2/test_cases/async/async_opstate.out
@@ -25,20 +25,18 @@ pub const fn op_async_opstate() -> ::deno_core::_ops::OpDecl {
             stringify!(op_async_opstate)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -63,7 +61,7 @@ pub const fn op_async_opstate() -> ::deno_core::_ops::OpDecl {
                     }
                     Err(err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let err = err.into();
                         let exception = deno_core::error::to_v8_error(
@@ -79,32 +77,34 @@ pub const fn op_async_opstate() -> ::deno_core::_ops::OpDecl {
             }
             return 2;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_async(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else if res == 1 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/async/async_result.out
+++ b/ops/op2/test_cases/async/async_result.out
@@ -25,20 +25,18 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
             stringify!(op_async)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -59,7 +57,7 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                     }
                     Err(err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let err = err.into();
                         let exception = deno_core::error::to_v8_error(
@@ -75,32 +73,34 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
             }
             return 2;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_async(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else if res == 1 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/async/async_result_impl.out
+++ b/ops/op2/test_cases/async/async_result_impl.out
@@ -25,27 +25,25 @@ pub const fn op_async_result_impl() -> ::deno_core::_ops::OpDecl {
             stringify!(op_async_result_impl)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             let result = {
                 let arg0 = args.get(1usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected i32".as_bytes(),
@@ -62,7 +60,7 @@ pub const fn op_async_result_impl() -> ::deno_core::_ops::OpDecl {
             let result = match result {
                 Ok(result) => result,
                 Err(err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let err = err.into();
                     let exception = deno_core::error::to_v8_error(
                         &mut scope,
@@ -89,7 +87,7 @@ pub const fn op_async_result_impl() -> ::deno_core::_ops::OpDecl {
                     }
                     Err(err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let err = err.into();
                         let exception = deno_core::error::to_v8_error(
@@ -105,32 +103,34 @@ pub const fn op_async_result_impl() -> ::deno_core::_ops::OpDecl {
             }
             return 2;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_async(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else if res == 1 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/async/async_result_smi.out
+++ b/ops/op2/test_cases/async/async_result_smi.out
@@ -25,27 +25,25 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
             stringify!(op_async)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             let result = {
                 let arg0 = args.get(1usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected i32".as_bytes(),
@@ -91,7 +89,7 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                     }
                     Err(err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let err = err.into();
                         let exception = deno_core::error::to_v8_error(
@@ -107,32 +105,34 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
             }
             return 2;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_async(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else if res == 1 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/async/async_v8_global.out
+++ b/ops/op2/test_cases/async/async_v8_global.out
@@ -25,21 +25,19 @@ pub const fn op_async_v8_global() -> ::deno_core::_ops::OpDecl {
             stringify!(op_async_v8_global)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -48,7 +46,7 @@ pub const fn op_async_v8_global() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::String,
                 >(arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected String".as_bytes(),
@@ -77,32 +75,34 @@ pub const fn op_async_v8_global() -> ::deno_core::_ops::OpDecl {
             }
             return 2;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_async(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else if res == 1 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/async/async_void.out
+++ b/ops/op2/test_cases/async/async_void.out
@@ -25,20 +25,18 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
             stringify!(op_async)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -58,32 +56,34 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
             }
             return 2;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_async(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else if res == 1 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -41,32 +41,36 @@ const fn op_add() -> ::deno_core::_ops::OpDecl {
             stringify!(op_add)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: u32,
             arg1: u32,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> u32 {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: u32,
             arg1: u32,
@@ -83,23 +87,21 @@ const fn op_add() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected u32".as_bytes(),
@@ -113,7 +115,7 @@ const fn op_add() -> ::deno_core::_ops::OpDecl {
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected u32".as_bytes(),
@@ -130,32 +132,34 @@ const fn op_add() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/add_options.out
+++ b/ops/op2/test_cases/sync/add_options.out
@@ -25,23 +25,21 @@ pub const fn op_test_add_option() -> ::deno_core::_ops::OpDecl {
             stringify!(op_test_add_option)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected u32".as_bytes(),
@@ -59,7 +57,7 @@ pub const fn op_test_add_option() -> ::deno_core::_ops::OpDecl {
                 } else {
                     let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -79,32 +77,34 @@ pub const fn op_test_add_option() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/bigint.out
+++ b/ops/op2/test_cases/sync/bigint.out
@@ -41,30 +41,34 @@ pub const fn op_bigint() -> ::deno_core::_ops::OpDecl {
             stringify!(op_bigint)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> u64 {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
         ) -> u64 {
             #[cfg(debug_assertions)]
@@ -75,47 +79,47 @@ pub const fn op_bigint() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let result = { Self::call() };
             rv.set(deno_core::_ops::RustToV8::to_v8(result, &mut scope));
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/bool.out
+++ b/ops/op2/test_cases/sync/bool.out
@@ -41,31 +41,35 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
             stringify!(op_bool)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: bool,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> bool {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, arg0);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: bool,
         ) -> bool {
@@ -80,19 +84,17 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let arg0 = arg0.is_true();
@@ -101,32 +103,34 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -41,41 +41,49 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
             stringify!(op_bool)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: bool,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> bool {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: bool,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> bool {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
@@ -99,25 +107,23 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             if let Some(err) = unsafe { opctx.unsafely_take_last_error_for_ops_only() } {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                 let err = err.into();
                 let exception = deno_core::error::to_v8_error(
                     &mut scope,
@@ -135,7 +141,7 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
             match result {
                 Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
                 Err(err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let err = err.into();
                     let exception = deno_core::error::to_v8_error(
                         &mut scope,
@@ -148,32 +154,34 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
             };
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -54,34 +54,38 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             stringify!(op_buffers)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
             arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
             arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
             arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
             arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
@@ -134,19 +138,17 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let mut arg0_temp;
@@ -154,7 +156,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -174,7 +176,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                     Ok(arg1) => arg1,
                     Err(arg1_err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -194,7 +196,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                     Ok(arg2) => arg2,
                     Err(arg2_err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -218,7 +220,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                     Ok(arg3) => arg3,
                     Err(arg3_err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -241,32 +243,34 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -335,34 +339,38 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
             stringify!(op_buffers_32)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
             arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
             arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
             arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
             arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
@@ -415,19 +423,17 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let mut arg0_temp;
@@ -435,7 +441,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -455,7 +461,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                     Ok(arg1) => arg1,
                     Err(arg1_err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -475,7 +481,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                     Ok(arg2) => arg2,
                     Err(arg2_err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -499,7 +505,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                     Ok(arg3) => arg3,
                     Err(arg3_err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -522,32 +528,34 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -587,19 +595,17 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
             stringify!(op_buffers_option)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let mut arg0_temp;
@@ -612,7 +618,7 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
                         Ok(arg0) => arg0,
                         Err(arg0_err) => {
                             let mut scope = unsafe {
-                                deno_core::v8::CallbackScope::new(&*info)
+                                deno_core::v8::CallbackScope::new(info)
                             };
                             let msg = deno_core::v8::String::new_from_one_byte(
                                     &mut scope,
@@ -642,7 +648,7 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
                         Ok(arg1) => arg1,
                         Err(arg1_err) => {
                             let mut scope = unsafe {
-                                deno_core::v8::CallbackScope::new(&*info)
+                                deno_core::v8::CallbackScope::new(info)
                             };
                             let msg = deno_core::v8::String::new_from_one_byte(
                                     &mut scope,
@@ -666,32 +672,34 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -52,33 +52,37 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             stringify!(op_buffers)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
             arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
             arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
             arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
@@ -115,19 +119,17 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let mut arg0_temp;
@@ -135,7 +137,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -155,7 +157,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                     Ok(arg1) => arg1,
                     Err(arg1_err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -175,7 +177,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                     Ok(arg2) => arg2,
                     Err(arg2_err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -194,32 +196,34 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -284,32 +288,36 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
             stringify!(op_buffers_32)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
             arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
             arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
@@ -338,19 +346,17 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let mut arg0_temp;
@@ -358,7 +364,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -378,7 +384,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                     Ok(arg1) => arg1,
                     Err(arg1_err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -397,32 +403,34 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/buffers_out.out
+++ b/ops/op2/test_cases/sync/buffers_out.out
@@ -25,20 +25,18 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             stringify!(op_buffers)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let mut arg0_temp;
@@ -46,7 +44,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -77,32 +75,34 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             };
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -144,20 +144,18 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
             stringify!(op_buffers_option)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let mut arg0_temp;
@@ -170,7 +168,7 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
                         Ok(arg0) => arg0,
                         Err(arg0_err) => {
                             let mut scope = unsafe {
-                                deno_core::v8::CallbackScope::new(&*info)
+                                deno_core::v8::CallbackScope::new(info)
                             };
                             let msg = deno_core::v8::String::new_from_one_byte(
                                     &mut scope,
@@ -206,32 +204,34 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
             };
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -273,20 +273,18 @@ const fn op_arraybuffers() -> ::deno_core::_ops::OpDecl {
             stringify!(op_arraybuffers)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let mut arg0_temp;
@@ -294,7 +292,7 @@ const fn op_arraybuffers() -> ::deno_core::_ops::OpDecl {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -321,32 +319,34 @@ const fn op_arraybuffers() -> ::deno_core::_ops::OpDecl {
             );
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/cfg.out
+++ b/ops/op2/test_cases/sync/cfg.out
@@ -43,30 +43,34 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
             stringify!(op_maybe_windows)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
         ) -> () {
             #[cfg(debug_assertions)]
@@ -77,46 +81,46 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let result = { Self::call() };
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -176,30 +180,34 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
             stringify!(op_maybe_windows)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
         ) -> () {
             #[cfg(debug_assertions)]
@@ -210,46 +218,46 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let result = { Self::call() };
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/clippy_allow.out
+++ b/ops/op2/test_cases/sync/clippy_allow.out
@@ -43,30 +43,34 @@ pub const fn op_extra_annotation() -> ::deno_core::_ops::OpDecl {
             stringify!(op_extra_annotation)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
         ) -> () {
             #[cfg(debug_assertions)]
@@ -77,46 +81,46 @@ pub const fn op_extra_annotation() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let result = { Self::call() };
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -174,30 +178,34 @@ pub const fn op_clippy_internal() -> ::deno_core::_ops::OpDecl {
             stringify!(op_clippy_internal)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
         ) -> () {
             #[cfg(debug_assertions)]
@@ -208,46 +216,46 @@ pub const fn op_clippy_internal() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let result = { Self::call() };
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -41,40 +41,48 @@ const fn op_file() -> ::deno_core::_ops::OpDecl {
             stringify!(op_file)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: deno_core::v8::Local<deno_core::v8::Value>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: deno_core::v8::Local<deno_core::v8::Value>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
             let result = {
                 let Some(arg0) = deno_core::cppgc::try_unwrap_cppgc_object::<
                     std::fs::File,
@@ -87,25 +95,23 @@ const fn op_file() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::cppgc::try_unwrap_cppgc_object::<
                     std::fs::File,
                 >(arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected std::fs::File".as_bytes(),
@@ -121,32 +127,34 @@ const fn op_file() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -186,17 +194,15 @@ const fn op_make_cppgc_object() -> ::deno_core::_ops::OpDecl {
             stringify!(op_make_cppgc_object)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let result = { Self::call() };
             rv.set(
                 deno_core::_ops::RustToV8NoScope::to_v8(
@@ -207,32 +213,34 @@ const fn op_make_cppgc_object() -> ::deno_core::_ops::OpDecl {
             );
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -274,21 +282,19 @@ const fn op_make_cppgc_object_async() -> ::deno_core::_ops::OpDecl {
             stringify!(op_make_cppgc_object_async)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -320,32 +326,34 @@ const fn op_make_cppgc_object_async() -> ::deno_core::_ops::OpDecl {
             }
             return 2;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_async(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else if res == 1 {
                 deno_core::_ops::dispatch_metrics_async(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/doc_comment.out
+++ b/ops/op2/test_cases/sync/doc_comment.out
@@ -42,30 +42,34 @@ pub const fn op_has_doc_comment() -> ::deno_core::_ops::OpDecl {
             stringify!(op_has_doc_comment)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
         ) -> () {
             #[cfg(debug_assertions)]
@@ -76,46 +80,46 @@ pub const fn op_has_doc_comment() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let result = { Self::call() };
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/fast_alternative.out
+++ b/ops/op2/test_cases/sync/fast_alternative.out
@@ -25,20 +25,18 @@ const fn op_slow() -> ::deno_core::_ops::OpDecl {
             stringify!(op_slow)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg1 = args.get(0usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
@@ -72,32 +70,34 @@ const fn op_slow() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -155,32 +155,36 @@ const fn op_fast() -> ::deno_core::_ops::OpDecl {
             stringify!(op_fast)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: u32,
             arg1: u32,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> u32 {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: u32,
             arg1: u32,
@@ -197,23 +201,21 @@ const fn op_fast() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected u32".as_bytes(),
@@ -227,7 +229,7 @@ const fn op_fast() -> ::deno_core::_ops::OpDecl {
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected u32".as_bytes(),
@@ -244,32 +246,34 @@ const fn op_fast() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -311,20 +315,18 @@ const fn op_slow_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
             stringify!(op_slow_generic)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg1 = args.get(0usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
@@ -358,32 +360,34 @@ const fn op_slow_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -441,32 +445,36 @@ const fn op_fast_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
             stringify!(op_fast_generic)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: u32,
             arg1: u32,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> u32 {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: u32,
             arg1: u32,
@@ -483,23 +491,21 @@ const fn op_fast_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected u32".as_bytes(),
@@ -513,7 +519,7 @@ const fn op_fast_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected u32".as_bytes(),
@@ -530,32 +536,34 @@ const fn op_fast_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/from_v8.out
+++ b/ops/op2/test_cases/sync/from_v8.out
@@ -25,20 +25,18 @@ pub const fn op_from_v8_arg() -> ::deno_core::_ops::OpDecl {
             stringify!(op_from_v8_arg)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let arg0 = match <Foo as deno_core::FromV8>::from_v8(&mut scope, arg0) {
@@ -59,32 +57,34 @@ pub const fn op_from_v8_arg() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -41,30 +41,34 @@ pub const fn op_generics<T: Trait>() -> ::deno_core::_ops::OpDecl {
             stringify!(op_generics)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
         ) -> () {
             #[cfg(debug_assertions)]
@@ -75,46 +79,46 @@ pub const fn op_generics<T: Trait>() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let result = { Self::call() };
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -170,30 +174,34 @@ pub const fn op_generics_static<T: Trait + 'static>() -> ::deno_core::_ops::OpDe
             stringify!(op_generics_static)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
         ) -> () {
             #[cfg(debug_assertions)]
@@ -204,46 +212,46 @@ pub const fn op_generics_static<T: Trait + 'static>() -> ::deno_core::_ops::OpDe
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let result = { Self::call() };
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -299,30 +307,34 @@ pub const fn op_generics_static_where<T: Trait + 'static>() -> ::deno_core::_ops
             stringify!(op_generics_static_where)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
         ) -> () {
             #[cfg(debug_assertions)]
@@ -333,46 +345,46 @@ pub const fn op_generics_static_where<T: Trait + 'static>() -> ::deno_core::_ops
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let result = { Self::call() };
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/nofast.out
+++ b/ops/op2/test_cases/sync/nofast.out
@@ -25,23 +25,21 @@ const fn op_nofast() -> ::deno_core::_ops::OpDecl {
             stringify!(op_nofast)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected u32".as_bytes(),
@@ -55,7 +53,7 @@ const fn op_nofast() -> ::deno_core::_ops::OpDecl {
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected u32".as_bytes(),
@@ -72,32 +70,34 @@ const fn op_nofast() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/op_state_attr.out
+++ b/ops/op2/test_cases/sync/op_state_attr.out
@@ -41,39 +41,47 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
             stringify!(op_state_rc)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
@@ -89,20 +97,18 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -117,32 +123,34 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/op_state_rc.out
+++ b/ops/op2/test_cases/sync/op_state_rc.out
@@ -41,39 +41,47 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
             stringify!(op_state_rc)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
@@ -86,20 +94,18 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -111,32 +117,34 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -41,39 +41,47 @@ const fn op_state_ref() -> ::deno_core::_ops::OpDecl {
             stringify!(op_state_ref)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
@@ -86,20 +94,18 @@ const fn op_state_ref() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -111,32 +117,34 @@ const fn op_state_ref() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -192,39 +200,47 @@ const fn op_state_mut() -> ::deno_core::_ops::OpDecl {
             stringify!(op_state_mut)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
@@ -237,20 +253,18 @@ const fn op_state_mut() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -262,32 +276,34 @@ const fn op_state_mut() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -327,20 +343,18 @@ const fn op_state_and_v8() -> ::deno_core::_ops::OpDecl {
             stringify!(op_state_and_v8)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -351,7 +365,7 @@ const fn op_state_and_v8() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::Function,
                 >(arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected Function".as_bytes(),
@@ -369,32 +383,34 @@ const fn op_state_and_v8() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -450,41 +466,49 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
             stringify!(op_state_and_v8_local)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg1: deno_core::v8::Local<deno_core::v8::Value>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, arg1, fast_api_callback_options);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg1: deno_core::v8::Local<deno_core::v8::Value>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
@@ -504,20 +528,18 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -527,7 +549,7 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::Function,
                 >(arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected Function".as_bytes(),
@@ -545,32 +567,34 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/result_external.out
+++ b/ops/op2/test_cases/sync/result_external.out
@@ -41,39 +41,47 @@ pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
             stringify!(op_external_with_result)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> *mut ::std::ffi::c_void {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> *mut ::std::ffi::c_void {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
@@ -94,29 +102,27 @@ pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             if let Some(err) = unsafe { opctx.unsafely_take_last_error_for_ops_only() } {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                    &*info
-                });
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                    info,
+                );
                 let err = err.into();
                 let exception = deno_core::error::to_v8_error(
                     &mut scope,
@@ -132,9 +138,9 @@ pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
                     rv.set(deno_core::_ops::RustToV8::to_v8(result, &mut scope))
                 }
                 Err(err) => {
-                    let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                        &*info
-                    });
+                    let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                        info,
+                    );
                     let err = err.into();
                     let exception = deno_core::error::to_v8_error(
                         &mut scope,
@@ -147,32 +153,34 @@ pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
             };
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -41,39 +41,47 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
             stringify!(op_u32_with_result)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> u32 {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> u32 {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
@@ -94,28 +102,26 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             if let Some(err) = unsafe { opctx.unsafely_take_last_error_for_ops_only() } {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                    &*info
-                });
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                    info,
+                );
                 let err = err.into();
                 let exception = deno_core::error::to_v8_error(
                     &mut scope,
@@ -129,10 +135,10 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
             match result {
                 Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
                 Err(err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                        &*info
-                    });
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+                    let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                        info,
+                    );
                     let err = err.into();
                     let exception = deno_core::error::to_v8_error(
                         &mut scope,
@@ -145,32 +151,34 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
             };
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/result_scope.out
+++ b/ops/op2/test_cases/sync/result_scope.out
@@ -25,20 +25,18 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
             stringify!(op_void_with_result)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = &mut scope;
                 Self::call(arg0)
@@ -46,7 +44,7 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
             match result {
                 Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
                 Err(err) => {
-                    let opctx = unsafe {
+                    let opctx: &'s _ = unsafe {
                         &*(deno_core::v8::Local::<
                             deno_core::v8::External,
                         >::cast(args.data())
@@ -64,32 +62,34 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
             };
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -41,39 +41,47 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
             stringify!(op_void_with_result)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
@@ -94,28 +102,26 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             if let Some(err) = unsafe { opctx.unsafely_take_last_error_for_ops_only() } {
-                let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                    &*info
-                });
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                    info,
+                );
                 let err = err.into();
                 let exception = deno_core::error::to_v8_error(
                     &mut scope,
@@ -129,10 +135,10 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
             match result {
                 Ok(result) => deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv),
                 Err(err) => {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-                    let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                        &*info
-                    });
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+                    let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                        info,
+                    );
                     let err = err.into();
                     let exception = deno_core::error::to_v8_error(
                         &mut scope,
@@ -145,32 +151,34 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
             };
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/serde_v8.out
+++ b/ops/op2/test_cases/sync/serde_v8.out
@@ -25,20 +25,18 @@ pub const fn op_serde_v8() -> ::deno_core::_ops::OpDecl {
             stringify!(op_serde_v8)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let arg0 = match deno_core::_ops::serde_v8_to_rust(&mut scope, arg0) {
@@ -77,32 +75,34 @@ pub const fn op_serde_v8() -> ::deno_core::_ops::OpDecl {
             };
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -48,34 +48,38 @@ const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
             stringify!(op_smi_unsigned_return)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: i32,
             arg1: i32,
             arg2: i32,
             arg3: i32,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> i32 {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: i32,
             arg1: i32,
@@ -96,23 +100,21 @@ const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected i32".as_bytes(),
@@ -126,7 +128,7 @@ const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_i32_option(&arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected i32".as_bytes(),
@@ -140,7 +142,7 @@ const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
                 let arg1 = arg1 as _;
                 let arg2 = args.get(2usize as i32);
                 let Some(arg2) = deno_core::_ops::to_i32_option(&arg2) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected i32".as_bytes(),
@@ -154,7 +156,7 @@ const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
                 let arg2 = arg2 as _;
                 let arg3 = args.get(3usize as i32);
                 let Some(arg3) = deno_core::_ops::to_i32_option(&arg3) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected i32".as_bytes(),
@@ -177,32 +179,34 @@ const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
             );
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -267,34 +271,38 @@ const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
             stringify!(op_smi_signed_return)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: i32,
             arg1: i32,
             arg2: i32,
             arg3: i32,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> i32 {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: i32,
             arg1: i32,
@@ -315,23 +323,21 @@ const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected i32".as_bytes(),
@@ -345,7 +351,7 @@ const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_i32_option(&arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected i32".as_bytes(),
@@ -359,7 +365,7 @@ const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
                 let arg1 = arg1 as _;
                 let arg2 = args.get(2usize as i32);
                 let Some(arg2) = deno_core::_ops::to_i32_option(&arg2) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected i32".as_bytes(),
@@ -373,7 +379,7 @@ const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
                 let arg2 = arg2 as _;
                 let arg3 = args.get(3usize as i32);
                 let Some(arg3) = deno_core::_ops::to_i32_option(&arg3) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected i32".as_bytes(),
@@ -396,32 +402,34 @@ const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
             );
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -463,19 +471,17 @@ const fn op_smi_option() -> ::deno_core::_ops::OpDecl {
             stringify!(op_smi_option)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let arg0 = if arg0.is_null_or_undefined() {
@@ -483,7 +489,7 @@ const fn op_smi_option() -> ::deno_core::_ops::OpDecl {
                 } else {
                     let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -503,32 +509,34 @@ const fn op_smi_option() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/string_cow.out
+++ b/ops/op2/test_cases/sync/string_cow.out
@@ -41,31 +41,35 @@ const fn op_string_cow() -> ::deno_core::_ops::OpDecl {
             stringify!(op_string_cow)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> u32 {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, arg0);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
         ) -> u32 {
@@ -86,20 +90,18 @@ const fn op_string_cow() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -115,32 +117,34 @@ const fn op_string_cow() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/string_onebyte.out
+++ b/ops/op2/test_cases/sync/string_onebyte.out
@@ -41,31 +41,35 @@ const fn op_string_onebyte() -> ::deno_core::_ops::OpDecl {
             stringify!(op_string_onebyte)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> u32 {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, arg0);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
         ) -> u32 {
@@ -80,20 +84,18 @@ const fn op_string_onebyte() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -104,7 +106,7 @@ const fn op_string_onebyte() -> ::deno_core::_ops::OpDecl {
                     Ok(arg0) => arg0,
                     Err(arg0) => {
                         let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(&*info)
+                            deno_core::v8::CallbackScope::new(info)
                         };
                         let msg = deno_core::v8::String::new_from_one_byte(
                                 &mut scope,
@@ -122,32 +124,34 @@ const fn op_string_onebyte() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/string_option_return.out
+++ b/ops/op2/test_cases/sync/string_option_return.out
@@ -25,20 +25,18 @@ pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
             stringify!(op_string_return)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let arg0 = if arg0.is_null_or_undefined() {
@@ -63,32 +61,34 @@ pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
             };
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/string_owned.out
+++ b/ops/op2/test_cases/sync/string_owned.out
@@ -41,31 +41,35 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
             stringify!(op_string_owned)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> u32 {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, arg0);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
         ) -> u32 {
@@ -80,20 +84,18 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -106,32 +108,34 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/string_ref.out
+++ b/ops/op2/test_cases/sync/string_ref.out
@@ -41,31 +41,35 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
             stringify!(op_string_owned)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> u32 {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, arg0);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: *mut deno_core::v8::fast_api::FastApiOneByteString,
         ) -> u32 {
@@ -86,20 +90,18 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
@@ -115,32 +117,34 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/string_return.out
+++ b/ops/op2/test_cases/sync/string_return.out
@@ -25,17 +25,15 @@ pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
             stringify!(op_string_return)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let result = { Self::call() };
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
@@ -52,32 +50,34 @@ pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
             };
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -119,17 +119,15 @@ pub const fn op_string_return_ref() -> ::deno_core::_ops::OpDecl {
             stringify!(op_string_return_ref)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let result = { Self::call() };
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
@@ -146,32 +144,34 @@ pub const fn op_string_return_ref() -> ::deno_core::_ops::OpDecl {
             };
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }
@@ -213,17 +213,15 @@ pub const fn op_string_return_cow() -> ::deno_core::_ops::OpDecl {
             stringify!(op_string_return_cow)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let result = { Self::call() };
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
@@ -240,32 +238,34 @@ pub const fn op_string_return_cow() -> ::deno_core::_ops::OpDecl {
             };
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/to_v8.out
+++ b/ops/op2/test_cases/sync/to_v8.out
@@ -25,17 +25,15 @@ pub const fn op_to_v8_return() -> ::deno_core::_ops::OpDecl {
             stringify!(op_to_v8_return)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
             let result = { Self::call() };
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(
                 deno_core::_ops::RustToV8Marker::<
@@ -58,32 +56,34 @@ pub const fn op_to_v8_return() -> ::deno_core::_ops::OpDecl {
             };
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/v8_global.out
+++ b/ops/op2/test_cases/sync/v8_global.out
@@ -25,26 +25,24 @@ pub const fn op_global() -> ::deno_core::_ops::OpDecl {
             stringify!(op_global)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::String,
                 >(arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected String".as_bytes(),
@@ -61,32 +59,34 @@ pub const fn op_global() -> ::deno_core::_ops::OpDecl {
             rv.set(deno_core::_ops::RustToV8::to_v8(result, &mut scope));
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/v8_handlescope.out
+++ b/ops/op2/test_cases/sync/v8_handlescope.out
@@ -25,20 +25,18 @@ const fn op_handlescope() -> ::deno_core::_ops::OpDecl {
             stringify!(op_handlescope)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg1 = args.get(0usize as i32);
                 let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
@@ -61,32 +59,34 @@ const fn op_handlescope() -> ::deno_core::_ops::OpDecl {
             rv.set(deno_core::_ops::RustToV8NoScope::to_v8(result));
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/v8_lifetime.out
+++ b/ops/op2/test_cases/sync/v8_lifetime.out
@@ -25,25 +25,23 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
             stringify!(op_v8_lifetime)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::String,
                 >(arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected String".as_bytes(),
@@ -60,32 +58,34 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
             rv.set(deno_core::_ops::RustToV8NoScope::to_v8(result));
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -51,42 +51,50 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
             stringify!(op_v8_lifetime)
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast_metrics(
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: deno_core::v8::Local<deno_core::v8::Value>,
             arg1: deno_core::v8::Local<deno_core::v8::Value>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
-            let opctx = unsafe {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<
                     deno_core::v8::External,
                 >::cast(unsafe { fast_api_callback_options.data.data })
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::v8_fn_ptr_fast(this, arg0, arg1, fast_api_callback_options);
             deno_core::_ops::dispatch_metrics_fast(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
             );
             res
         }
         #[allow(clippy::too_many_arguments)]
-        extern "C" fn v8_fn_ptr_fast(
+        extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
             arg0: deno_core::v8::Local<deno_core::v8::Value>,
             arg1: deno_core::v8::Local<deno_core::v8::Value>,
-            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let fast_api_callback_options = unsafe { &mut *fast_api_callback_options };
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
             let result = {
                 let Ok(mut arg0) = deno_core::_ops::v8_try_convert_option::<
                     deno_core::v8::String,
@@ -113,25 +121,23 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
             result as _
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Ok(mut arg0) = deno_core::_ops::v8_try_convert_option::<
                     deno_core::v8::String,
                 >(arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected String".as_bytes(),
@@ -150,7 +156,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg1) = deno_core::_ops::v8_try_convert_option::<
                     deno_core::v8::String,
                 >(arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected String".as_bytes(),
@@ -170,32 +176,34 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
             deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases/sync/v8_string.out
+++ b/ops/op2/test_cases/sync/v8_string.out
@@ -25,25 +25,23 @@ const fn op_v8_string() -> ::deno_core::_ops::OpDecl {
             stringify!(op_v8_string)
         }
         #[inline(always)]
-        fn slow_function_impl(
-            info: *const deno_core::v8::FunctionCallbackInfo,
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
         ) -> usize {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
-            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(unsafe {
-                &*info
-            });
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::String,
                 >(arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected String".as_bytes(),
@@ -59,7 +57,7 @@ const fn op_v8_string() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::String,
                 >(arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(&*info) };
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
                             &mut scope,
                             "expected String".as_bytes(),
@@ -76,32 +74,34 @@ const fn op_v8_string() -> ::deno_core::_ops::OpDecl {
             rv.set(deno_core::_ops::RustToV8NoScope::to_v8(result));
             return 0;
         }
-        extern "C" fn v8_fn_ptr(info: *const deno_core::v8::FunctionCallbackInfo) {
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
             Self::slow_function_impl(info);
         }
-        extern "C" fn v8_fn_ptr_metrics(
+        extern "C" fn v8_fn_ptr_metrics<'s>(
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(unsafe {
-                &*info
-            });
-            let opctx = unsafe {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
                 &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
                     .value() as *const deno_core::_ops::OpCtx)
             };
             deno_core::_ops::dispatch_metrics_slow(
-                &opctx,
+                opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
             let res = Self::slow_function_impl(info);
             if res == 0 {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Completed,
                 );
             } else {
                 deno_core::_ops::dispatch_metrics_slow(
-                    &opctx,
+                    opctx,
                     deno_core::_ops::OpMetricsEvent::Error,
                 );
             }

--- a/ops/op2/test_cases_fail/lifetimes.rs
+++ b/ops/op2/test_cases_fail/lifetimes.rs
@@ -1,0 +1,13 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+#![deny(warnings)]
+deno_ops_compile_test_runner::prelude!();
+use deno_core::error::AnyError;
+use std::future::Future;
+
+struct Wrap;
+
+#[op2(fast)]
+fn op_use_cppgc_object(#[cppgc] _wrap: &'static Wrap) {}
+
+#[op2(fast)]
+fn op_use_buffer(#[buffer] _buffer: &'static [u8]) {}

--- a/ops/op2/test_cases_fail/lifetimes.stderr
+++ b/ops/op2/test_cases_fail/lifetimes.stderr
@@ -1,0 +1,56 @@
+error: unused import: `deno_core::error::AnyError`
+ --> ../op2/test_cases_fail/lifetimes.rs:4:5
+  |
+4 | use deno_core::error::AnyError;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+note: the lint level is defined here
+ --> ../op2/test_cases_fail/lifetimes.rs:2:9
+  |
+2 | #![deny(warnings)]
+  |         ^^^^^^^^
+  = note: `#[deny(unused_imports)]` implied by `#[deny(warnings)]`
+
+error: unused import: `std::future::Future`
+ --> ../op2/test_cases_fail/lifetimes.rs:5:5
+  |
+5 | use std::future::Future;
+  |     ^^^^^^^^^^^^^^^^^^^
+
+error[E0521]: borrowed data escapes outside of associated function
+ --> ../op2/test_cases_fail/lifetimes.rs:9:1
+  |
+9 | #[op2(fast)]
+  | ^^^^^^^^^^^^
+  | |
+  | `arg0` is a reference that is only valid in the associated function body
+  | `arg0` escapes the associated function body here
+  | has type `Local<'1, deno_core::v8::Value>`
+  | argument requires that `'1` must outlive `'static`
+  |
+  = note: this error originates in the attribute macro `op2` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0521]: borrowed data escapes outside of associated function
+ --> ../op2/test_cases_fail/lifetimes.rs:9:1
+  |
+9 | #[op2(fast)]
+  | ^^^^^^^^^^^^
+  | |
+  | `info` is a reference that is only valid in the associated function body
+  | `info` escapes the associated function body here
+  | lifetime `'s` defined here
+  | argument requires that `'s` must outlive `'static`
+  |
+  = note: this error originates in the attribute macro `op2` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0597]: `arg0_temp` does not live long enough
+  --> ../op2/test_cases_fail/lifetimes.rs:12:1
+   |
+12 | #[op2(fast)]
+   | ^^^^^^^^^^^-
+   | |          |
+   | |          `arg0_temp` dropped here while still borrowed
+   | borrowed value does not live long enough
+   | argument requires that `arg0_temp` is borrowed for `'static`
+   |
+   = note: this error originates in the attribute macro `op2` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Previously cppgc objects were not correctly rooted
during async ops. This commit fixes that.

It also improves lifetimes in the generated op
code. This results in the compiler being able to
reason about lifetimes of function arguments
correctly, preventing compilation of incorrect
code. Previously `#[op2] async fn foo(a: &mut HandleScope)`
would compile for example, even though it is not
safe.
