### PR TITLE
chore: upgrade rusty_v8 to 0.99.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2728,9 +2728,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.98.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b8009c63eec162cbcc41aa4db66b81974f641d32a35b1a3198ec2ce4712d6b"
+checksum = "fa3fc0608a78f0c7d4ec88025759cb78c90a29984b48540060355a626ae329c1"
 dependencies = [
  "bindgen",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ deno_ops = { version = "0.173.0", path = "./ops" }
 serde_v8 = { version = "0.206.0", path = "./serde_v8" }
 deno_core_testing = { path = "./testing" }
 
-v8 = { version = "0.98.2", default-features = false }
+v8 = { version = "0.99.0", default-features = false }
 deno_ast = { version = "=0.40.0", features = ["transpiling"] }
 deno_unsync = "0.3.10"
 deno_core_icudata = "0.0.73"


### PR DESCRIPTION
rusty_v8 0.98.1 and 0.98.2 had to be yanked, because
they broke peoples' builds.

There are no functional changes, just a new release.