### PR TITLE
fix: borrow checker errors with isolate and object wrap usage

### DIFF
--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -594,8 +594,8 @@ pub(crate) fn generate_dispatch_fast(
       #with_opstate;
       #with_stack_trace
       #with_js_runtime_state
-      #with_isolate
       #with_self
+      #with_isolate
       let #result = {
         #(#call_args)*
         #call (#(#call_names),*)

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -144,11 +144,11 @@ pub(crate) fn generate_dispatch_slow(
         #with_retval
         #with_args
         #with_opctx
+        #with_self
         #with_isolate
         #with_opstate
         #with_stack_trace
         #with_js_runtime_state
-        #with_self
 
         #output;
         return 0;


### PR DESCRIPTION
```
error[E0308]: mismatched types
   --> ext/webstorage/lib.rs:55:1
    |
55  | #[op2]
    | ^^^^^^
    | |
    | expected `&mut HandleScope<'_, ()>`, found `&mut &mut Isolate`
    | arguments to this function are incorrect
    |
    = note: expected mutable reference `&mut HandleScope<'_, ()>`
               found mutable reference `&mut &mut Isolate`
note: associated function defined here
   --> /Users/divy/.cargo/registry/src/index.crates.io-6f17d22bba15001f/v8-130.0.1/src/string.rs:368:10
    |
368 |   pub fn new_from_one_byte<'s>(
    |          ^^^^^^^^^^^^^^^^^
    = note: this error originates in the attribute macro `op2` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0308]: mismatched types
   --> ext/webstorage/lib.rs:55:1
    |
55  | #[op2]
    | ^^^^^^
    | |
    | expected `&mut HandleScope<'_>`, found `&mut &mut Isolate`
    | arguments to this function are incorrect
    |
    = note: expected mutable reference `&mut HandleScope<'_>`
               found mutable reference `&mut &mut Isolate`
note: associated function defined here
   --> /Users/divy/.cargo/registry/src/index.crates.io-6f17d22bba15001f/v8-130.0.1/src/exception.rs:368:10
    |
368 |   pub fn type_error<'s>(
    |          ^^^^^^^^^^
    = note: this error originates in the attribute macro `op2` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no method named `throw_exception` found for mutable reference `&mut Isolate` in the current scope
  --> ext/webstorage/lib.rs:55:1
   |
55 | #[op2]
   | ^^^^^^ method not found in `&mut Isolate`
   |
note: there's an earlier shadowed binding `scope` of type `CallbackScope<'_>` that has method `throw_exception` available
  --> ext/webstorage/lib.rs:55:1
   |
55 | #[op2]
   | ^^^^^^
   | |
   | `scope` of type `CallbackScope<'_>` that has method `throw_exception` defined earlier here
   | earlier `scope` shadowed here with type `&mut Isolate`
   = note: this error originates in the attribute macro `op2` (in Nightly builds, run with -Z macro-backtrace for more info)
```