### PR TITLE
feat: upgrade rusty_v8 to 0.96.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2735,9 +2735,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.95.0"
+version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4395d3c43b81368d91335ffc78d71cb6e3288d311ab6a55094634cb2afdc5c5"
+checksum = "6fecc88a0a882b5b2d2a1a4a166e19657fe786220a4319a982f8e36f6136ab93"
 dependencies = [
  "bindgen",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ deno_ops = { version = "0.168.0", path = "./ops" }
 serde_v8 = { version = "0.201.0", path = "./serde_v8" }
 deno_core_testing = { path = "./testing" }
 
-v8 = { version = "0.95.0", default-features = false }
+v8 = { version = "0.96.0", default-features = false }
 deno_ast = { version = "=0.35.3", features = ["transpiling"] }
 deno_unsync = "0.3.2"
 deno_core_icudata = "0.0.73"


### PR DESCRIPTION
Includes: 
- [feat: Add Source Maps APIs ](https://github.com/denoland/rusty_v8/commit/49b92c1e7602c2de900ede0e1b59cb97003899b8)