### PR TITLE
fix: preserve cped in dynamic imports

### DIFF
--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -115,6 +115,11 @@ struct DynImportModEvaluate {
   module: v8::Global<v8::Module>,
 }
 
+struct DynImportState {
+  resolver: v8::Global<v8::PromiseResolver>,
+  cped: v8::Global<v8::Value>,
+}
+
 /// A collection of JS modules.
 pub(crate) struct ModuleMap {
   // Handling of futures for loading module sources
@@ -123,8 +128,7 @@ pub(crate) struct ModuleMap {
   pub(crate) import_meta_resolve_cb: ImportMetaResolveCallback,
 
   exception_state: Rc<ExceptionState>,
-  dynamic_import_map:
-    RefCell<HashMap<ModuleLoadId, v8::Global<v8::PromiseResolver>>>,
+  dynamic_import_map: RefCell<HashMap<ModuleLoadId, DynImportState>>,
   preparing_dynamic_imports:
     RefCell<FuturesUnordered<Pin<Box<PrepareLoadFuture>>>>,
   preparing_dynamic_imports_pending: Cell<bool>,
@@ -941,6 +945,7 @@ impl ModuleMap {
     referrer: &str,
     requested_module_type: RequestedModuleType,
     resolver_handle: v8::Global<v8::PromiseResolver>,
+    cped_handle: v8::Global<v8::Value>,
   ) {
     let load = RecursiveModuleLoad::dynamic_import(
       specifier,
@@ -949,10 +954,13 @@ impl ModuleMap {
       self.clone(),
     );
 
-    self
-      .dynamic_import_map
-      .borrow_mut()
-      .insert(load.id, resolver_handle);
+    self.dynamic_import_map.borrow_mut().insert(
+      load.id,
+      DynImportState {
+        resolver: resolver_handle,
+        cped: cped_handle,
+      },
+    );
 
     let resolve_result =
       self.resolve(specifier, referrer, ResolutionKind::DynamicImport);
@@ -1223,6 +1231,19 @@ impl ModuleMap {
     // https://github.com/denoland/deno/issues/4908
     // https://v8.dev/features/top-level-await#module-execution-order
     let tc_scope = &mut v8::TryCatch::new(scope);
+
+    {
+      let cped = self
+        .dynamic_import_map
+        .borrow()
+        .get(&load_id)
+        .unwrap()
+        .cped
+        .clone();
+      let cped = v8::Local::new(tc_scope, cped);
+      tc_scope.set_continuation_preserved_embedder_data(cped);
+    }
+
     let module = v8::Local::new(tc_scope, &module_handle);
     let maybe_value = module.evaluate(tc_scope);
 
@@ -1344,7 +1365,8 @@ impl ModuleMap {
       .dynamic_import_map
       .borrow_mut()
       .remove(&id)
-      .expect("Invalid dynamic import id");
+      .expect("Invalid dynamic import id")
+      .resolver;
     let resolver = resolver_handle.open(scope);
 
     let exception = v8::Local::new(scope, exception);
@@ -1362,7 +1384,8 @@ impl ModuleMap {
       .dynamic_import_map
       .borrow_mut()
       .remove(&id)
-      .expect("Invalid dynamic import id");
+      .expect("Invalid dynamic import id")
+      .resolver;
     let resolver = resolver_handle.open(scope);
 
     let module = self

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -426,6 +426,8 @@ pub fn host_import_module_dynamically_callback<'s>(
   specifier: v8::Local<'s, v8::String>,
   import_attributes: v8::Local<'s, v8::FixedArray>,
 ) -> Option<v8::Local<'s, v8::Promise>> {
+  let cped = scope.get_continuation_preserved_embedder_data();
+
   // NOTE(bartlomieju): will crash for non-UTF-8 specifier
   let specifier_str = specifier
     .to_string(scope)
@@ -465,6 +467,7 @@ pub fn host_import_module_dynamically_callback<'s>(
     get_requested_module_type_from_attributes(&assertions);
 
   let resolver_handle = v8::Global::new(scope, resolver);
+  let cped_handle = v8::Global::new(scope, cped);
   {
     let state = JsRuntime::state_from(scope);
     let module_map_rc = JsRealm::module_map_from(scope);
@@ -475,6 +478,7 @@ pub fn host_import_module_dynamically_callback<'s>(
       &referrer_name_str,
       requested_module_type,
       resolver_handle,
+      cped_handle,
     );
     state.notify_new_dynamic_import();
   }


### PR DESCRIPTION
Fix for https://github.com/denoland/deno/issues/25275

This code is like hacks on top of hacks, but basically save & restore cped in the dynamic import flow.