### PR TITLE
build: remove futures dep from dcore binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,6 @@ dependencies = [
  "deno_core",
  "deno_core_testing",
  "fastwebsockets",
- "futures",
  "http",
  "http-body-util",
  "hyper",

--- a/dcore/Cargo.toml
+++ b/dcore/Cargo.toml
@@ -19,11 +19,10 @@ deno_core_testing.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-deno_core_testing.workspace = true
 clap = "4.5.1"
 deno_core.workspace = true
+deno_core_testing.workspace = true
 fastwebsockets = { version = "0.6", features = ["upgrade", "unstable-split"] }
-futures.workspace = true
 http = { version = "1.0" }
 http-body-util = { version = "0.1" }
 hyper = { version = "=1.1.0", features = ["full"] }


### PR DESCRIPTION
To fix `cargo-machete` lint.