### PR TITLE
Use wrapping cast for #[smi] arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+
+[[package]]
 name = "backtrace"
 version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +568,7 @@ name = "deno_core"
 version = "0.322.0"
 dependencies = [
  "anyhow",
+ "az",
  "bencher",
  "bincode",
  "bit-set",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -49,6 +49,7 @@ tokio.workspace = true
 url.workspace = true
 v8.workspace = true
 wasm_dep_analyzer = "0.1.0"
+az = "1.2.1"
 
 [dev-dependencies]
 bencher.workspace = true

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -500,6 +500,7 @@ pub(crate) fn op_ctx_template<'s>(
   } else {
     builder.build(scope)
   };
+  template.set_class_name(op_ctx.decl.name_fast.v8_string(scope));
 
   template
 }

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -143,6 +143,11 @@ impl DOMPoint {
   fn z(&self) -> f64 {
     self.z
   }
+
+  #[fast]
+  fn wrapping_smi(&self, #[smi] t: u32) -> u32 {
+    t
+  }
 }
 
 #[op2(fast)]

--- a/testing/ops.d.ts
+++ b/testing/ops.d.ts
@@ -25,5 +25,9 @@ export class DOMPoint {
   static fromPoint(
     other: { x?: number; y?: number; z?: number; w?: number },
   ): DOMPoint;
-  x(): number;
+  get x(): number;
+  get y(): number;
+  get z(): number;
+  get w(): number;
+  wrappingSmi(value: number): number;
 }

--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -82,4 +82,8 @@ test(function testDomPoint() {
     caught = e;
   }
   assert(caught);
+
+  assertEquals(p1.wrappingSmi(4294967295), 4294967295);
+  assertEquals(p1.wrappingSmi(4294967296), 0);
+  assertEquals(p1.wrappingSmi(4294967297), 1);
 });

--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -83,9 +83,10 @@ test(function testDomPoint() {
   }
   assert(caught);
 
-  assertEquals(p1.wrappingSmi(4294967295), 4294967295);
-  assertEquals(p1.wrappingSmi(4294967296), 0);
-  assertEquals(p1.wrappingSmi(4294967297), 1);
+  const u32Max = 4294967295; // test wrapping for smi
+  assertEquals(p1.wrappingSmi(u32Max), u32Max);
+  assertEquals(p1.wrappingSmi(u32Max + 1), 0);
+  assertEquals(p1.wrappingSmi(u32Max + 2), 1);
 
   assertEquals(
     p1.wrappingSmi.toString(),

--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -86,4 +86,9 @@ test(function testDomPoint() {
   assertEquals(p1.wrappingSmi(4294967295), 4294967295);
   assertEquals(p1.wrappingSmi(4294967296), 0);
   assertEquals(p1.wrappingSmi(4294967297), 1);
+
+  assertEquals(
+    p1.wrappingSmi.toString(),
+    DOMPoint.prototype.wrappingSmi.toString(),
+  );
 });


### PR DESCRIPTION
This is to match the default equivalent WebIDL converter. I don't know of any ops in Deno that depend on the clamping behavior.