### PR TITLE
feat: Add a temporary way to warn on import assertions

### DIFF
--- a/core/modules/loaders.rs
+++ b/core/modules/loaders.rs
@@ -96,6 +96,13 @@ pub trait ModuleLoader {
     async {}.boxed_local()
   }
 
+  /// Called when V8 code cache should be ignored for this module. This can happen
+  /// if eg. module causes a V8 warning, like when using deprecated import assertions.
+  /// Implementors should make sure that the code cache for this module is purged and not saved anymore.
+  ///
+  /// It's not required to implement this method.
+  fn purge_and_prevent_code_cache(&self, _module_specifier: &str) {}
+
   /// Returns a source map for given `file_name`.
   ///
   /// This function will soon be deprecated or renamed.

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -618,6 +618,14 @@ extern "C" fn isolate_message_listener(
   let start_column = message.get_start_column();
 
   let js_runtime_state = JsRuntime::state_from(scope);
+  if let Some(specifier) = maybe_script_resource_name.as_ref() {
+    let module_map = JsRealm::module_map_from(scope);
+    module_map
+      .loader
+      .borrow()
+      .purge_and_prevent_code_cache(specifier);
+  }
+
   match &js_runtime_state.import_assertions_support {
     ImportAssertionsSupport::Warning => {
       let mut msg = "⚠️  Import assertions are deprecated. Use `with` keyword, instead of 'assert' keyword.".to_string();


### PR DESCRIPTION
This commit adds a `ModuleLoader::purge_and_prevent_code_cache`
method that is called when a V8 warning for import assertions is received.

This is a temporary method, that will be removed after Deno 2 when 
requirement for import assertion support is dropped completely.
