### PR TITLE
fix: remove future machiney from evaluate_sync

### DIFF
--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -2337,12 +2337,7 @@ impl JsRuntime {
     let isolate = &mut self.inner.v8_isolate;
     let realm = &self.inner.main_realm;
     let scope = &mut realm.handle_scope(isolate);
-    self
-      .inner
-      .main_realm
-      .0
-      .module_map
-      .mod_evaluate(scope, id, true)
+    self.inner.main_realm.0.module_map.mod_evaluate(scope, id)
   }
 
   /// Asynchronously load specified module and all of its dependencies.


### PR DESCRIPTION
Fixes crash reported in https://github.com/denoland/deno/issues/20610#issuecomment-2357238775

The assert was intended to mean that the promise returned from evaluate should always be settled, but instead we were asserting that the mpsc::channel never needed to be polled more than once. Also fixes an issue where we were draining the microtask queue within `op_import_sync`, which is wrong.