### PR TITLE
fix: return wrapped module instead of original module

### DIFF
--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -530,7 +530,7 @@ fn wrap_module<'s>(
 
   wrapper_module.evaluate(scope)?;
 
-  Some(module)
+  Some(wrapper_module)
 }
 
 #[op2(reentrant)]


### PR DESCRIPTION
We were adding the `__esModule` export as intended, but then returning the original module instead of the wrapped one.