### PR TITLE
fix: add top-level error fallback for get_error_code

### DIFF
--- a/core/error_codes.rs
+++ b/core/error_codes.rs
@@ -4,8 +4,8 @@ use anyhow::Error;
 
 pub fn get_error_code(err: &Error) -> Option<&'static str> {
   err
-    .chain()
-    .find_map(|e| e.downcast_ref::<std::io::Error>())
+    .downcast_ref::<std::io::Error>()
+    .or_else(|| err.chain().find_map(|e| e.downcast_ref::<std::io::Error>()))
     .map(|e| match e.raw_os_error() {
       Some(code) => get_os_error_code(code),
       None => get_io_error_code(e),


### PR DESCRIPTION
Apparently anyhow's chain doesnt include the top level error, even though some resources state otherwise.
This fixes to add a fallback for the top-level error