### PR TITLE
fix: SourceMapper correctly uses `ModuleLoader` to get source lines

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -475,26 +475,18 @@ impl JsError {
       {
         let state = JsRuntime::state_from(scope);
         let mut source_mapper = state.source_mapper.borrow_mut();
-        if source_mapper.has_user_sources() {
-          for (i, frame) in frames.iter().enumerate() {
-            if let (Some(file_name), Some(line_number)) =
-              (&frame.file_name, frame.line_number)
-            {
-              if !file_name.trim_start_matches('[').starts_with("ext:") {
-                source_line =
-                  source_mapper.get_source_line(file_name, line_number);
-                source_line_frame_index = Some(i);
-                break;
-              }
-            }
-          }
-        } else if let Some(frame) = frames.first() {
-          if let Some(file_name) = &frame.file_name {
+        for (i, frame) in frames.iter().enumerate() {
+          eprintln!("iterating over frames");
+          if let (Some(file_name), Some(line_number)) =
+            (&frame.file_name, frame.line_number)
+          {
+            eprintln!("iterating over frames, got match, {}", file_name);
             if !file_name.trim_start_matches('[').starts_with("ext:") {
-              source_line = msg
-                .get_source_line(scope)
-                .map(|v| v.to_rust_string_lossy(scope));
-              source_line_frame_index = Some(0);
+              source_line =
+                source_mapper.get_source_line(file_name, line_number);
+              eprintln!("get_source_line returned {:?}", source_line);
+              source_line_frame_index = Some(i);
+              break;
             }
           }
         }

--- a/core/error.rs
+++ b/core/error.rs
@@ -476,15 +476,12 @@ impl JsError {
         let state = JsRuntime::state_from(scope);
         let mut source_mapper = state.source_mapper.borrow_mut();
         for (i, frame) in frames.iter().enumerate() {
-          eprintln!("iterating over frames");
           if let (Some(file_name), Some(line_number)) =
             (&frame.file_name, frame.line_number)
           {
-            eprintln!("iterating over frames, got match, {}", file_name);
             if !file_name.trim_start_matches('[').starts_with("ext:") {
               source_line =
                 source_mapper.get_source_line(file_name, line_number);
-              eprintln!("get_source_line returned {:?}", source_line);
               source_line_frame_index = Some(i);
               break;
             }

--- a/core/source_map.rs
+++ b/core/source_map.rs
@@ -193,19 +193,13 @@ mod tests {
 
   use super::*;
   use crate::ascii_str;
-  use crate::error::generic_error;
-  use crate::resolve_import;
   use crate::ModuleCodeString;
   use crate::ModuleLoadResponse;
-  use crate::ModuleSource;
-  use crate::ModuleSourceCode;
   use crate::ModuleSpecifier;
-  use crate::ModuleType;
   use crate::RequestedModuleType;
   use crate::ResolutionKind;
 
   struct SourceMapLoaderContent {
-    code: ModuleCodeString,
     source_map: Option<ModuleCodeString>,
   }
 
@@ -257,15 +251,11 @@ mod tests {
     let mut loader = SourceMapLoader::default();
     loader.map.insert(
       Url::parse("file:///b.js").unwrap(),
-      SourceMapLoaderContent {
-        code: ascii_str!("export function b() { return 'b' }").into(),
-        source_map: None,
-      },
+      SourceMapLoaderContent { source_map: None },
     );
     loader.map.insert(
       Url::parse("file:///a.ts").unwrap(),
       SourceMapLoaderContent {
-        code: ascii_str!(r#"export function a() {\nreturn "a";\n}"#).into(),
         source_map: Some(ascii_str!(r#"{"version":3,"sources":["file:///a.ts"],"sourcesContent":["export function a(): string {\n  return \"a\";\n}\n"],"names":[],"mappings":"AAAA,OAAO,SAAS;EACd,OAAO;AACT"}"#).into()),
       },
     );

--- a/core/source_map.rs
+++ b/core/source_map.rs
@@ -217,31 +217,21 @@ mod tests {
   impl ModuleLoader for SourceMapLoader {
     fn resolve(
       &self,
-      specifier: &str,
-      referrer: &str,
+      _specifier: &str,
+      _referrer: &str,
       _kind: ResolutionKind,
     ) -> Result<ModuleSpecifier, Error> {
-      Ok(resolve_import(specifier, referrer)?)
+      unreachable!()
     }
 
     fn load(
       &self,
-      module_specifier: &ModuleSpecifier,
+      _module_specifier: &ModuleSpecifier,
       _maybe_referrer: Option<&ModuleSpecifier>,
       _is_dyn_import: bool,
       _requested_module_type: RequestedModuleType,
     ) -> ModuleLoadResponse {
-      let res = if let Some(content) = self.map.get(module_specifier) {
-        Ok(ModuleSource::new(
-          ModuleType::JavaScript,
-          ModuleSourceCode::String(content.code.try_clone().unwrap()),
-          module_specifier,
-          None,
-        ))
-      } else {
-        Err(generic_error("Module not found"))
-      };
-      ModuleLoadResponse::Sync(res)
+      unreachable!()
     }
 
     fn get_source_map(&self, file_name: &str) -> Option<Vec<u8>> {
@@ -300,6 +290,10 @@ mod tests {
         column_number: 17
       }
     );
+
+    let line = source_mapper.get_source_line("file:///a.ts", 1).unwrap();
+    assert_eq!(line, "fake source line");
+    // Get again to hit a cache
     let line = source_mapper.get_source_line("file:///a.ts", 1).unwrap();
     assert_eq!(line, "fake source line");
   }

--- a/core/source_map.rs
+++ b/core/source_map.rs
@@ -181,6 +181,6 @@ impl SourceMapper {
       (file_name.to_string(), line_number),
       maybe_source_line.clone(),
     );
-    return maybe_source_line;
+    maybe_source_line
   }
 }


### PR DESCRIPTION
Fixes `SourceMapper` API that was changed in https://github.com/denoland/deno_core/pull/823.

Now the source lines are correctly mapped even if deprecated `SourceMapGetter` API is not
used.

I need to add some tests too.