### PR TITLE
Fix panic in `prepare_stack_trace_callback` when global interceptor throws

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -1251,12 +1251,10 @@ pub fn prepare_stack_trace_callback<'s>(
   // `globalThis.Error.prepareStackTrace`
   let global = scope.get_current_context().global(scope);
   let global_error = get_property(scope, global, ERROR).map(|g| g.cast());
-  let prepare_fn = global_error
-    .map(|g| {
-      get_property(scope, g, PREPARE_STACK_TRACE)
-        .and_then(|f| f.try_cast::<v8::Function>().ok())
-    })
-    .flatten();
+  let prepare_fn = global_error.and_then(|g| {
+    get_property(scope, g, PREPARE_STACK_TRACE)
+      .and_then(|f| f.try_cast::<v8::Function>().ok())
+  });
 
   if let Some(prepare_fn) = prepare_fn {
     // User defined `Error.prepareStackTrace`.

--- a/core/error.rs
+++ b/core/error.rs
@@ -1250,9 +1250,8 @@ pub fn prepare_stack_trace_callback<'s>(
 
   // `globalThis.Error.prepareStackTrace`
   let global = scope.get_current_context().global(scope);
-  let global_error = get_property(scope, global, ERROR)
-    .map(|g| g.try_cast().ok())
-    .flatten();
+  let global_error =
+    get_property(scope, global, ERROR).and_then(|g| g.try_cast().ok());
   let prepare_fn = global_error.and_then(|g| {
     get_property(scope, g, PREPARE_STACK_TRACE)
       .and_then(|f| f.try_cast::<v8::Function>().ok())

--- a/core/error.rs
+++ b/core/error.rs
@@ -1250,9 +1250,13 @@ pub fn prepare_stack_trace_callback<'s>(
 
   // `globalThis.Error.prepareStackTrace`
   let global = scope.get_current_context().global(scope);
-  let global_error = get_property(scope, global, ERROR).unwrap().cast();
-  let prepare_fn = get_property(scope, global_error, PREPARE_STACK_TRACE)
-    .and_then(|f| f.try_cast::<v8::Function>().ok());
+  let global_error = get_property(scope, global, ERROR).map(|g| g.cast());
+  let prepare_fn = global_error
+    .map(|g| {
+      get_property(scope, g, PREPARE_STACK_TRACE)
+        .and_then(|f| f.try_cast::<v8::Function>().ok())
+    })
+    .flatten();
 
   if let Some(prepare_fn) = prepare_fn {
     // User defined `Error.prepareStackTrace`.
@@ -1274,7 +1278,7 @@ pub fn prepare_stack_trace_callback<'s>(
     let patched_callsites = v8::Array::new_with_elements(scope, &patched);
 
     // call the user's `prepareStackTrace` with our patched "callsite" objects
-    let this = global_error.into();
+    let this = global_error.unwrap().into();
     let args = &[error, patched_callsites.into()];
     return prepare_fn
       .call(scope, this, args)

--- a/core/error.rs
+++ b/core/error.rs
@@ -1250,7 +1250,9 @@ pub fn prepare_stack_trace_callback<'s>(
 
   // `globalThis.Error.prepareStackTrace`
   let global = scope.get_current_context().global(scope);
-  let global_error = get_property(scope, global, ERROR).map(|g| g.cast());
+  let global_error = get_property(scope, global, ERROR)
+    .map(|g| g.try_cast().ok())
+    .flatten();
   let prepare_fn = global_error.and_then(|g| {
     get_property(scope, g, PREPARE_STACK_TRACE)
       .and_then(|f| f.try_cast::<v8::Function>().ok())

--- a/testing/integration/error_prepare_stack_trace_crash/error_prepare_stack_trace_crash.js
+++ b/testing/integration/error_prepare_stack_trace_crash/error_prepare_stack_trace_crash.js
@@ -1,0 +1,5 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+delete globalThis.Error;
+
+const e = new TypeError("e");
+e.stack;

--- a/testing/lib.rs
+++ b/testing/lib.rs
@@ -64,6 +64,7 @@ integration_test!(
   error_eval_stack,
   error_ext_stack,
   error_prepare_stack_trace,
+  error_prepare_stack_trace_crash,
   error_with_stack,
   error_without_stack,
   error_get_file_name,


### PR DESCRIPTION
Fix panic when a global interceptor is misconfigured or throws an exception. 

Fixes https://github.com/denoland/deno/pull/24985#issuecomment-2365460210 and https://github.com/denoland/deno/issues/26240