### PR TITLE
refactor: ability to get borrowed source map bytes from loader

### DIFF
--- a/core/examples/ts_module_loader.rs
+++ b/core/examples/ts_module_loader.rs
@@ -4,6 +4,7 @@
 //!
 //! It will only transpile, not typecheck (like Deno's `--no-check` flag).
 
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -124,8 +125,12 @@ impl ModuleLoader for TypescriptModuleLoader {
     ModuleLoadResponse::Sync(load(source_maps, module_specifier))
   }
 
-  fn get_source_map(&self, specifier: &str) -> Option<Vec<u8>> {
-    self.source_maps.borrow().get(specifier).cloned()
+  fn get_source_map(&self, specifier: &str) -> Option<Cow<[u8]>> {
+    self
+      .source_maps
+      .borrow()
+      .get(specifier)
+      .map(|v| v.clone().into())
   }
 }
 

--- a/core/modules/loaders.rs
+++ b/core/modules/loaders.rs
@@ -18,6 +18,7 @@ use anyhow::bail;
 use anyhow::Context;
 use anyhow::Error;
 use futures::future::FutureExt;
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::future::Future;
@@ -117,7 +118,7 @@ pub trait ModuleLoader {
   /// Returns a source map for given `file_name`.
   ///
   /// This function will soon be deprecated or renamed.
-  fn get_source_map(&self, _file_name: &str) -> Option<Vec<u8>> {
+  fn get_source_map(&self, _file_name: &str) -> Option<Cow<[u8]>> {
     None
   }
 

--- a/core/source_map.rs
+++ b/core/source_map.rs
@@ -205,13 +205,13 @@ mod tests {
       unreachable!()
     }
 
-    fn get_source_map(&self, file_name: &str) -> Option<Vec<u8>> {
+    fn get_source_map(&self, file_name: &str) -> Option<Cow<[u8]>> {
       let url = Url::parse(file_name).unwrap();
       let content = self.map.get(&url)?;
       content
         .source_map
         .as_ref()
-        .map(|s| s.to_string().into_bytes())
+        .map(|s| Cow::Borrowed(s.as_bytes()))
     }
 
     fn get_source_mapped_source_line(

--- a/testing/checkin/runner/ts_module_loader.rs
+++ b/testing/checkin/runner/ts_module_loader.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -152,8 +153,12 @@ impl ModuleLoader for TypescriptModuleLoader {
     ))
   }
 
-  fn get_source_map(&self, specifier: &str) -> Option<Vec<u8>> {
-    self.source_maps.borrow().get(specifier).cloned()
+  fn get_source_map(&self, specifier: &str) -> Option<Cow<[u8]>> {
+    self
+      .source_maps
+      .borrow()
+      .get(specifier)
+      .map(|v| v.clone().into())
   }
 }
 

--- a/testing/checkin/runner/ts_module_loader.rs
+++ b/testing/checkin/runner/ts_module_loader.rs
@@ -1,5 +1,6 @@
-use std::borrow::Cow;
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs;


### PR DESCRIPTION
This will reduce an allocation in a refactor I'm doing for `deno compile` because we can return a static reference to the bytes.