### PR TITLE
Default to camelCase for object wrap ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,7 @@ dependencies = [
  "proc-macro-rules",
  "proc-macro2",
  "quote",
+ "stringcase",
  "strum",
  "strum_macros",
  "syn",
@@ -1998,6 +1999,12 @@ dependencies = [
  "swc_macros_common",
  "syn",
 ]
+
+[[package]]
+name = "stringcase"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04028eeb851ed08af6aba5caa29f2d59a13ed168cee4d6bd753aeefcf1d636b0"
 
 [[package]]
 name = "strsim"

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -429,7 +429,6 @@ fn op_ctx_template_or_accessor<'s>(
 
   let op_ctx_ptr = op_ctx as *const OpCtx as *const c_void;
   let external = v8::External::new(scope, op_ctx_ptr as *mut c_void);
-  let key = op_ctx.decl.name_fast.v8_string(scope).into();
 
   if let Some((named_getter, named_setter)) =
     accessor_store.get(op_ctx.decl.name)
@@ -460,6 +459,7 @@ fn op_ctx_template_or_accessor<'s>(
       None
     };
 
+    let key = op_ctx.decl.name_fast.v8_string(scope).into();
     tmpl.set_accessor_property(
       key,
       Some(getter_fn),

--- a/ops/Cargo.toml
+++ b/ops/Cargo.toml
@@ -22,6 +22,7 @@ strum.workspace = true
 strum_macros.workspace = true
 syn.workspace = true
 thiserror.workspace = true
+stringcase = "0.3.0"
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/ops/op2/object_wrap.rs
+++ b/ops/op2/object_wrap.rs
@@ -85,6 +85,12 @@ pub(crate) fn generate_impl_ops(
       /* First attribute idents, for all functions in block */
       let attrs = method.attrs.swap_remove(0);
 
+      /* Convert snake_case to camelCase */
+      method.sig.ident = format_ident!(
+        "{}",
+        stringcase::camel_case(&method.sig.ident.to_string())
+      );
+
       let ident = method.sig.ident.clone();
       let func = ItemFn {
         attrs: method.attrs,

--- a/testing/ops.d.ts
+++ b/testing/ops.d.ts
@@ -22,7 +22,7 @@ export function op_worker_terminate(...any: any[]): any;
 
 export class DOMPoint {
   constructor(x?: number, y?: number, z?: number, w?: number);
-  static from_point(
+  static fromPoint(
     other: { x?: number; y?: number; z?: number; w?: number },
   ): DOMPoint;
   x(): number;

--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -67,8 +67,8 @@ test(async function testCppgcAsync() {
 test(function testDomPoint() {
   const p1 = new DOMPoint(100, 100);
   const p2 = new DOMPoint();
-  const p3 = DOMPoint.from_point({ x: 200 });
-  const p4 = DOMPoint.from_point({ x: 0, y: 100, z: 99.9, w: 100 });
+  const p3 = DOMPoint.fromPoint({ x: 200 });
+  const p4 = DOMPoint.fromPoint({ x: 0, y: 100, z: 99.9, w: 100 });
   assertEquals(p1.x, 100);
   assertEquals(p2.x, 0);
   assertEquals(p3.x, 200);


### PR DESCRIPTION
`fn from_point` in Rust is exposed as `.fromPoint` in JS. I think this is better than having an explict rename attribute since that's very rare to be used.