### PR TITLE
experiment with moving `eventLoopTick` to rust

### DIFF
--- a/core/00_infra.js
+++ b/core/00_infra.js
@@ -31,6 +31,7 @@
   let nextPromiseId = 0;
   const promiseMap = new SafeMap();
   const RING_SIZE = 4 * 1024;
+  const outArray = [null, null];
   const NO_PROMISE = null; // Alias to null is faster than plain nulls
   const promiseRing = ArrayPrototypeFill(new Array(RING_SIZE), NO_PROMISE);
   // TODO(bartlomieju): in the future use `v8::Private` so it's not visible
@@ -198,9 +199,8 @@
       /* DO NOT MODIFY: use rebuild_async_stubs.js to regenerate */
       case 0:
         fn = function async_op_0() {
-          const id = nextPromiseId;
           try {
-            const maybeResult = originalOp(id);
+            const maybeResult = originalOp(outArray);
             if (maybeResult !== undefined) {
               return PromiseResolve(maybeResult);
             }
@@ -208,18 +208,17 @@
             ErrorCaptureStackTrace(err, async_op_0);
             return PromiseReject(err);
           }
+          const id = outArray[0];
           if (isLeakTracingEnabled) {
             submitLeakTrace(id);
           }
-          nextPromiseId = (id + 1) & 0xffffffff;
-          return setPromise(id);
+          return outArray[1];
         };
         break;
       case 1:
         fn = function async_op_1(a) {
-          const id = nextPromiseId;
           try {
-            const maybeResult = originalOp(id, a);
+            const maybeResult = originalOp(outArray, a);
             if (maybeResult !== undefined) {
               return PromiseResolve(maybeResult);
             }
@@ -227,18 +226,17 @@
             ErrorCaptureStackTrace(err, async_op_1);
             return PromiseReject(err);
           }
+          const id = outArray[0];
           if (isLeakTracingEnabled) {
             submitLeakTrace(id);
           }
-          nextPromiseId = (id + 1) & 0xffffffff;
-          return setPromise(id);
+          return outArray[1];
         };
         break;
       case 2:
         fn = function async_op_2(a, b) {
-          const id = nextPromiseId;
           try {
-            const maybeResult = originalOp(id, a, b);
+            const maybeResult = originalOp(outArray, a, b);
             if (maybeResult !== undefined) {
               return PromiseResolve(maybeResult);
             }
@@ -246,18 +244,17 @@
             ErrorCaptureStackTrace(err, async_op_2);
             return PromiseReject(err);
           }
+          const id = outArray[0];
           if (isLeakTracingEnabled) {
             submitLeakTrace(id);
           }
-          nextPromiseId = (id + 1) & 0xffffffff;
-          return setPromise(id);
+          return outArray[1];
         };
         break;
       case 3:
         fn = function async_op_3(a, b, c) {
-          const id = nextPromiseId;
           try {
-            const maybeResult = originalOp(id, a, b, c);
+            const maybeResult = originalOp(outArray, a, b, c);
             if (maybeResult !== undefined) {
               return PromiseResolve(maybeResult);
             }
@@ -265,18 +262,17 @@
             ErrorCaptureStackTrace(err, async_op_3);
             return PromiseReject(err);
           }
+          const id = outArray[0];
           if (isLeakTracingEnabled) {
             submitLeakTrace(id);
           }
-          nextPromiseId = (id + 1) & 0xffffffff;
-          return setPromise(id);
+          return outArray[1];
         };
         break;
       case 4:
         fn = function async_op_4(a, b, c, d) {
-          const id = nextPromiseId;
           try {
-            const maybeResult = originalOp(id, a, b, c, d);
+            const maybeResult = originalOp(outArray, a, b, c, d);
             if (maybeResult !== undefined) {
               return PromiseResolve(maybeResult);
             }
@@ -284,18 +280,17 @@
             ErrorCaptureStackTrace(err, async_op_4);
             return PromiseReject(err);
           }
+          const id = outArray[0];
           if (isLeakTracingEnabled) {
             submitLeakTrace(id);
           }
-          nextPromiseId = (id + 1) & 0xffffffff;
-          return setPromise(id);
+          return outArray[1];
         };
         break;
       case 5:
         fn = function async_op_5(a, b, c, d, e) {
-          const id = nextPromiseId;
           try {
-            const maybeResult = originalOp(id, a, b, c, d, e);
+            const maybeResult = originalOp(outArray, a, b, c, d, e);
             if (maybeResult !== undefined) {
               return PromiseResolve(maybeResult);
             }
@@ -303,18 +298,17 @@
             ErrorCaptureStackTrace(err, async_op_5);
             return PromiseReject(err);
           }
+          const id = outArray[0];
           if (isLeakTracingEnabled) {
             submitLeakTrace(id);
           }
-          nextPromiseId = (id + 1) & 0xffffffff;
-          return setPromise(id);
+          return outArray[1];
         };
         break;
       case 6:
         fn = function async_op_6(a, b, c, d, e, f) {
-          const id = nextPromiseId;
           try {
-            const maybeResult = originalOp(id, a, b, c, d, e, f);
+            const maybeResult = originalOp(outArray, a, b, c, d, e, f);
             if (maybeResult !== undefined) {
               return PromiseResolve(maybeResult);
             }
@@ -322,18 +316,17 @@
             ErrorCaptureStackTrace(err, async_op_6);
             return PromiseReject(err);
           }
+          const id = outArray[0];
           if (isLeakTracingEnabled) {
             submitLeakTrace(id);
           }
-          nextPromiseId = (id + 1) & 0xffffffff;
-          return setPromise(id);
+          return outArray[1];
         };
         break;
       case 7:
         fn = function async_op_7(a, b, c, d, e, f, g) {
-          const id = nextPromiseId;
           try {
-            const maybeResult = originalOp(id, a, b, c, d, e, f, g);
+            const maybeResult = originalOp(outArray, a, b, c, d, e, f, g);
             if (maybeResult !== undefined) {
               return PromiseResolve(maybeResult);
             }
@@ -341,18 +334,17 @@
             ErrorCaptureStackTrace(err, async_op_7);
             return PromiseReject(err);
           }
+          const id = outArray[0];
           if (isLeakTracingEnabled) {
             submitLeakTrace(id);
           }
-          nextPromiseId = (id + 1) & 0xffffffff;
-          return setPromise(id);
+          return outArray[1];
         };
         break;
       case 8:
         fn = function async_op_8(a, b, c, d, e, f, g, h) {
-          const id = nextPromiseId;
           try {
-            const maybeResult = originalOp(id, a, b, c, d, e, f, g, h);
+            const maybeResult = originalOp(outArray, a, b, c, d, e, f, g, h);
             if (maybeResult !== undefined) {
               return PromiseResolve(maybeResult);
             }
@@ -360,18 +352,17 @@
             ErrorCaptureStackTrace(err, async_op_8);
             return PromiseReject(err);
           }
+          const id = outArray[0];
           if (isLeakTracingEnabled) {
             submitLeakTrace(id);
           }
-          nextPromiseId = (id + 1) & 0xffffffff;
-          return setPromise(id);
+          return outArray[1];
         };
         break;
       case 9:
         fn = function async_op_9(a, b, c, d, e, f, g, h, i) {
-          const id = nextPromiseId;
           try {
-            const maybeResult = originalOp(id, a, b, c, d, e, f, g, h, i);
+            const maybeResult = originalOp(outArray, a, b, c, d, e, f, g, h, i);
             if (maybeResult !== undefined) {
               return PromiseResolve(maybeResult);
             }
@@ -379,11 +370,11 @@
             ErrorCaptureStackTrace(err, async_op_9);
             return PromiseReject(err);
           }
+          const id = outArray[0];
           if (isLeakTracingEnabled) {
             submitLeakTrace(id);
           }
-          nextPromiseId = (id + 1) & 0xffffffff;
-          return setPromise(id);
+          return outArray[1];
         };
         break;
       /* END TEMPLATE */

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -160,12 +160,6 @@
   // before last are alternating integers and any values that describe the
   // responses of async ops.
   function eventLoopTick() {
-    // First respond to all pending ops.
-    for (let i = 0; i < arguments.length - 3; i += 2) {
-      const promiseId = arguments[i];
-      const res = arguments[i + 1];
-      __resolvePromise(promiseId, res);
-    }
     // Drain nextTick queue if there's a tick scheduled.
     if (arguments[arguments.length - 1]) {
       for (let i = 0; i < nextTickCallbacks.length; i++) {

--- a/core/rebuild_async_stubs.js
+++ b/core/rebuild_async_stubs.js
@@ -6,7 +6,6 @@ const doNotModify =
 
 // The template function we build op_async_N functions from
 function __TEMPLATE__(__ARGS_PARAM__) {
-  const id = nextPromiseId;
   try {
     const maybeResult = __OP__(__ARGS__);
     if (maybeResult !== undefined) {
@@ -17,11 +16,11 @@ function __TEMPLATE__(__ARGS_PARAM__) {
     ErrorCaptureStackTrace(err, __TEMPLATE__);
     return PromiseReject(err);
   }
+  const id = outArray[0];
   if (isLeakTracingEnabled) {
     submitLeakTrace(id);
   }
-  nextPromiseId = (id + 1) & 0xffffffff;
-  return setPromise(id);
+  return outArray[1];
 }
 
 const infraJsPath = new URL("00_infra.js", import.meta.url);
@@ -36,7 +35,7 @@ let asyncStubCases = "/* BEGIN TEMPLATE setUpAsyncStub */\n";
 asyncStubCases += doNotModify;
 const vars = "abcdefghijklm";
 for (let i = 0; i < 10; i++) {
-  let args = "id";
+  let args = "outArray";
   for (let j = 0; j < i; j++) {
     args += `, ${vars[j]}`;
   }
@@ -45,7 +44,7 @@ for (let i = 0; i < 10; i++) {
   const func = `fn = ${templateString}`
     .replaceAll(/__TEMPLATE__/g, name)
     .replaceAll(/__ARGS__/g, args)
-    .replaceAll(/__ARGS_PARAM__/g, args.replace(/id(, )?/, ""))
+    .replaceAll(/__ARGS_PARAM__/g, args.replace(/outArray(, )?/, ""))
     .replaceAll(/__OP__/g, "originalOp")
     .replaceAll(/[\s]*__ERR__;/g, "")
     .replaceAll(/^/gm, "  ");

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -76,6 +76,7 @@ pub struct ContextState {
   pub(crate) get_error_class_fn: GetErrorClassFn,
   pub(crate) external_ops_tracker: ExternalOpsTracker,
   pub(crate) promises: Promises,
+  pub(crate) internal_promise_sym: RefCell<Option<Rc<v8::Global<v8::Symbol>>>>,
 }
 
 type PromiseId = i32;
@@ -130,6 +131,7 @@ impl ContextState {
       unrefed_ops: Default::default(),
       external_ops_tracker,
       promises: Default::default(),
+      internal_promise_sym: Default::default(),
     }
   }
 }
@@ -219,6 +221,7 @@ impl JsRealmInner {
     state.exception_state.prepare_to_destroy();
     std::mem::take(&mut *state.js_event_loop_tick_cb.borrow_mut());
     std::mem::take(&mut *state.js_wasm_streaming_cb.borrow_mut());
+    std::mem::take(&mut *state.internal_promise_sym.borrow_mut());
 
     {
       let ctx = self.context().open(isolate);

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -112,9 +112,10 @@ pub fn make_promise(
   let context = JsRealm::state_from_scope(scope);
   let prom = v8::PromiseResolver::new(scope).unwrap();
   let p = prom.get_promise(scope);
-  let s =
-    FastString::from_static("Deno.core.internalPromiseId").v8_string(scope);
-  let sym = v8::Symbol::for_key(scope, s);
+  let sym = v8::Local::new(
+    scope,
+    &*context.internal_promise_sym.borrow().clone().unwrap(),
+  );
   let prom = v8::Global::new(scope, prom);
   let id = context.promises.register_new(prom.clone());
   let id_v = v8::Integer::new(scope, id);

--- a/ops/op2/dispatch_async.rs
+++ b/ops/op2/dispatch_async.rs
@@ -95,7 +95,10 @@ pub(crate) fn generate_dispatch_async(
     let lazy = config.async_lazy;
     let deferred = config.async_deferred;
     output.extend(gs_quote!(generator_state(promise_id, fn_args, result, opctx, scope) => {
-      let #promise_id = deno_core::_ops::to_i32_option(&#fn_args.get(0)).unwrap_or_default();
+      let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+      let out_arr = #fn_args.get(0);
+      let (promise_id, promise) = deno_core::_ops::make_promise(&mut *scope);
+      deno_core::_ops::set_out_promises(&mut *scope, out_arr, promise_id, promise);
       // Lazy and deferred results will always return None
       deno_core::_ops::#mapper(#opctx, #lazy, #deferred, #promise_id, #result, |#scope, #result| {
         #return_value
@@ -103,7 +106,10 @@ pub(crate) fn generate_dispatch_async(
     }));
   } else {
     output.extend(gs_quote!(generator_state(promise_id, fn_args, result, opctx, scope) => {
-      let #promise_id = deno_core::_ops::to_i32_option(&#fn_args.get(0)).unwrap_or_default();
+      let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+      let out_arr = #fn_args.get(0);
+      let (promise_id, promise) = deno_core::_ops::make_promise(&mut *scope);
+      deno_core::_ops::set_out_promises(&mut *scope, out_arr, promise_id, promise);
       if let Some(#result) = deno_core::_ops::#mapper(#opctx, false, false, #promise_id, #result, |#scope, #result| {
         #return_value
       }) {


### PR DESCRIPTION
moves promise resolution and tracking from js to rust, curious to see if we could gain any perf from moving `eventLoopTick` to rust.

right now we have the rust event loop calling into JS to actually dispatch most of the event loop (which also often involves calling op_run_microtasks from JS, which calls back into rust!)

we might be able to skip a hop and eliminate `op_run_microtasks` entirely