### PR TITLE
feat: Depcrate `SourceMapGetter`, move methods to `ModuleLoader`

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -161,6 +161,7 @@ pub use crate::runtime::MODULE_MAP_SLOT_INDEX;
 pub use crate::runtime::V8_WRAPPER_OBJECT_INDEX;
 pub use crate::runtime::V8_WRAPPER_TYPE_INDEX;
 pub use crate::source_map::SourceMapData;
+#[allow(deprecated)]
 pub use crate::source_map::SourceMapGetter;
 pub use crate::tasks::V8CrossThreadTaskSpawner;
 pub use crate::tasks::V8TaskSpawner;

--- a/core/modules/loaders.rs
+++ b/core/modules/loaders.rs
@@ -95,6 +95,21 @@ pub trait ModuleLoader {
   ) -> Pin<Box<dyn Future<Output = ()>>> {
     async {}.boxed_local()
   }
+
+  /// Returns a source map for given `file_name`.
+  ///
+  /// This function will soon be deprecated or renamed.
+  fn get_source_map(&self, _file_name: &str) -> Option<Vec<u8>> {
+    None
+  }
+
+  fn get_source_mapped_source_line(
+    &self,
+    _file_name: &str,
+    _line_number: usize,
+  ) -> Option<String> {
+    None
+  }
 }
 
 /// Placeholder structure used when creating

--- a/testing/checkin/runner/mod.rs
+++ b/testing/checkin/runner/mod.rs
@@ -125,7 +125,6 @@ pub fn create_runtime_from_snapshot(
       deno_core::error::get_custom_error_class(error).unwrap_or("Error")
     }),
     shared_array_buffer_store: Some(CrossIsolateStore::default()),
-    source_map_getter: Some(module_loader),
     custom_module_evaluation_cb: Some(Box::new(custom_module_evaluation_cb)),
     inspector,
     ..Default::default()

--- a/testing/checkin/runner/ts_module_loader.rs
+++ b/testing/checkin/runner/ts_module_loader.rs
@@ -28,30 +28,17 @@ use deno_core::ModuleType;
 use deno_core::RequestedModuleType;
 use deno_core::ResolutionKind;
 use deno_core::SourceMapData;
-use deno_core::SourceMapGetter;
 
-#[derive(Clone, Default)]
-struct SourceMapStore(Rc<RefCell<HashMap<String, Vec<u8>>>>);
+// TODO(bartlomieju): this is duplicated in `core/examples/ts_modules_loader.rs`.
+type SourceMapStore = Rc<RefCell<HashMap<String, Vec<u8>>>>;
 
-impl SourceMapGetter for TypescriptModuleLoader {
-  fn get_source_map(&self, specifier: &str) -> Option<Vec<u8>> {
-    self.source_maps.0.borrow().get(specifier).cloned()
-  }
-
-  fn get_source_line(
-    &self,
-    _file_name: &str,
-    _line_number: usize,
-  ) -> Option<String> {
-    None
-  }
-}
-
+// TODO(bartlomieju): this is duplicated in `core/examples/ts_modules_loader.rs`.
 #[derive(Default)]
 pub struct TypescriptModuleLoader {
   source_maps: SourceMapStore,
 }
 
+// TODO(bartlomieju): this is duplicated in `core/examples/ts_modules_loader.rs`.
 impl ModuleLoader for TypescriptModuleLoader {
   fn resolve(
     &self,
@@ -135,7 +122,6 @@ impl ModuleLoader for TypescriptModuleLoader {
         })?;
         let source_map = res.source_map.unwrap();
         source_maps
-          .0
           .borrow_mut()
           .insert(module_specifier.to_string(), source_map.into_bytes());
         res.text
@@ -155,6 +141,10 @@ impl ModuleLoader for TypescriptModuleLoader {
       module_specifier,
       requested_module_type,
     ))
+  }
+
+  fn get_source_map(&self, specifier: &str) -> Option<Vec<u8>> {
+    self.source_maps.borrow().get(specifier).cloned()
   }
 }
 


### PR DESCRIPTION
This commit deprecates `SourceMapGetter` trait, `JsRuntime::source_map_getter`
option and updates `ModuleLoader` trait to have the same methods as
`SourceMapGetter`.

In real usage it's always implementor of `ModuleLoader` that also implements
`SourceMapGetter`. It makes little sense to keep these two trait separate.

This will open up doors for native source map support that is being
developed in https://github.com/denoland/deno_core/pull/819.

`SourceMapGetter` is scheduled to be removed in 0.297.0.