### PR TITLE
fix: upgrade V8 to v0.106

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2728,9 +2728,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.105.0"
+version = "0.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692624c4fd58ff50aa6d690c159df18e7881c13970005b9b2bff77dc425fd370"
+checksum = "a381badc47c6f15acb5fe0b5b40234162349ed9d4e4fd7c83a7f5547c0fc69c5"
 dependencies = [
  "bindgen",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ deno_ops = { version = "0.183.0", path = "./ops" }
 serde_v8 = { version = "0.216.0", path = "./serde_v8" }
 deno_core_testing = { path = "./testing" }
 
-v8 = { version = "0.105.0", default-features = false }
+v8 = { version = "0.106.0", default-features = false }
 deno_ast = { version = "=0.40.0", features = ["transpiling"] }
 deno_unsync = "0.4.0"
 deno_core_icudata = "0.0.73"

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -151,6 +151,7 @@ pub(crate) struct InnerIsolateState {
   main_realm: ManuallyDrop<JsRealm>,
   pub(crate) state: ManuallyDropRc<JsRuntimeState>,
   v8_isolate: ManuallyDrop<v8::OwnedIsolate>,
+  v8_cpp_heap: ManuallyDrop<v8::UniqueRef<v8::cppgc::Heap>>,
 }
 
 impl InnerIsolateState {
@@ -187,18 +188,29 @@ impl InnerIsolateState {
     debug_assert_eq!(Rc::strong_count(&self.state), 1);
   }
 
+  pub fn cleanup_cpp_heap(&mut self) {
+    self.v8_isolate.detach_cpp_heap();
+    self.v8_cpp_heap.terminate();
+    unsafe {
+      ManuallyDrop::drop(&mut self.v8_cpp_heap);
+    }
+  }
+
   pub fn prepare_for_snapshot(mut self) -> v8::OwnedIsolate {
     self.cleanup();
+
     // SAFETY: We're copying out of self and then immediately forgetting self
-    let (state, isolate) = unsafe {
-      (
-        ManuallyDrop::take(&mut self.state.0),
-        ManuallyDrop::take(&mut self.v8_isolate),
-      )
-    };
-    std::mem::forget(self);
-    drop(state);
-    isolate
+    unsafe {
+      ManuallyDrop::drop(&mut self.state.0);
+
+      self.cleanup_cpp_heap();
+
+      let isolate = ManuallyDrop::take(&mut self.v8_isolate);
+
+      std::mem::forget(self);
+
+      isolate
+    }
   }
 }
 
@@ -208,6 +220,9 @@ impl Drop for InnerIsolateState {
     // SAFETY: We gotta drop these
     unsafe {
       ManuallyDrop::drop(&mut self.state.0);
+
+      self.cleanup_cpp_heap();
+
       if self.will_snapshot {
         // Create the snapshot and just drop it.
         #[allow(clippy::print_stderr)]
@@ -918,6 +933,8 @@ impl JsRuntime {
       maybe_startup_snapshot,
       external_refs_static,
     );
+    let mut cpp_heap = setup::create_cpp_heap();
+    isolate.attach_cpp_heap(&mut cpp_heap);
 
     if state_rc.import_assertions_support.has_warning() {
       isolate.add_message_listener_with_error_level(
@@ -1092,6 +1109,7 @@ impl JsRuntime {
         main_realm: ManuallyDrop::new(main_realm),
         state: ManuallyDropRc(ManuallyDrop::new(state_rc)),
         v8_isolate: ManuallyDrop::new(isolate),
+        v8_cpp_heap: ManuallyDrop::new(cpp_heap),
       },
       allocations: isolate_allocations,
       files_loaded_from_fs_during_snapshot: vec![],

--- a/core/runtime/setup.rs
+++ b/core/runtime/setup.rs
@@ -111,7 +111,7 @@ pub fn init_v8(
   });
 }
 
-fn create_cpp_heap() -> v8::UniqueRef<v8::cppgc::Heap> {
+pub fn create_cpp_heap() -> v8::UniqueRef<v8::cppgc::Heap> {
   v8::cppgc::Heap::create(
     v8::V8::get_current_platform(),
     v8::cppgc::HeapCreateParams::default(),
@@ -129,8 +129,7 @@ pub fn create_isolate(
     .embedder_wrapper_type_info_offsets(
       V8_WRAPPER_TYPE_INDEX,
       V8_WRAPPER_OBJECT_INDEX,
-    )
-    .cpp_heap(create_cpp_heap());
+    );
   let mut isolate = if will_snapshot {
     snapshot::create_snapshot_creator(
       external_refs,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.81.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Fixes: https://github.com/denoland/deno_core/issues/894

The IsolateParams `cpp_heap` option has bugs, so switch back to `attach_cpp_heap`.