### PR TITLE
add `--strace-ops` flag to dcore

### DIFF
--- a/dcore/src/metrics.rs
+++ b/dcore/src/metrics.rs
@@ -1,0 +1,119 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use deno_core::anyhow::Error;
+use deno_core::OpDecl;
+use deno_core::OpMetricsEvent;
+use deno_core::OpMetricsFactoryFn;
+use deno_core::OpMetricsSource;
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+#[derive(Default, Debug, Clone, deno_core::serde::Serialize)]
+#[serde(crate = "deno_core::serde")]
+struct OpCount {
+  slow: u64,
+  fast: u64,
+  #[serde(rename = "async")]
+  async_: u64,
+}
+
+#[derive(Default, Debug, Clone, deno_core::serde::Serialize)]
+#[serde(crate = "deno_core::serde")]
+struct OpMetricsSummaryInner {
+  counts: HashMap<String, OpCount>,
+  completed_sync: u64,
+  completed_async: u64,
+  errored_sync: u64,
+  errored_async: u64,
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct OpMetricsSummary(Rc<RefCell<OpMetricsSummaryInner>>);
+
+impl OpMetricsSummary {
+  pub fn completed(&self, source: OpMetricsSource) {
+    let mut inner = self.0.borrow_mut();
+    if matches!(source, OpMetricsSource::Async) {
+      inner.completed_async += 1;
+    } else {
+      inner.completed_sync += 1;
+    }
+  }
+
+  pub fn dispatched(&self, name: String, source: OpMetricsSource) {
+    let mut inner = self.0.borrow_mut();
+    let entry = inner.counts.entry(name).or_default();
+    match source {
+      OpMetricsSource::Slow => entry.slow += 1,
+      OpMetricsSource::Fast => entry.fast += 1,
+      OpMetricsSource::Async => entry.async_ += 1,
+    }
+  }
+
+  pub fn errored(&self, source: OpMetricsSource) {
+    let mut inner = self.0.borrow_mut();
+    if matches!(source, OpMetricsSource::Async) {
+      inner.errored_async += 1;
+    } else {
+      inner.errored_sync += 1;
+    }
+  }
+
+  pub fn to_json_pretty(&self) -> Result<String, Error> {
+    serde_json::to_string_pretty(&*self.0.borrow()).map_err(Into::into)
+  }
+}
+
+fn fmt_op_name(decl: &OpDecl) -> String {
+  match decl.accessor_type {
+    deno_core::AccessorType::Getter => todo!(),
+    deno_core::AccessorType::Setter => todo!(),
+    deno_core::AccessorType::None => todo!(),
+}
+}
+
+// Option<Box<dyn Fn(u16, usize, &OpDecl) -> Option<Rc<dyn Fn(&OpCtx, OpMetricsEvent, OpMetricsSource), Global>>, Global>>
+pub fn create_metrics(
+  strace: bool,
+  summary: bool,
+) -> (OpMetricsSummary, OpMetricsFactoryFn) {
+  let metrics_summary = OpMetricsSummary::default();
+  let now = std::time::Instant::now();
+  let max_len: Rc<std::cell::Cell<usize>> = Default::default();
+  (
+    metrics_summary.clone(),
+    Box::new({
+      move |_, _, decl| {
+        max_len.set(max_len.get().max(decl.name.len()));
+        let max_len = max_len.clone();
+        let metrics_summary = metrics_summary.clone();
+        Some(Rc::new(move |op, event, source| {
+          let metrics_summary = metrics_summary.clone();
+          let name = op.decl().name.to_owned();
+          if strace {
+            eprintln!(
+              "[{: >10.3}] {name:max_len$}: {event:?} {source:?}",
+              now.elapsed().as_secs_f64(),
+              max_len = max_len.get()
+            );
+          }
+          if summary {
+            match event {
+              OpMetricsEvent::Completed | OpMetricsEvent::CompletedAsync => {
+                metrics_summary.completed(source);
+              }
+              OpMetricsEvent::Dispatched => {
+                metrics_summary.dispatched(name, source);
+              }
+              OpMetricsEvent::Error | OpMetricsEvent::ErrorAsync => {
+                metrics_summary.errored(source);
+              }
+            }
+          }
+        }))
+      }
+    }),
+  )
+}

--- a/dcore/src/metrics.rs
+++ b/dcore/src/metrics.rs
@@ -71,7 +71,7 @@ fn fmt_op_name(decl: &OpDecl) -> String {
     deno_core::AccessorType::Getter => todo!(),
     deno_core::AccessorType::Setter => todo!(),
     deno_core::AccessorType::None => todo!(),
-}
+  }
 }
 
 // Option<Box<dyn Fn(u16, usize, &OpDecl) -> Option<Rc<dyn Fn(&OpCtx, OpMetricsEvent, OpMetricsSource), Global>>, Global>>

--- a/dcore/src/metrics.rs
+++ b/dcore/src/metrics.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 use deno_core::anyhow::Error;
-use deno_core::OpDecl;
 use deno_core::OpMetricsEvent;
 use deno_core::OpMetricsFactoryFn;
 use deno_core::OpMetricsSource;

--- a/dcore/src/metrics.rs
+++ b/dcore/src/metrics.rs
@@ -66,15 +66,6 @@ impl OpMetricsSummary {
   }
 }
 
-fn fmt_op_name(decl: &OpDecl) -> String {
-  match decl.accessor_type {
-    deno_core::AccessorType::Getter => todo!(),
-    deno_core::AccessorType::Setter => todo!(),
-    deno_core::AccessorType::None => todo!(),
-  }
-}
-
-// Option<Box<dyn Fn(u16, usize, &OpDecl) -> Option<Rc<dyn Fn(&OpCtx, OpMetricsEvent, OpMetricsSource), Global>>, Global>>
 pub fn create_metrics(
   strace: bool,
   summary: bool,

--- a/testing/checkin/runner/mod.rs
+++ b/testing/checkin/runner/mod.rs
@@ -111,6 +111,19 @@ pub fn create_runtime_from_snapshot(
   inspector: bool,
   additional_extensions: Vec<Extension>,
 ) -> JsRuntime {
+  create_runtime_from_snapshot_with_options(
+    snapshot,
+    inspector,
+    additional_extensions,
+    RuntimeOptions::default(),
+  )
+}
+pub fn create_runtime_from_snapshot_with_options(
+  snapshot: &'static [u8],
+  inspector: bool,
+  additional_extensions: Vec<Extension>,
+  options: RuntimeOptions,
+) -> JsRuntime {
   let mut extensions = vec![extensions::checkin_runtime::init_ops::<()>()];
   extensions.extend(additional_extensions);
   let module_loader =
@@ -129,7 +142,7 @@ pub fn create_runtime_from_snapshot(
     custom_module_evaluation_cb: Some(Box::new(custom_module_evaluation_cb)),
     inspector,
     import_assertions_support: ImportAssertionsSupport::Warning,
-    ..Default::default()
+    ..options
   });
 
   let stats = runtime.runtime_activity_stats_factory();

--- a/testing/lib.rs
+++ b/testing/lib.rs
@@ -3,6 +3,7 @@
 mod checkin;
 
 pub use checkin::runner::create_runtime_from_snapshot;
+pub use checkin::runner::create_runtime_from_snapshot_with_options;
 pub use checkin::runner::snapshot::create_snapshot;
 
 macro_rules! unit_test {


### PR DESCRIPTION
Adds two flags, `--strace-ops` and `--strace-ops-summary`.

`--strace-ops` prints out events (like it does in deno)
`--strace-ops-summary` prints out a json object at the end of execution with summary stats like
```json
{
  "counts": {
    "op_foo": {
      "fast": 10,
      "slow": 1000
    }
  },
  "completed_sync": 0,
  "completed_async": 0,
  "errored_sync": 0,
  "errored_async": 0
}
```

Useful for checking whether you're getting fast calls