### PR TITLE
Upgrade to twox-hash 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2623,14 +2623,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "rand",
- "static_assertions",
-]
+checksum = "d09466de2fbca05ea830e16e62943f26607ab2148fb72b642505541711d99ad2"
 
 [[package]]
 name = "typed-arena"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ strum_macros = "0.25.0"
 testing_macros = "0.2.11"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
-twox-hash = "1.6.3"
+twox-hash = { version = "2.0.0", default-features = false, features = ["xxhash64"] }
 url = { version = "2", features = ["serde", "expose_internals"] }
 
 # macros


### PR DESCRIPTION
Thanks for using my crate!

Note that version 2.0 increases the MSRV to Rust 1.81. I understand if you don't want to upgrade right away, but hopefully this PR will be useful when you do.

I'm opening these PRs for the top users of twox-hash and have no current plans to become a consistent contributor to this specific repository; please feel free to rewrite the commit as appropriate for your project's requirements.