### PR TITLE
Allow `#[cppgc] &mut T` in sync ops

### DIFF
--- a/core/cppgc.rs
+++ b/core/cppgc.rs
@@ -43,6 +43,7 @@ pub fn make_cppgc_object<'a, T: GcResource + 'static>(
   obj
 }
 
+// TODO(littledivy): https://github.com/denoland/rusty_v8/pull/1505
 #[repr(C)]
 struct InnerMember {
   inner: [usize; 2],

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -1953,18 +1953,18 @@ mod tests {
   {
     run_async_test(
       10,
-      "op_test_make_cppgc_resource, op_test_get_cppgc_resource, op_test_get_cppgc_resource_option, op_test_make_cppgc_resource_option",
+      "op_test_make_cppgc_resource, op_test_get_cppgc_resource, op_test_get_cppgc_resource_option, op_test_make_cppgc_resource_option, op_test_set_cppgc_resource",
       r"
       const resource = op_test_make_cppgc_resource();
       assert((await op_test_get_cppgc_resource(resource)) === 42);
       assert(op_test_get_cppgc_resource_option(resource) === 42);
-      op_test_set_cppgc_resource(resource, 43);
-      assert(op_test_get_cppgc_resource(resource) == 43);
       assert(op_test_get_cppgc_resource_option(null) === 0);
       const resource2 = op_test_make_cppgc_resource_option(false);
       assert(resource2 === null);
       const resource3 = op_test_make_cppgc_resource_option(true);
-      assert((await op_test_get_cppgc_resource(resource3)) === 42);",
+      assert((await op_test_get_cppgc_resource(resource3)) === 42);
+      op_test_set_cppgc_resource(resource, 43);
+      assert((await op_test_get_cppgc_resource(resource)) == 43);"
     ).await?;
     Ok(())
   }

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -608,6 +608,7 @@ mod tests {
       op_arraybuffer_slice,
       op_test_get_cppgc_resource,
       op_test_make_cppgc_resource,
+      op_test_set_cppgc_resource,
       op_external_make,
       op_external_process,
       op_external_make_ptr,
@@ -1907,14 +1908,24 @@ mod tests {
     resource.value
   }
 
+  #[op2(fast)]
+  pub fn op_test_set_cppgc_resource(
+    #[cppgc] resource: &mut TestResource,
+    value: u32,
+  ) {
+    resource.value = value;
+  }
+
   #[test]
   pub fn test_op_cppgc_object() -> Result<(), Box<dyn std::error::Error>> {
     run_test2(
       10,
-      "op_test_make_cppgc_resource, op_test_get_cppgc_resource",
+      "op_test_make_cppgc_resource, op_test_get_cppgc_resource, op_test_set_cppgc_resource",
       r"
       const resource = op_test_make_cppgc_resource();
-      assert(op_test_get_cppgc_resource(resource) == 42);",
+      assert(op_test_get_cppgc_resource(resource) == 42);
+      op_test_set_cppgc_resource(resource, 43);
+      assert(op_test_get_cppgc_resource(resource) == 43);",
     )?;
     Ok(())
   }

--- a/ops/op2/dispatch_async.rs
+++ b/ops/op2/dispatch_async.rs
@@ -47,7 +47,7 @@ pub(crate) fn generate_dispatch_async(
   let mut output = TokenStream::new();
 
   let with_self = if generator_state.needs_self {
-    with_self(generator_state, &signature.ret_val)
+    with_self(generator_state, true, &signature.ret_val)
       .map_err(V8SignatureMappingError::NoSelfMapping)?
   } else {
     quote!()

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -748,22 +748,16 @@ fn map_v8_fastcall_arg_to_arg(
         };
       }
     }
-    Arg::OptionCppGcResource(ty, mut_ref) => {
+    Arg::OptionCppGcResource(ty) => {
       let ty =
         syn::parse_str::<syn::Path>(ty).expect("Failed to reparse state type");
-
-      let deref = if *mut_ref {
-        quote!(#arg_ident)
-      } else {
-        quote!(#arg_ident as _)
-      };
 
       *needs_fast_api_callback_options = true;
       quote! {
         let #arg_ident = if #arg_ident.is_null_or_undefined() {
           None
         } else if let Some(#arg_ident) = deno_core::_ops::try_unwrap_cppgc_object::<#ty>(#arg_ident) {
-          Some(#deref)
+          Some(#arg_ident as _)
         } else {
           #fast_api_callback_options.fallback = true;
           // SAFETY: All fast return types have zero as a valid value

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -593,7 +593,7 @@ pub fn from_arg(
         }
       }
     }
-    Arg::OptionCppGcResource(ty, mut_ref) => {
+    Arg::OptionCppGcResource(ty) => {
       let throw_exception =
         throw_type_error(generator_state, format!("expected {}", &ty))?;
       let ty =
@@ -615,17 +615,11 @@ pub fn from_arg(
           .push((arg_ident.clone(), true));
         tokens
       } else {
-        let deref = if *mut_ref {
-          quote!(#arg_ident)
-        } else {
-          quote!(#arg_ident.deref())
-        };
-
         quote! {
           let #arg_ident = if #arg_ident.is_null_or_undefined() {
             None
           } else if let Some(#arg_ident) = deno_core::_ops::try_unwrap_cppgc_object::<#ty>(#arg_ident) {
-            Some(#deref)
+            Some(#arg_ident as _)
           } else {
             #throw_exception;
           };

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -92,7 +92,7 @@ pub(crate) fn generate_dispatch_slow(
   )?);
 
   let with_self = if generator_state.needs_self {
-    with_self(generator_state, &signature.ret_val)
+    with_self(generator_state, false, &signature.ret_val)
       .map_err(V8SignatureMappingError::NoSelfMapping)?
   } else {
     quote!()
@@ -246,6 +246,7 @@ pub(crate) fn with_js_runtime_state(
 
 pub(crate) fn with_self(
   generator_state: &mut GeneratorState,
+  is_async: bool,
   ret_val: &RetVal,
 ) -> Result<TokenStream, V8MappingError> {
   generator_state.needs_opctx = true;
@@ -254,6 +255,7 @@ pub(crate) fn with_self(
     format!("expected {}", &generator_state.self_ty),
   )?;
   let tokens = if matches!(ret_val, RetVal::Future(_) | RetVal::FutureResult(_))
+    || is_async
   {
     let tokens = gs_quote!(generator_state(self_ty, fn_args, scope) => {
       let Some(self_) = deno_core::_ops::CppGcObjectGuard::<#self_ty>::try_new_from_cppgc_object(&mut *#scope, #fn_args.this().into()) else {

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -1470,12 +1470,10 @@ fn parse_type_state(ty: &Type) -> Result<Arg, ArgError> {
 
 fn parse_cppgc(position: Position, ty: &Type) -> Result<Arg, ArgError> {
   match (position, ty) {
-    (Position::Arg, Type::Reference(of)) if of.mutability.is_none() => {
-      match &*of.elem {
-        Type::Path(of) => Ok(Arg::CppGcResource(stringify_token(&of.path))),
-        _ => Err(ArgError::InvalidCppGcType(stringify_token(ty))),
-      }
-    }
+    (Position::Arg, Type::Reference(of)) => match &*of.elem {
+      Type::Path(of) => Ok(Arg::CppGcResource(stringify_token(&of.path))),
+      _ => Err(ArgError::InvalidCppGcType(stringify_token(ty))),
+    },
     (Position::RetVal, Type::Path(of)) => {
       Ok(Arg::CppGcResource(stringify_token(&of.path)))
     }

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -252,3 +252,170 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
     }
     <op_use_cppgc_object as ::deno_core::_ops::Op>::DECL
 }
+
+#[allow(non_camel_case_types)]
+const fn op_use_cppgc_object_mut() -> ::deno_core::_ops::OpDecl {
+    #[allow(non_camel_case_types)]
+    struct op_use_cppgc_object_mut {
+        _unconstructable: ::std::marker::PhantomData<()>,
+    }
+    impl ::deno_core::_ops::Op for op_use_cppgc_object_mut {
+        const NAME: &'static str = stringify!(op_use_cppgc_object_mut);
+        const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+            ::deno_core::__op_name_fast!(op_use_cppgc_object_mut),
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
+    }
+    impl op_use_cppgc_object_mut {
+        pub const fn name() -> &'static str {
+            stringify!(op_use_cppgc_object_mut)
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: deno_core::v8::Local<deno_core::v8::Value>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
+        ) -> () {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
+            deno_core::_ops::dispatch_metrics_fast(
+                opctx,
+                deno_core::_ops::OpMetricsEvent::Completed,
+            );
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast<'s>(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: deno_core::v8::Local<deno_core::v8::Value>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let result = {
+                let Some(arg0) = deno_core::cppgc::try_unwrap_cppgc_object::<Wrap>(arg0)
+                else {
+                    fast_api_callback_options.fallback = true;
+                    return unsafe { std::mem::zeroed() };
+                };
+                Self::call(arg0)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let Some(arg0) = deno_core::cppgc::try_unwrap_cppgc_object::<Wrap>(arg0)
+                else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected Wrap".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                Self::call(arg0)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics<'s>(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_slow(
+                opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+    }
+    impl op_use_cppgc_object_mut {
+        #[inline(always)]
+        fn call(_wrap: &mut Wrap) {}
+    }
+    <op_use_cppgc_object_mut as ::deno_core::_ops::Op>::DECL
+}

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -256,7 +256,7 @@ const fn op_option_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 } else if let Some(arg0) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Wrap,
                 >(arg0) {
-                    Some(arg0)
+                    Some(arg0 as _)
                 } else {
                     fast_api_callback_options.fallback = true;
                     return unsafe { std::mem::zeroed() };
@@ -284,7 +284,7 @@ const fn op_option_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 } else if let Some(arg0) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Wrap,
                 >(arg0) {
-                    Some(arg0)
+                    Some(arg0 as _)
                 } else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
@@ -600,7 +600,6 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
 }
 
 #[allow(non_camel_case_types)]
-<<<<<<< HEAD
 const fn op_use_cppgc_object_mut() -> ::deno_core::_ops::OpDecl {
     #[allow(non_camel_case_types)]
     struct op_use_cppgc_object_mut {
@@ -610,7 +609,164 @@ const fn op_use_cppgc_object_mut() -> ::deno_core::_ops::OpDecl {
         const NAME: &'static str = stringify!(op_use_cppgc_object_mut);
         const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
             ::deno_core::__op_name_fast!(op_use_cppgc_object_mut),
-=======
+            false,
+            false,
+            1usize as u8,
+            Self::v8_fn_ptr as _,
+            Self::v8_fn_ptr_metrics as _,
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast as *const ::std::ffi::c_void,
+                )
+            }),
+            Some({
+                use deno_core::v8::fast_api::Type;
+                use deno_core::v8::fast_api::CType;
+                deno_core::v8::fast_api::FastFunction::new_with_bigint(
+                    &[Type::V8Value, Type::V8Value, Type::CallbackOptions],
+                    CType::Void,
+                    Self::v8_fn_ptr_fast_metrics as *const ::std::ffi::c_void,
+                )
+            }),
+            ::deno_core::OpMetadata {
+                ..::deno_core::OpMetadata::default()
+            },
+        );
+    }
+    impl op_use_cppgc_object_mut {
+        pub const fn name() -> &'static str {
+            stringify!(op_use_cppgc_object_mut)
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast_metrics<'s>(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: deno_core::v8::Local<deno_core::v8::Value>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
+        ) -> () {
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let opctx: &'s _ = unsafe {
+                &*(deno_core::v8::Local::<
+                    deno_core::v8::External,
+                >::cast(unsafe { fast_api_callback_options.data.data })
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_fast(
+                opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
+            deno_core::_ops::dispatch_metrics_fast(
+                opctx,
+                deno_core::_ops::OpMetricsEvent::Completed,
+            );
+            res
+        }
+        #[allow(clippy::too_many_arguments)]
+        extern "C" fn v8_fn_ptr_fast<'s>(
+            this: deno_core::v8::Local<deno_core::v8::Object>,
+            arg0: deno_core::v8::Local<deno_core::v8::Value>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
+        ) -> () {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
+            let result = {
+                let Some(arg0) = deno_core::_ops::try_unwrap_cppgc_object::<Wrap>(arg0)
+                else {
+                    fast_api_callback_options.fallback = true;
+                    return unsafe { std::mem::zeroed() };
+                };
+                Self::call(arg0)
+            };
+            result as _
+        }
+        #[inline(always)]
+        fn slow_function_impl<'s>(
+            info: &'s deno_core::v8::FunctionCallbackInfo,
+        ) -> usize {
+            #[cfg(debug_assertions)]
+            let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                &<Self as deno_core::_ops::Op>::DECL,
+            );
+            let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(info);
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let result = {
+                let arg0 = args.get(0usize as i32);
+                let Some(arg0) = deno_core::_ops::try_unwrap_cppgc_object::<Wrap>(arg0)
+                else {
+                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected Wrap".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                Self::call(arg0)
+            };
+            deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+            return 0;
+        }
+        extern "C" fn v8_fn_ptr<'s>(info: *const deno_core::v8::FunctionCallbackInfo) {
+            let info: &'s _ = unsafe { &*info };
+            Self::slow_function_impl(info);
+        }
+        extern "C" fn v8_fn_ptr_metrics<'s>(
+            info: *const deno_core::v8::FunctionCallbackInfo,
+        ) {
+            let info: &'s _ = unsafe { &*info };
+            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                info,
+            );
+            let opctx: &'s _ = unsafe {
+                &*(deno_core::v8::Local::<deno_core::v8::External>::cast(args.data())
+                    .value() as *const deno_core::_ops::OpCtx)
+            };
+            deno_core::_ops::dispatch_metrics_slow(
+                opctx,
+                deno_core::_ops::OpMetricsEvent::Dispatched,
+            );
+            let res = Self::slow_function_impl(info);
+            if res == 0 {
+                deno_core::_ops::dispatch_metrics_slow(
+                    opctx,
+                    deno_core::_ops::OpMetricsEvent::Completed,
+                );
+            } else {
+                deno_core::_ops::dispatch_metrics_slow(
+                    opctx,
+                    deno_core::_ops::OpMetricsEvent::Error,
+                );
+            }
+        }
+    }
+    impl op_use_cppgc_object_mut {
+        #[inline(always)]
+        fn call(_wrap: &mut Wrap) {}
+    }
+    <op_use_cppgc_object_mut as ::deno_core::_ops::Op>::DECL
+}
+
+#[allow(non_camel_case_types)]
 const fn op_make_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
     #[allow(non_camel_case_types)]
     struct op_make_cppgc_object_option {
@@ -713,7 +869,6 @@ const fn op_use_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
         const NAME: &'static str = stringify!(op_use_cppgc_object_option);
         const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
             ::deno_core::__op_name_fast!(op_use_cppgc_object_option),
->>>>>>> f9766abf7a60f891fc809f9b3f53d78706545677
             false,
             false,
             1usize as u8,
@@ -742,15 +897,9 @@ const fn op_use_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
             },
         );
     }
-<<<<<<< HEAD
-    impl op_use_cppgc_object_mut {
-        pub const fn name() -> &'static str {
-            stringify!(op_use_cppgc_object_mut)
-=======
     impl op_use_cppgc_object_option {
         pub const fn name() -> &'static str {
             stringify!(op_use_cppgc_object_option)
->>>>>>> f9766abf7a60f891fc809f9b3f53d78706545677
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics<'s>(
@@ -796,11 +945,7 @@ const fn op_use_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
                 &mut *fast_api_callback_options
             };
             let result = {
-<<<<<<< HEAD
-                let Some(arg0) = deno_core::cppgc::try_unwrap_cppgc_object::<Wrap>(arg0)
-=======
                 let Some(arg0) = deno_core::_ops::try_unwrap_cppgc_object::<Wrap>(arg0)
->>>>>>> f9766abf7a60f891fc809f9b3f53d78706545677
                 else {
                     fast_api_callback_options.fallback = true;
                     return unsafe { std::mem::zeroed() };
@@ -823,11 +968,7 @@ const fn op_use_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
             );
             let result = {
                 let arg0 = args.get(0usize as i32);
-<<<<<<< HEAD
-                let Some(arg0) = deno_core::cppgc::try_unwrap_cppgc_object::<Wrap>(arg0)
-=======
                 let Some(arg0) = deno_core::_ops::try_unwrap_cppgc_object::<Wrap>(arg0)
->>>>>>> f9766abf7a60f891fc809f9b3f53d78706545677
                 else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
                     let msg = deno_core::v8::String::new_from_one_byte(
@@ -878,17 +1019,9 @@ const fn op_use_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
             }
         }
     }
-<<<<<<< HEAD
-    impl op_use_cppgc_object_mut {
-        #[inline(always)]
-        fn call(_wrap: &mut Wrap) {}
-    }
-    <op_use_cppgc_object_mut as ::deno_core::_ops::Op>::DECL
-=======
     impl op_use_cppgc_object_option {
         #[inline(always)]
         fn call(_wrap: &Wrap) {}
     }
     <op_use_cppgc_object_option as ::deno_core::_ops::Op>::DECL
->>>>>>> f9766abf7a60f891fc809f9b3f53d78706545677
 }

--- a/ops/op2/test_cases/sync/cppgc_resource.rs
+++ b/ops/op2/test_cases/sync/cppgc_resource.rs
@@ -12,3 +12,6 @@ fn op_make_cppgc_object() -> Wrap {
 
 #[op2(fast)]
 fn op_use_cppgc_object(#[cppgc] _wrap: &Wrap) {}
+
+#[op2(fast)]
+fn op_use_cppgc_object_mut(#[cppgc] _wrap: &mut Wrap) {}

--- a/ops/op2/test_cases_fail/lifetimes.rs
+++ b/ops/op2/test_cases_fail/lifetimes.rs
@@ -11,3 +11,6 @@ fn op_use_cppgc_object(#[cppgc] _wrap: &'static Wrap) {}
 
 #[op2(fast)]
 fn op_use_buffer(#[buffer] _buffer: &'static [u8]) {}
+
+#[op2(async)]
+async fn op_use_cppgc_object_mut_async(#[cppgc] _wrap: &mut Wrap) {}

--- a/ops/op2/test_cases_fail/lifetimes.stderr
+++ b/ops/op2/test_cases_fail/lifetimes.stderr
@@ -17,6 +17,26 @@ error: unused import: `std::future::Future`
 6 | use std::future::Future;
   |     ^^^^^^^^^^^^^^^^^^^
 
+error[E0308]: mismatched types
+  --> ../op2/test_cases_fail/lifetimes.rs:18:1
+   |
+18 | #[op2(async)]
+   | ^^^^^^^^^^^^^
+   | |
+   | types differ in mutability
+   | arguments to this function are incorrect
+   |
+   = note: expected mutable reference `&mut Wrap`
+                      found reference `&Wrap`
+note: associated function defined here
+  --> ../op2/test_cases_fail/lifetimes.rs:18:1
+   |
+18 | #[op2(async)]
+   | ^^^^^^^^^^^^^
+19 | async fn op_use_cppgc_object_mut_async(#[cppgc] _wrap: &mut Wrap) {}
+   |                                                 ----------------
+   = note: this error originates in the attribute macro `op2` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0521]: borrowed data escapes outside of associated function
   --> ../op2/test_cases_fail/lifetimes.rs:12:1
    |


### PR DESCRIPTION
Allow `#[cppgc] _: &mut T` and `#[cppgc] _: Option<&mut T>`

Closes https://github.com/denoland/deno_core/issues/787

Trying to use it with async op gives a compiler error:
```
error[E0308]: mismatched types
    --> core/runtime/ops.rs:1911:3
     |
1911 |   #[op2(async)]
     |   ^^^^^^^^^^^^^
     |   |
     |   types differ in mutability
     |   arguments to this function are incorrect
     |
     = note: expected mutable reference `&mut TestResource`
                        found reference `&TestResource`
note: associated function defined here
    --> core/runtime/ops.rs:1911:3
     |
1911 |   #[op2(async)]
     |   ^^^^^^^^^^^^^
1912 |   pub async fn op_test_set_cppgc_resource(#[cppgc] resource: &mut TestResource, value: u32) {
```