### PR TITLE
allow static and instance methods with same name

### DIFF
--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -401,7 +401,14 @@ pub(crate) fn initialize_deno_core_ops_bindings<'s>(
 
     for method in op_method_ctx.static_methods.iter() {
       let op_fn = op_ctx_template(scope, method);
-      let method_key = method.decl.name_fast.v8_string(scope).unwrap();
+      let method_key = method.decl.name;
+      let method_key = method_key.strip_prefix("__static_").unwrap();
+      let method_key = v8::String::new_from_one_byte(
+        scope,
+        method_key.as_bytes(),
+        v8::NewStringType::Normal,
+      )
+      .unwrap();
       tmpl.set(method_key.into(), op_fn.into());
     }
 
@@ -1018,7 +1025,14 @@ pub fn create_exports_for_ops_virtual_module<'s>(
 
     for method in ctx.static_methods.iter() {
       let op_fn = op_ctx_template(scope, method);
-      let method_key = method.decl.name_fast.v8_string(scope).unwrap();
+      let method_key = method.decl.name;
+      let method_key = method_key.strip_prefix("__static_").unwrap();
+      let method_key = v8::String::new_from_one_byte(
+        scope,
+        method_key.as_bytes(),
+        v8::NewStringType::Normal,
+      )
+      .unwrap();
       tmpl.set(method_key.into(), op_fn.into());
     }
 

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -401,15 +401,8 @@ pub(crate) fn initialize_deno_core_ops_bindings<'s>(
 
     for method in op_method_ctx.static_methods.iter() {
       let op_fn = op_ctx_template(scope, method);
-      let method_key = method.decl.name;
-      let method_key = method_key.strip_prefix("__static_").unwrap();
-      let method_key = v8::String::new_from_one_byte(
-        scope,
-        method_key.as_bytes(),
-        v8::NewStringType::Normal,
-      )
-      .unwrap();
-      tmpl.set(method_key.into(), op_fn.into());
+      let method_key = method.decl.name_fast;
+      tmpl.set(method_key.v8_string(scope).unwrap().into(), op_fn.into());
     }
 
     let op_fn = tmpl.get_function(scope).unwrap();
@@ -533,17 +526,15 @@ fn create_accessor_store(ctx: &OpMethodCtx) -> AccessorStore {
   for method in ctx.methods.iter() {
     // Populate all setters first.
     if method.decl.accessor_type == AccessorType::Setter {
-      let key = method.decl.name_fast.to_string();
+      let key = method.decl.name_fast;
 
-      // All setters must start with "__set_".
-      let key = key.strip_prefix("__set_").expect("Invalid setter name");
-
+      let key_str = key.to_string();
       // There must be a getter for each setter.
       let getter = ctx
         .methods
         .iter()
         .find(|m| {
-          m.decl.name == key && m.decl.accessor_type == AccessorType::Getter
+          m.decl.name == key_str && m.decl.accessor_type == AccessorType::Getter
         })
         .expect("Getter not found for setter");
 
@@ -1025,15 +1016,8 @@ pub fn create_exports_for_ops_virtual_module<'s>(
 
     for method in ctx.static_methods.iter() {
       let op_fn = op_ctx_template(scope, method);
-      let method_key = method.decl.name;
-      let method_key = method_key.strip_prefix("__static_").unwrap();
-      let method_key = v8::String::new_from_one_byte(
-        scope,
-        method_key.as_bytes(),
-        v8::NewStringType::Normal,
-      )
-      .unwrap();
-      tmpl.set(method_key.into(), op_fn.into());
+      let method_key = method.decl.name_fast;
+      tmpl.set(method_key.v8_string(scope).unwrap().into(), op_fn.into());
     }
 
     let op_fn = tmpl.get_function(scope).unwrap();

--- a/ops/op2/mod.rs
+++ b/ops/op2/mod.rs
@@ -121,6 +121,8 @@ pub(crate) fn generate_op2(
   if config.setter {
     // Prepend "__set_" to the setter function name.
     func.sig.ident = format_ident!("__set_{}", func.sig.ident);
+  } else if config.static_member {
+    func.sig.ident = format_ident!("__static_{}", func.sig.ident);
   }
   let signature = parse_signature(func.attrs, func.sig.clone())?;
   if let Some(ident) = signature.lifetime.as_ref().map(|s| format_ident!("{s}"))

--- a/ops/op2/object_wrap.rs
+++ b/ops/op2/object_wrap.rs
@@ -116,7 +116,7 @@ pub(crate) fn generate_impl_ops(
 
         constructor = Some(ident);
       } else if config.static_member {
-        static_methods.push(ident);
+        static_methods.push(format_ident!("__static_{}", ident));
       } else {
         if config.setter {
           methods.push(format_ident!("__set_{}", ident));

--- a/ops/op2/test_cases/sync/object_wrap.out
+++ b/ops/op2/test_cases/sync/object_wrap.out
@@ -7,8 +7,9 @@ impl Foo {
             Foo::zzz(),
             Foo::withVarargs(),
             Foo::with_RENAME(),
+            Foo::doThing(),
         ],
-        static_methods: &[],
+        static_methods: &[Foo::__static_doThing()],
         constructor: Foo::constructor(),
         name: ::deno_core::__op_name_fast!(Foo),
         type_name: || std::any::type_name::<Foo>(),
@@ -260,9 +261,9 @@ impl Foo {
             _unconstructable: ::std::marker::PhantomData<()>,
         }
         impl ::deno_core::_ops::Op for __set_x {
-            const NAME: &'static str = stringify!(__set_x);
+            const NAME: &'static str = stringify!(x);
             const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
-                ::deno_core::__op_name_fast!(__set_x),
+                ::deno_core::__op_name_fast!(x),
                 false,
                 false,
                 1usize as u8,
@@ -928,5 +929,198 @@ impl Foo {
             fn call(&self) {}
         }
         <with_RENAME as ::deno_core::_ops::Op>::DECL
+    }
+    #[allow(non_camel_case_types)]
+    const fn __static_doThing() -> ::deno_core::_ops::OpDecl {
+        #[allow(non_camel_case_types)]
+        struct __static_doThing {
+            _unconstructable: ::std::marker::PhantomData<()>,
+        }
+        impl ::deno_core::_ops::Op for __static_doThing {
+            const NAME: &'static str = stringify!(doThing);
+            const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+                ::deno_core::__op_name_fast!(doThing),
+                false,
+                false,
+                0usize as u8,
+                false,
+                Self::v8_fn_ptr as _,
+                Self::v8_fn_ptr_metrics as _,
+                ::deno_core::AccessorType::None,
+                None,
+                None,
+                ::deno_core::OpMetadata {
+                    ..::deno_core::OpMetadata::default()
+                },
+            );
+        }
+        impl __static_doThing {
+            pub const fn name() -> &'static str {
+                <Self as deno_core::_ops::Op>::NAME
+            }
+            #[inline(always)]
+            fn slow_function_impl<'s>(
+                info: &'s deno_core::v8::FunctionCallbackInfo,
+            ) -> usize {
+                #[cfg(debug_assertions)]
+                let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                    &<Self as deno_core::_ops::Op>::DECL,
+                );
+                let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(
+                    info,
+                );
+                let result = { Self::call() };
+                deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+                return 0;
+            }
+            extern "C" fn v8_fn_ptr<'s>(
+                info: *const deno_core::v8::FunctionCallbackInfo,
+            ) {
+                let info: &'s _ = unsafe { &*info };
+                Self::slow_function_impl(info);
+            }
+            extern "C" fn v8_fn_ptr_metrics<'s>(
+                info: *const deno_core::v8::FunctionCallbackInfo,
+            ) {
+                let info: &'s _ = unsafe { &*info };
+                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                    info,
+                );
+                let opctx: &'s _ = unsafe {
+                    &*(deno_core::v8::Local::<
+                        deno_core::v8::External,
+                    >::cast_unchecked(args.data())
+                        .value() as *const deno_core::_ops::OpCtx)
+                };
+                deno_core::_ops::dispatch_metrics_slow(
+                    opctx,
+                    deno_core::_ops::OpMetricsEvent::Dispatched,
+                );
+                let res = Self::slow_function_impl(info);
+                if res == 0 {
+                    deno_core::_ops::dispatch_metrics_slow(
+                        opctx,
+                        deno_core::_ops::OpMetricsEvent::Completed,
+                    );
+                } else {
+                    deno_core::_ops::dispatch_metrics_slow(
+                        opctx,
+                        deno_core::_ops::OpMetricsEvent::Error,
+                    );
+                }
+            }
+        }
+        impl __static_doThing {
+            #[inline(always)]
+            fn call() {}
+        }
+        <__static_doThing as ::deno_core::_ops::Op>::DECL
+    }
+    #[allow(non_camel_case_types)]
+    const fn doThing() -> ::deno_core::_ops::OpDecl {
+        #[allow(non_camel_case_types)]
+        struct doThing {
+            _unconstructable: ::std::marker::PhantomData<()>,
+        }
+        impl ::deno_core::_ops::Op for doThing {
+            const NAME: &'static str = stringify!(doThing);
+            const DECL: ::deno_core::_ops::OpDecl = ::deno_core::_ops::OpDecl::new_internal_op2(
+                ::deno_core::__op_name_fast!(doThing),
+                false,
+                false,
+                0usize as u8,
+                false,
+                Self::v8_fn_ptr as _,
+                Self::v8_fn_ptr_metrics as _,
+                ::deno_core::AccessorType::None,
+                None,
+                None,
+                ::deno_core::OpMetadata {
+                    ..::deno_core::OpMetadata::default()
+                },
+            );
+        }
+        impl doThing {
+            pub const fn name() -> &'static str {
+                <Self as deno_core::_ops::Op>::NAME
+            }
+            #[inline(always)]
+            fn slow_function_impl<'s>(
+                info: &'s deno_core::v8::FunctionCallbackInfo,
+            ) -> usize {
+                #[cfg(debug_assertions)]
+                let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
+                    &<Self as deno_core::_ops::Op>::DECL,
+                );
+                let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
+                let mut rv = deno_core::v8::ReturnValue::from_function_callback_info(
+                    info,
+                );
+                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                    info,
+                );
+                let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
+                    Foo,
+                >(&mut scope, args.this().into()) else {
+                    let msg = deno_core::v8::String::new_from_one_byte(
+                            &mut scope,
+                            "expected Foo".as_bytes(),
+                            deno_core::v8::NewStringType::Normal,
+                        )
+                        .unwrap();
+                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
+                    scope.throw_exception(exc);
+                    return 1;
+                };
+                let self_ = &*self_;
+                let result = { Foo::call(self_) };
+                deno_core::_ops::RustToV8RetVal::to_v8_rv(result, &mut rv);
+                return 0;
+            }
+            extern "C" fn v8_fn_ptr<'s>(
+                info: *const deno_core::v8::FunctionCallbackInfo,
+            ) {
+                let info: &'s _ = unsafe { &*info };
+                Self::slow_function_impl(info);
+            }
+            extern "C" fn v8_fn_ptr_metrics<'s>(
+                info: *const deno_core::v8::FunctionCallbackInfo,
+            ) {
+                let info: &'s _ = unsafe { &*info };
+                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
+                    info,
+                );
+                let opctx: &'s _ = unsafe {
+                    &*(deno_core::v8::Local::<
+                        deno_core::v8::External,
+                    >::cast_unchecked(args.data())
+                        .value() as *const deno_core::_ops::OpCtx)
+                };
+                deno_core::_ops::dispatch_metrics_slow(
+                    opctx,
+                    deno_core::_ops::OpMetricsEvent::Dispatched,
+                );
+                let res = Self::slow_function_impl(info);
+                if res == 0 {
+                    deno_core::_ops::dispatch_metrics_slow(
+                        opctx,
+                        deno_core::_ops::OpMetricsEvent::Completed,
+                    );
+                } else {
+                    deno_core::_ops::dispatch_metrics_slow(
+                        opctx,
+                        deno_core::_ops::OpMetricsEvent::Error,
+                    );
+                }
+            }
+        }
+        trait Callable {
+            fn call(&self);
+        }
+        impl Callable for Foo {
+            #[inline(always)]
+            fn call(&self) {}
+        }
+        <doThing as ::deno_core::_ops::Op>::DECL
     }
 }

--- a/ops/op2/test_cases/sync/object_wrap.rs
+++ b/ops/op2/test_cases/sync/object_wrap.rs
@@ -50,4 +50,11 @@ impl Foo {
   #[nofast]
   #[rename("with_RENAME")]
   fn with_rename(&self) {}
+
+  #[nofast]
+  #[static_method]
+  fn do_thing() {}
+
+  #[nofast]
+  fn do_thing(&self) {}
 }

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -105,6 +105,31 @@ pub struct DOMPoint {
 
 impl GarbageCollected for DOMPoint {}
 
+impl DOMPoint {
+  fn from_point_inner(
+    scope: &mut v8::HandleScope,
+    other: v8::Local<v8::Object>,
+  ) -> Result<DOMPoint, AnyError> {
+    fn get(
+      scope: &mut v8::HandleScope,
+      other: v8::Local<v8::Object>,
+      key: &str,
+    ) -> Option<f64> {
+      let key = v8::String::new(scope, key).unwrap();
+      other
+        .get(scope, key.into())
+        .map(|x| x.to_number(scope).unwrap().value())
+    }
+
+    Ok(DOMPoint {
+      x: get(scope, other, "x").unwrap_or(0.0),
+      y: get(scope, other, "y").unwrap_or(0.0),
+      z: get(scope, other, "z").unwrap_or(0.0),
+      w: get(scope, other, "w").unwrap_or(0.0),
+    })
+  }
+}
+
 #[op2]
 impl DOMPoint {
   #[constructor]
@@ -130,23 +155,17 @@ impl DOMPoint {
     scope: &mut v8::HandleScope,
     other: v8::Local<v8::Object>,
   ) -> Result<DOMPoint, AnyError> {
-    fn get(
-      scope: &mut v8::HandleScope,
-      other: v8::Local<v8::Object>,
-      key: &str,
-    ) -> Option<f64> {
-      let key = v8::String::new(scope, key).unwrap();
-      other
-        .get(scope, key.into())
-        .map(|x| x.to_number(scope).unwrap().value())
-    }
+    DOMPoint::from_point_inner(scope, other)
+  }
 
-    Ok(DOMPoint {
-      x: get(scope, other, "x").unwrap_or(0.0),
-      y: get(scope, other, "y").unwrap_or(0.0),
-      z: get(scope, other, "z").unwrap_or(0.0),
-      w: get(scope, other, "w").unwrap_or(0.0),
-    })
+  #[required(1)]
+  #[cppgc]
+  fn from_point(
+    &self,
+    scope: &mut v8::HandleScope,
+    other: v8::Local<v8::Object>,
+  ) -> Result<DOMPoint, AnyError> {
+    DOMPoint::from_point_inner(scope, other)
   }
 
   #[getter]
@@ -165,6 +184,7 @@ impl DOMPoint {
   fn w(&self) -> f64 {
     self.w
   }
+
   #[getter]
   fn z(&self) -> f64 {
     self.z

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -185,6 +185,7 @@ impl DOMPoint {
     self.w
   }
 
+  #[fast]
   #[getter]
   fn z(&self) -> f64 {
     self.z

--- a/testing/ops.d.ts
+++ b/testing/ops.d.ts
@@ -25,6 +25,9 @@ export class DOMPoint {
   static fromPoint(
     other: { x?: number; y?: number; z?: number; w?: number },
   ): DOMPoint;
+  fromPoint(
+    other: { x?: number; y?: number; z?: number; w?: number },
+  ): DOMPoint;
   get x(): number;
   get y(): number;
   get z(): number;

--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -69,10 +69,12 @@ test(function testDomPoint() {
   const p2 = new DOMPoint();
   const p3 = DOMPoint.fromPoint({ x: 200 });
   const p4 = DOMPoint.fromPoint({ x: 0, y: 100, z: 99.9, w: 100 });
+  const p5 = p1.fromPoint({ x: 200 });
   assertEquals(p1.x, 100);
   assertEquals(p2.x, 0);
   assertEquals(p3.x, 200);
   assertEquals(p4.x, 0);
+  assertEquals(p5.x, 200);
 
   let caught;
   try {


### PR DESCRIPTION
To support e.g.

```rust
#[op2]
impl Foo {
  #[static_method]
  fn foo() {}

  fn foo(&self) {}
}
```