### PR TITLE
feat: `remove_es_module`  

### DIFF
--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -248,6 +248,7 @@ impl ModuleMap {
     self.data.borrow().get_id(name, requested_module_type)
   }
 
+  // Removes a module or its alias from the module map.
   pub(crate) fn remove_id(
     &self,
     name: &str,

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -248,6 +248,18 @@ impl ModuleMap {
     self.data.borrow().get_id(name, requested_module_type)
   }
 
+  pub(crate) fn remove_id(
+    &self,
+    name: &str,
+    requested_module_type: impl AsRef<RequestedModuleType>,
+    main: bool,
+  ) -> Option<ModuleId> {
+    self
+      .data
+      .borrow_mut()
+      .remove_id(name, requested_module_type, main)
+  }
+
   pub(crate) fn is_main_module(&self, global: &v8::Global<v8::Module>) -> bool {
     self.data.borrow().is_main_module(global)
   }

--- a/core/modules/module_map_data.rs
+++ b/core/modules/module_map_data.rs
@@ -227,22 +227,21 @@ impl ModuleMapData {
     }
   }
 
+  // Removes a module or its alias from the module map.
   pub fn remove_id(
     &mut self,
     name: &str,
     requested_module_type: impl AsRef<RequestedModuleType>,
     main: bool,
   ) -> Option<ModuleId> {
-    let mut map = &mut self.by_name;
+    let map = &mut self.by_name;
     let first_symbolic_module =
       map.remove(requested_module_type.as_ref(), name)?;
-
     let mod_id = match first_symbolic_module {
       SymbolicModule::Mod(mod_id) => mod_id,
       SymbolicModule::Alias(mut mod_name) => loop {
         let symbolic_module =
           map.remove(requested_module_type.as_ref(), &mod_name)?;
-
         match symbolic_module {
           SymbolicModule::Alias(target) => {
             debug_assert_ne!(mod_name, target);
@@ -258,7 +257,6 @@ impl ModuleMapData {
         debug_assert_eq!(main_id, mod_id);
       }
     }
-
     Some(mod_id)
   }
 

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -413,6 +413,9 @@ impl JsRealm {
     Ok(root_id)
   }
 
+  /// Removes the specified main module from the module map.
+  ///
+  /// This method will panic if the module is not found.
   pub(crate) async fn remove_main_es_module(
     &self,
     specifier: &ModuleSpecifier,
@@ -475,6 +478,9 @@ impl JsRealm {
     Ok(root_id)
   }
 
+  /// Removes the specified side module from the module map.
+  ///
+  /// This method will panic if the module is not found.
   pub(crate) async fn remove_side_es_module(
     &self,
     specifier: &ModuleSpecifier,

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -2364,6 +2364,11 @@ impl JsRuntime {
       .await
   }
 
+  /// Remove the specified main module from the module map.
+  ///
+  /// This method is useful when you need to update a previously loaded main
+  /// module and potentially replace it with a different version.
+  /// It returns the `ModuleId` of the old module that was removed from the module map.
   pub async fn remove_main_es_module(
     &mut self,
     specifier: &ModuleSpecifier,
@@ -2420,7 +2425,12 @@ impl JsRuntime {
       .load_side_es_module_from_code(isolate, specifier, None)
       .await
   }
-
+  
+  /// Remove the specified side module from the module map.
+  ///
+  /// This method is useful when you need to update a previously loaded side
+  /// module and potentially replace it with a different version.
+  /// It returns the `ModuleId` of the old module that was removed from the module map.
   pub async fn remove_side_es_module(
     &mut self,
     specifier: &ModuleSpecifier,

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -2364,6 +2364,13 @@ impl JsRuntime {
       .await
   }
 
+  pub async fn remove_main_es_module(
+    &mut self,
+    specifier: &ModuleSpecifier,
+  ) -> Result<ModuleId, Error> {
+    self.inner.main_realm.remove_main_es_module(specifier).await
+  }
+
   /// Asynchronously load specified ES module and all of its dependencies from the
   /// provided source.
   ///
@@ -2412,6 +2419,13 @@ impl JsRuntime {
       .main_realm
       .load_side_es_module_from_code(isolate, specifier, None)
       .await
+  }
+
+  pub async fn remove_side_es_module(
+    &mut self,
+    specifier: &ModuleSpecifier,
+  ) -> Result<ModuleId, Error> {
+    self.inner.main_realm.remove_side_es_module(specifier).await
   }
 
   /// Load and evaluate an ES module provided the specifier and source code.


### PR DESCRIPTION
Related issue: https://github.com/denoland/deno_core/issues/885
Example usage: https://github.com/kurtexdev/kurtex/blob/main/crates/kurtex_core/src/deno/runtime.rs#L110

Look at the tests to understand in more detail what the functionality is about. The point is to update existing V8 modules with the old `JsRuntime` instance, without creating new ones.

If you have any ideas, let me know, and I'll finish this PR.