### PR TITLE
Support `#[varargs]` in object wrap

### DIFF
--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -761,6 +761,11 @@ fn map_v8_fastcall_arg_to_arg(
         let #arg_ident = #arg_ident.try_borrow_mut::<#state>();
       }
     }
+    Arg::VarArgs => {
+      quote! {
+        let #arg_ident = None;
+      }
+    }
     Arg::String(Strings::RefStr) => {
       quote! {
         let mut #arg_temp: [::std::mem::MaybeUninit<u8>; deno_core::_ops::STRING_STACK_BUFFER_SIZE] = [::std::mem::MaybeUninit::uninit(); deno_core::_ops::STRING_STACK_BUFFER_SIZE];
@@ -888,6 +893,7 @@ fn map_arg_to_v8_fastcall_type(
     | Arg::Rc(Special::JsRuntimeState)
     | Arg::Ref(RefType::Ref, Special::JsRuntimeState)
     | Arg::State(..)
+    | Arg::VarArgs
     | Arg::Special(Special::Isolate)
     | Arg::OptionState(..) => V8FastCallType::Virtual,
     // Other types + ref types are not handled

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -493,6 +493,11 @@ pub fn from_arg(
         };
       })
     }
+    Arg::VarArgs => {
+      gs_quote!(generator_state(fn_args) => {
+        let #arg_ident = Some(#fn_args);
+      })
+    }
     Arg::Buffer(buffer_type, mode, source) => {
       // Explicit temporary lifetime extension so we can take a reference
       let temp = format_ident!("{}_temp", arg_ident);

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -495,7 +495,7 @@ pub fn from_arg(
     }
     Arg::VarArgs => {
       gs_quote!(generator_state(fn_args) => {
-        let #arg_ident = Some(#fn_args);
+        let #arg_ident = Some(&#fn_args);
       })
     }
     Arg::Buffer(buffer_type, mode, source) => {

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -86,7 +86,7 @@ impl TestObjectWrap {
   #[smi]
   fn with_varargs(
     &self,
-    #[varargs] args: Option<v8::FunctionCallbackArguments>,
+    #[varargs] args: Option<&v8::FunctionCallbackArguments>,
   ) -> u32 {
     args.map(|args| args.length() as u32).unwrap_or(0)
   }

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -71,6 +71,7 @@ pub fn op_stats_delete(
 }
 
 pub struct TestObjectWrap {}
+
 impl GarbageCollected for TestObjectWrap {}
 
 #[op2]
@@ -79,6 +80,15 @@ impl TestObjectWrap {
   #[cppgc]
   fn new(_: bool) -> TestObjectWrap {
     TestObjectWrap {}
+  }
+
+  #[fast]
+  #[smi]
+  fn with_varargs(
+    &self,
+    #[varargs] args: Option<v8::FunctionCallbackArguments>,
+  ) -> u32 {
+    args.map(|args| args.length() as u32).unwrap_or(0)
   }
 }
 

--- a/testing/checkin/runtime/object.ts
+++ b/testing/checkin/runtime/object.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { DOMPoint } from "ext:core/ops";
+import { DOMPoint, TestObjectWrap } from "ext:core/ops";
 
-export { DOMPoint };
+export { DOMPoint, TestObjectWrap };

--- a/testing/ops.d.ts
+++ b/testing/ops.d.ts
@@ -31,3 +31,8 @@ export class DOMPoint {
   get w(): number;
   wrappingSmi(value: number): number;
 }
+
+export class TestObjectWrap {
+  constructor();
+  withVarargs(...args: any[]): number;
+}

--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assert, assertArrayEquals, assertEquals, test } from "checkin:testing";
-import { DOMPoint } from "checkin:object";
+import { DOMPoint, TestObjectWrap } from "checkin:object";
 
 const {
   op_pipe_create,
@@ -92,4 +92,10 @@ test(function testDomPoint() {
     p1.wrappingSmi.toString(),
     DOMPoint.prototype.wrappingSmi.toString(),
   );
+
+  const wrap = new TestObjectWrap();
+  assertEquals(wrap.withVarargs(1, 2, 3), 3);
+  assertEquals(wrap.withVarargs(1, 2, 3, 4, 5), 5);
+  assertEquals(wrap.withVarargs(), 0);
+  assertEquals(wrap.withVarargs(undefined), 1);
 });


### PR DESCRIPTION
```rust
#[fast]
fn with_varargs(
  &self,
  #[varargs] args: Option<&v8::FunctionCallbackArguments>,
) {
    
}
```