### PR TITLE
perf: Make SourceMaps cheaper by using static strs

### DIFF
--- a/core/extension_set.rs
+++ b/core/extension_set.rs
@@ -14,7 +14,6 @@ use crate::ops::OpCtx;
 use crate::runtime::ExtensionTranspiler;
 use crate::runtime::JsRuntimeState;
 use crate::runtime::OpDriverImpl;
-use crate::source_map::SourceMapper;
 use crate::ExtensionFileSource;
 use crate::FastString;
 use crate::GetErrorClassFn;
@@ -22,6 +21,7 @@ use crate::ModuleCodeString;
 use crate::OpDecl;
 use crate::OpMetricsFactoryFn;
 use crate::OpState;
+use crate::SourceMapData;
 
 /// Contribute to the `OpState` from each extension.
 pub fn setup_op_state(op_state: &mut OpState, extensions: &mut [Extension]) {
@@ -241,9 +241,8 @@ impl<'a> IntoIterator for &'a mut LoadedSources {
 fn load(
   transpiler: Option<&ExtensionTranspiler>,
   source: &ExtensionFileSource,
-  source_mapper: &mut SourceMapper,
   load_callback: &mut impl FnMut(&ExtensionFileSource),
-) -> Result<ModuleCodeString, AnyError> {
+) -> Result<(ModuleCodeString, Option<SourceMapData>), AnyError> {
   load_callback(source);
   let mut source_code = source.load()?;
   let mut source_map = None;
@@ -251,21 +250,20 @@ fn load(
     (source_code, source_map) =
       transpiler(ModuleName::from_static(source.specifier), source_code)?;
   }
+  let mut maybe_source_map = None;
   if let Some(source_map) = source_map {
-    source_mapper
-      .ext_source_maps
-      .insert(ModuleName::from_static(source.specifier), source_map);
+    maybe_source_map = Some(source_map);
   }
-  Ok(source_code)
+  Ok((source_code, maybe_source_map))
 }
 
-pub fn into_sources(
+pub fn into_sources_and_source_maps(
   transpiler: Option<&ExtensionTranspiler>,
   extensions: &[Extension],
-  source_mapper: &mut SourceMapper,
   mut load_callback: impl FnMut(&ExtensionFileSource),
-) -> Result<LoadedSources, AnyError> {
+) -> Result<(LoadedSources, Vec<(ModuleName, SourceMapData)>), AnyError> {
   let mut sources = LoadedSources::default();
+  let mut source_maps = vec![];
 
   for extension in extensions {
     if let Some(esm_entry_point) = extension.esm_entry_point {
@@ -274,29 +272,41 @@ pub fn into_sources(
         .push(FastString::from_static(esm_entry_point));
     }
     for file in &*extension.lazy_loaded_esm_files {
-      let code = load(transpiler, file, source_mapper, &mut load_callback)?;
+      let (code, maybe_source_map) =
+        load(transpiler, file, &mut load_callback)?;
       sources.lazy_esm.push(LoadedSource {
         source_type: ExtensionSourceType::LazyEsm,
         specifier: ModuleName::from_static(file.specifier),
         code,
       });
+      if let Some(source_map) = maybe_source_map {
+        source_maps.push((ModuleName::from_static(file.specifier), source_map));
+      }
     }
     for file in &*extension.js_files {
-      let code = load(transpiler, file, source_mapper, &mut load_callback)?;
+      let (code, maybe_source_map) =
+        load(transpiler, file, &mut load_callback)?;
       sources.js.push(LoadedSource {
         source_type: ExtensionSourceType::Js,
         specifier: ModuleName::from_static(file.specifier),
         code,
       });
+      if let Some(source_map) = maybe_source_map {
+        source_maps.push((ModuleName::from_static(file.specifier), source_map));
+      }
     }
     for file in &*extension.esm_files {
-      let code = load(transpiler, file, source_mapper, &mut load_callback)?;
+      let (code, maybe_source_map) =
+        load(transpiler, file, &mut load_callback)?;
       sources.esm.push(LoadedSource {
         source_type: ExtensionSourceType::Esm,
         specifier: ModuleName::from_static(file.specifier),
         code,
       });
+      if let Some(source_map) = maybe_source_map {
+        source_maps.push((ModuleName::from_static(file.specifier), source_map));
+      }
     }
   }
-  Ok(sources)
+  Ok((sources, source_maps))
 }

--- a/core/extension_set.rs
+++ b/core/extension_set.rs
@@ -254,7 +254,7 @@ fn load(
   if let Some(source_map) = source_map {
     source_mapper
       .ext_source_maps
-      .insert(source.specifier.to_owned(), source_map);
+      .insert(ModuleName::from_static(source.specifier), source_map);
   }
   Ok(source_code)
 }

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -922,7 +922,9 @@ impl JsRuntime {
 
       let mut mapper = state_rc.source_mapper.borrow_mut();
       for (key, map) in snapshotted_data.ext_source_maps {
-        mapper.ext_source_maps.insert(key, map.into());
+        mapper
+          .ext_source_maps
+          .insert(ModuleName::from_static(key), map.into());
       }
     }
 
@@ -1958,7 +1960,7 @@ impl JsRuntimeForSnapshot {
     );
     let mut ext_source_maps = HashMap::with_capacity(source_maps.len());
     for (k, v) in &source_maps {
-      ext_source_maps.insert(k.clone(), v.as_ref());
+      ext_source_maps.insert(k.as_static_str().unwrap(), v.as_ref());
     }
 
     // Serialize the module map and store its data in the snapshot.

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -679,11 +679,6 @@ impl JsRuntime {
       .module_loader
       .unwrap_or_else(|| Rc::new(NoopModuleLoader));
 
-    // TODO(bartlomieju): defer creation of `SourceMapper` until we can create a `ModuleMap`.
-    // The problem is that `op_apply_source_map` relies on `source_mapper` being presented in
-    // the `JsRuntimeState`. Maybe we can make it an `Option` and expect it always is present.
-    // Alternatively we could have a cheap default impl of `SourceMapper` that we later replace
-    // with actual impl.
     #[allow(deprecated)]
     let mut source_mapper =
       SourceMapper::new(loader.clone(), options.source_map_getter);

--- a/core/runtime/snapshot.rs
+++ b/core/runtime/snapshot.rs
@@ -255,7 +255,7 @@ pub(crate) struct SnapshottedData<'snapshot> {
   pub source_count: usize,
   pub addl_refs_count: usize,
   #[serde(borrow)]
-  pub ext_source_maps: HashMap<String, &'snapshot [u8]>,
+  pub ext_source_maps: HashMap<&'snapshot str, &'snapshot [u8]>,
   #[serde(borrow)]
   pub external_strings: Vec<&'snapshot [u8]>,
 }

--- a/core/source_map.rs
+++ b/core/source_map.rs
@@ -7,6 +7,7 @@
 
 use crate::resolve_url;
 use crate::ModuleLoader;
+use crate::ModuleName;
 pub use sourcemap::SourceMap;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -49,7 +50,7 @@ pub struct SourceMapper {
   loader: Rc<dyn ModuleLoader>,
 
   getter: Option<Rc<dyn SourceMapGetter>>,
-  pub(crate) ext_source_maps: HashMap<String, SourceMapData>,
+  pub(crate) ext_source_maps: HashMap<ModuleName, SourceMapData>,
   // This is not the right place for this, but it's the easiest way to make
   // op_apply_source_map a fast op. This stashing should happen in #[op2].
   pub(crate) stashed_file_name: Option<String>,


### PR DESCRIPTION
This commits updates `SourceMapper` API to be a bit more performant
by using `ModuleName` (which in case of snapshots is a `&'static str`)
instead of owned `String`.