### PR TITLE
feat: Remove `SourceMapGetter` trait

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -161,8 +161,6 @@ pub use crate::runtime::MODULE_MAP_SLOT_INDEX;
 pub use crate::runtime::V8_WRAPPER_OBJECT_INDEX;
 pub use crate::runtime::V8_WRAPPER_TYPE_INDEX;
 pub use crate::source_map::SourceMapData;
-#[allow(deprecated)]
-pub use crate::source_map::SourceMapGetter;
 pub use crate::tasks::V8CrossThreadTaskSpawner;
 pub use crate::tasks::V8TaskSpawner;
 

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -45,8 +45,6 @@ use crate::runtime::ContextState;
 use crate::runtime::JsRealm;
 use crate::runtime::OpDriverImpl;
 use crate::source_map::SourceMapData;
-#[allow(deprecated)]
-use crate::source_map::SourceMapGetter;
 use crate::source_map::SourceMapper;
 use crate::stats::RuntimeActivityType;
 use crate::Extension;
@@ -443,11 +441,6 @@ pub struct JsRuntimeState {
 
 #[derive(Default)]
 pub struct RuntimeOptions {
-  /// Source map reference for errors.
-  #[deprecated = "Update `ModuleLoader` trait implementations. This option will be removed in deno_core v0.300.0."]
-  #[allow(deprecated)]
-  pub source_map_getter: Option<Rc<dyn SourceMapGetter>>,
-
   /// Allows to map error type to a string "class" used to represent
   /// error in JavaScript.
   pub get_error_class_fn: Option<GetErrorClassFn>,
@@ -694,9 +687,7 @@ impl JsRuntime {
       .module_loader
       .unwrap_or_else(|| Rc::new(NoopModuleLoader));
 
-    #[allow(deprecated)]
-    let mut source_mapper =
-      SourceMapper::new(loader.clone(), options.source_map_getter);
+    let mut source_mapper = SourceMapper::new(loader.clone());
 
     let mut sources = extension_set::into_sources_and_source_maps(
       options.extension_transpiler.as_deref(),


### PR DESCRIPTION
This trait was deprecated in https://github.com/denoland/deno_core/pull/823 and is
scheduled to be removed in 0.300.0