### PR TITLE
fix: add `getScriptNameOrSourceURL` to `CallSite` prototype

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -985,6 +985,7 @@ pub fn throw_type_error(scope: &mut v8::HandleScope, message: impl AsRef<str>) {
 v8_static_strings::v8_static_strings! {
   ERROR = "Error",
   GET_FILE_NAME = "getFileName",
+  GET_SCRIPT_NAME_OR_SOURCE_URL = "getScriptNameOrSourceURL",
   GET_THIS = "getThis",
   GET_TYPE_NAME = "getTypeName",
   GET_FUNCTION = "getFunction",
@@ -1124,6 +1125,10 @@ pub mod callsite_fns {
   make_callsite_fn!(is_async, IS_ASYNC);
   make_callsite_fn!(is_promise_all, IS_PROMISE_ALL);
   make_callsite_fn!(get_promise_index, GET_PROMISE_INDEX);
+  make_callsite_fn!(
+    get_script_name_or_source_url,
+    GET_SCRIPT_NAME_OR_SOURCE_URL
+  );
 
   pub fn to_string(
     scope: &mut v8::HandleScope<'_>,
@@ -1213,6 +1218,12 @@ pub(crate) fn make_callsite_prototype<'s>(
   set_attr!(scope, template, is_async, IS_ASYNC);
   set_attr!(scope, template, is_promise_all, IS_PROMISE_ALL);
   set_attr!(scope, template, get_promise_index, GET_PROMISE_INDEX);
+  set_attr!(
+    scope,
+    template,
+    get_script_name_or_source_url,
+    GET_SCRIPT_NAME_OR_SOURCE_URL
+  );
   set_attr!(scope, template, to_string, TO_STRING);
 
   template.new_instance(scope).unwrap()

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -124,6 +124,9 @@ pub(crate) fn create_external_references(
     function: callsite_fns::get_file_name.map_fn_to(),
   });
   references.push(v8::ExternalReference {
+    function: callsite_fns::get_script_name_or_source_url.map_fn_to(),
+  });
+  references.push(v8::ExternalReference {
     function: callsite_fns::get_line_number.map_fn_to(),
   });
   references.push(v8::ExternalReference {

--- a/testing/integration/error_get_script_name_or_source_url/error_get_script_name_or_source_url.out
+++ b/testing/integration/error_get_script_name_or_source_url/error_get_script_name_or_source_url.out
@@ -1,0 +1,5 @@
+[
+  "test:///integration/error_get_file_name/error_get_file_name.ts",
+  null,
+  "test:///integration/error_get_file_name/error_get_file_name.ts"
+]

--- a/testing/integration/error_get_script_name_or_source_url/error_get_script_name_or_source_url.out
+++ b/testing/integration/error_get_script_name_or_source_url/error_get_script_name_or_source_url.out
@@ -1,5 +1,5 @@
 [
-  "test:///integration/error_get_file_name/error_get_file_name.ts",
+  "test:///integration/error_get_script_name_or_source_url/error_get_script_name_or_source_url.ts",
   null,
-  "test:///integration/error_get_file_name/error_get_file_name.ts"
+  "test:///integration/error_get_script_name_or_source_url/error_get_script_name_or_source_url.ts"
 ]

--- a/testing/integration/error_get_script_name_or_source_url/error_get_script_name_or_source_url.ts
+++ b/testing/integration/error_get_script_name_or_source_url/error_get_script_name_or_source_url.ts
@@ -1,0 +1,12 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// deno-lint-ignore no-explicit-any
+(Error as any).prepareStackTrace = (_err: unknown, frames: any[]) => {
+  return frames.map((frame) => frame.getScriptNameOrSourceURL());
+};
+
+new Promise((_, reject) => {
+  reject(new Error("fail").stack);
+}).catch((err) => {
+  console.log(err);
+});

--- a/testing/integration/error_prepare_stack_trace/error_prepare_stack_trace.out
+++ b/testing/integration/error_prepare_stack_trace/error_prepare_stack_trace.out
@@ -15,6 +15,7 @@
   "isAsync",
   "isPromiseAll",
   "getPromiseIndex",
+  "getScriptNameOrSourceURL",
   "toString"
 ]
 []
@@ -37,4 +38,5 @@ isConstructor() threw an error: The receiver is not a valid callsite object.
 isAsync() threw an error: The receiver is not a valid callsite object.
 isPromiseAll() threw an error: The receiver is not a valid callsite object.
 getPromiseIndex() threw an error: The receiver is not a valid callsite object.
+getScriptNameOrSourceURL() threw an error: The receiver is not a valid callsite object.
 toString() threw an error: The receiver is not a valid callsite object.

--- a/testing/lib.rs
+++ b/testing/lib.rs
@@ -68,6 +68,7 @@ integration_test!(
   error_without_stack,
   error_get_file_name,
   error_get_file_name_to_string,
+  error_get_script_name_or_source_url,
   main_module_handler,
   module_types,
   pending_unref_op_tla,


### PR DESCRIPTION
Both Chrome and Node have a `getScriptNameOrSourceUrl()` method on the `CallSite` prototype. We didn't have that which causes an error in `vitest`, see https://github.com/denoland/deno/issues/24898 