### PR TITLE
execute virtual ops module on startup if need ops bindings

### DIFF
--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1178,7 +1178,7 @@ impl JsRuntime {
       //     skip_op_registration: true
       //   }
       // ) {
-      if init_mode == InitMode::New {
+      if init_mode.needs_ops_bindings() {
         js_runtime
           .execute_virtual_ops_module(context_global, module_map.clone());
       }


### PR DESCRIPTION
This doesn't affect e.g. deno run (which has all of its bindings in the snapshot), but allows commands like jupyter,bench,test to use ops from `ext:core/ops` even though they aren't in the snapshot