### PR TITLE
Clamp smi in fast calls by default

### DIFF
--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -135,6 +135,8 @@ impl FastSignature {
 
     quote!(
       use deno_core::v8::fast_api::Type as CType;
+      use deno_core::v8;
+
       deno_core::v8::fast_api::CFunction::new(
         Self::#fast_function as _,
         &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -230,8 +232,16 @@ impl V8FastCallType {
     match &self {
       V8FastCallType::Void => quote!(CType::Void.scalar()),
       V8FastCallType::Bool => quote!(CType::Bool.scalar()),
-      V8FastCallType::U32 => quote!(CType::Uint32.scalar()),
-      V8FastCallType::I32 => quote!(CType::Int32.scalar()),
+      V8FastCallType::U32 => quote!(v8::fast_api::CTypeInfo::new(
+        CType::Uint32,
+        v8::fast_api::SequenceType::Scalar,
+        v8::fast_api::Flags::Clamp
+      )),
+      V8FastCallType::I32 => quote!(v8::fast_api::CTypeInfo::new(
+        CType::Int32,
+        v8::fast_api::SequenceType::Scalar,
+        v8::fast_api::Flags::Clamp
+      )),
       V8FastCallType::U64 => quote!(CType::Uint64.scalar()),
       V8FastCallType::I64 => quote!(CType::Int64.scalar()),
       V8FastCallType::F32 => quote!(CType::Float32.scalar()),

--- a/ops/op2/test_cases/async/async_deferred.out
+++ b/ops/op2/test_cases/async/async_deferred.out
@@ -16,13 +16,18 @@ pub const fn op_async_deferred() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         CType::Void.scalar(),
                         &[
                             CType::V8Value.scalar(),
-                            CType::Int32.scalar(),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
                             CType::CallbackOptions.scalar(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
@@ -31,13 +36,18 @@ pub const fn op_async_deferred() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         CType::Void.scalar(),
                         &[
                             CType::V8Value.scalar(),
-                            CType::Int32.scalar(),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
                             CType::CallbackOptions.scalar(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,

--- a/ops/op2/test_cases/async/async_lazy.out
+++ b/ops/op2/test_cases/async/async_lazy.out
@@ -16,13 +16,18 @@ pub const fn op_async_lazy() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         CType::Void.scalar(),
                         &[
                             CType::V8Value.scalar(),
-                            CType::Int32.scalar(),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
                             CType::CallbackOptions.scalar(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
@@ -31,13 +36,18 @@ pub const fn op_async_lazy() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         CType::Void.scalar(),
                         &[
                             CType::V8Value.scalar(),
-                            CType::Int32.scalar(),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
                             CType::CallbackOptions.scalar(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -16,14 +16,27 @@ const fn op_add() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Uint32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Uint32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[
                             CType::V8Value.scalar(),
-                            CType::Uint32.scalar(),
-                            CType::Uint32.scalar(),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Uint32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Uint32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -31,14 +44,27 @@ const fn op_add() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Uint32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Uint32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[
                             CType::V8Value.scalar(),
-                            CType::Uint32.scalar(),
-                            CType::Uint32.scalar(),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Uint32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Uint32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
                             CType::CallbackOptions.scalar(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,

--- a/ops/op2/test_cases/sync/bigint.out
+++ b/ops/op2/test_cases/sync/bigint.out
@@ -16,6 +16,7 @@ pub const fn op_bigint() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -27,6 +28,7 @@ pub const fn op_bigint() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(

--- a/ops/op2/test_cases/sync/bool.out
+++ b/ops/op2/test_cases/sync/bool.out
@@ -16,6 +16,7 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -27,6 +28,7 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -16,6 +16,7 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -31,6 +32,7 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -16,6 +16,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -33,6 +34,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -296,6 +298,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -313,6 +316,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -16,6 +16,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -32,6 +33,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -252,6 +254,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -267,6 +270,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(

--- a/ops/op2/test_cases/sync/cfg.out
+++ b/ops/op2/test_cases/sync/cfg.out
@@ -18,6 +18,7 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -29,6 +30,7 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -162,6 +164,7 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -173,6 +176,7 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(

--- a/ops/op2/test_cases/sync/clippy_allow.out
+++ b/ops/op2/test_cases/sync/clippy_allow.out
@@ -18,6 +18,7 @@ pub const fn op_extra_annotation() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -29,6 +30,7 @@ pub const fn op_extra_annotation() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -160,6 +162,7 @@ pub const fn op_clippy_internal() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -171,6 +174,7 @@ pub const fn op_clippy_internal() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -16,6 +16,7 @@ const fn op_cppgc_object() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -31,6 +32,7 @@ const fn op_cppgc_object() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -218,6 +220,7 @@ const fn op_option_cppgc_object() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -233,6 +236,7 @@ const fn op_option_cppgc_object() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -521,6 +525,7 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -536,6 +541,7 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -819,6 +825,7 @@ const fn op_use_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -834,6 +841,7 @@ const fn op_use_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(

--- a/ops/op2/test_cases/sync/doc_comment.out
+++ b/ops/op2/test_cases/sync/doc_comment.out
@@ -17,6 +17,7 @@ pub const fn op_has_doc_comment() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -28,6 +29,7 @@ pub const fn op_has_doc_comment() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(

--- a/ops/op2/test_cases/sync/fast_alternative.out
+++ b/ops/op2/test_cases/sync/fast_alternative.out
@@ -133,14 +133,27 @@ const fn op_fast() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Uint32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Uint32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[
                             CType::V8Value.scalar(),
-                            CType::Uint32.scalar(),
-                            CType::Uint32.scalar(),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Uint32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Uint32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -148,14 +161,27 @@ const fn op_fast() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Uint32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Uint32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[
                             CType::V8Value.scalar(),
-                            CType::Uint32.scalar(),
-                            CType::Uint32.scalar(),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Uint32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Uint32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
                             CType::CallbackOptions.scalar(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
@@ -442,14 +468,27 @@ const fn op_fast_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Uint32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Uint32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[
                             CType::V8Value.scalar(),
-                            CType::Uint32.scalar(),
-                            CType::Uint32.scalar(),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Uint32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Uint32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -457,14 +496,27 @@ const fn op_fast_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Uint32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Uint32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[
                             CType::V8Value.scalar(),
-                            CType::Uint32.scalar(),
-                            CType::Uint32.scalar(),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Uint32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Uint32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
                             CType::CallbackOptions.scalar(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -16,6 +16,7 @@ pub const fn op_generics<T: Trait>() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -27,6 +28,7 @@ pub const fn op_generics<T: Trait>() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -156,6 +158,7 @@ pub const fn op_generics_static<T: Trait + 'static>() -> ::deno_core::_ops::OpDe
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -167,6 +170,7 @@ pub const fn op_generics_static<T: Trait + 'static>() -> ::deno_core::_ops::OpDe
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -296,6 +300,7 @@ pub const fn op_generics_static_where<T: Trait + 'static>() -> ::deno_core::_ops
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -307,6 +312,7 @@ pub const fn op_generics_static_where<T: Trait + 'static>() -> ::deno_core::_ops
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(

--- a/ops/op2/test_cases/sync/op_state_attr.out
+++ b/ops/op2/test_cases/sync/op_state_attr.out
@@ -16,6 +16,7 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -27,6 +28,7 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(

--- a/ops/op2/test_cases/sync/op_state_rc.out
+++ b/ops/op2/test_cases/sync/op_state_rc.out
@@ -16,6 +16,7 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -27,6 +28,7 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -16,6 +16,7 @@ const fn op_state_ref() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -27,6 +28,7 @@ const fn op_state_ref() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -184,6 +186,7 @@ const fn op_state_mut() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -195,6 +198,7 @@ const fn op_state_mut() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -464,6 +468,7 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -479,6 +484,7 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(

--- a/ops/op2/test_cases/sync/result_external.out
+++ b/ops/op2/test_cases/sync/result_external.out
@@ -16,6 +16,7 @@ pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -27,6 +28,7 @@ pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -16,10 +16,15 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Uint32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Uint32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -27,10 +32,15 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Uint32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Uint32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),

--- a/ops/op2/test_cases/sync/result_scope.out
+++ b/ops/op2/test_cases/sync/result_scope.out
@@ -16,6 +16,7 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -27,6 +28,7 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -16,6 +16,7 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -27,6 +28,7 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -16,16 +16,37 @@ const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Int32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Int32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[
                             CType::V8Value.scalar(),
-                            CType::Int32.scalar(),
-                            CType::Int32.scalar(),
-                            CType::Int32.scalar(),
-                            CType::Int32.scalar(),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -33,16 +54,37 @@ const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Int32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Int32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[
                             CType::V8Value.scalar(),
-                            CType::Int32.scalar(),
-                            CType::Int32.scalar(),
-                            CType::Int32.scalar(),
-                            CType::Int32.scalar(),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
                             CType::CallbackOptions.scalar(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
@@ -252,16 +294,37 @@ const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Int32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Int32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[
                             CType::V8Value.scalar(),
-                            CType::Int32.scalar(),
-                            CType::Int32.scalar(),
-                            CType::Int32.scalar(),
-                            CType::Int32.scalar(),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -269,16 +332,37 @@ const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Int32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Int32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[
                             CType::V8Value.scalar(),
-                            CType::Int32.scalar(),
-                            CType::Int32.scalar(),
-                            CType::Int32.scalar(),
-                            CType::Int32.scalar(),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
+                            v8::fast_api::CTypeInfo::new(
+                                CType::Int32,
+                                v8::fast_api::SequenceType::Scalar,
+                                v8::fast_api::Flags::Clamp,
+                            ),
                             CType::CallbackOptions.scalar(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,

--- a/ops/op2/test_cases/sync/string_cow.out
+++ b/ops/op2/test_cases/sync/string_cow.out
@@ -16,10 +16,15 @@ const fn op_string_cow() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Uint32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Uint32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[CType::V8Value.scalar(), CType::SeqOneByteString.scalar()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -27,10 +32,15 @@ const fn op_string_cow() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Uint32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Uint32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[
                             CType::V8Value.scalar(),
                             CType::SeqOneByteString.scalar(),

--- a/ops/op2/test_cases/sync/string_onebyte.out
+++ b/ops/op2/test_cases/sync/string_onebyte.out
@@ -16,10 +16,15 @@ const fn op_string_onebyte() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Uint32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Uint32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[CType::V8Value.scalar(), CType::SeqOneByteString.scalar()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -27,10 +32,15 @@ const fn op_string_onebyte() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Uint32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Uint32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[
                             CType::V8Value.scalar(),
                             CType::SeqOneByteString.scalar(),

--- a/ops/op2/test_cases/sync/string_owned.out
+++ b/ops/op2/test_cases/sync/string_owned.out
@@ -16,10 +16,15 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Uint32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Uint32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[CType::V8Value.scalar(), CType::SeqOneByteString.scalar()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -27,10 +32,15 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Uint32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Uint32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[
                             CType::V8Value.scalar(),
                             CType::SeqOneByteString.scalar(),

--- a/ops/op2/test_cases/sync/string_ref.out
+++ b/ops/op2/test_cases/sync/string_ref.out
@@ -16,10 +16,15 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Uint32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Uint32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[CType::V8Value.scalar(), CType::SeqOneByteString.scalar()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -27,10 +32,15 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Uint32.scalar(),
+                        v8::fast_api::CTypeInfo::new(
+                            CType::Uint32,
+                            v8::fast_api::SequenceType::Scalar,
+                            v8::fast_api::Flags::Clamp,
+                        ),
                         &[
                             CType::V8Value.scalar(),
                             CType::SeqOneByteString.scalar(),

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -16,6 +16,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
             Self::v8_fn_ptr_metrics as _,
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
@@ -32,6 +33,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
             }),
             Some({
                 use deno_core::v8::fast_api::Type as CType;
+                use deno_core::v8;
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(


### PR DESCRIPTION
Ref https://github.com/denoland/deno/issues/26480

Matches Rust's `as` cast (used by slow calls)