### PR TITLE
fix: explicitly set the named lifetime to static

### DIFF
--- a/core/runtime/snapshot.rs
+++ b/core/runtime/snapshot.rs
@@ -29,7 +29,7 @@ pub(crate) struct V8Snapshot(pub(crate) &'static [u8]);
 
 pub(crate) fn deconstruct(
   slice: &'static [u8],
-) -> (V8Snapshot, SerializableSnapshotSidecarData) {
+) -> (V8Snapshot, SerializableSnapshotSidecarData<'static>) {
   let len =
     usize::from_le_bytes(slice[slice.len() - ULEN..].try_into().unwrap());
   let data = SerializableSnapshotSidecarData::from_slice(


### PR DESCRIPTION
Due to a change in Rust nightly, the Rust linter now warns when an elided lifetime ends up being a named lifetime [1]. In this case, the elided lifetime is `'static`, so we should explicitly set the lifetime to `'static`.

[1] https://github.com/rust-lang/rust/pull/129207