### PR TITLE
fix: use non-special formatting for OpError message

### DIFF
--- a/core/runtime/op_driver/op_results.rs
+++ b/core/runtime/op_driver/op_results.rs
@@ -275,7 +275,7 @@ impl OpError {
   pub fn new(get_class: GetErrorClassFn, err: Error) -> Self {
     Self {
       class_name: (get_class)(&err),
-      message: format!("{err:#}"),
+      message: err.to_string(),
       code: crate::error_codes::get_error_code(&err),
     }
   }


### PR DESCRIPTION
This is causing duplicate messages to show up during the efforts of https://github.com/denoland/deno/issues/26171. 
This change does not affect errors as they currently are, and also all tests in CLI (and WPT) pass locally without trouble