### PR TITLE
chore: fix failing lint CI job on main

### DIFF
--- a/testing/integration/error_source_maps_with_prepare_stack_trace/error_source_maps_with_prepare_stack_trace.out
+++ b/testing/integration/error_source_maps_with_prepare_stack_trace/error_source_maps_with_prepare_stack_trace.out
@@ -3,7 +3,7 @@
     "filename": "test:///integration/error_source_maps_with_prepare_stack_trace/error_source_maps_with_prepare_stack_trace.ts",
     "methodName": null,
     "functionName": null,
-    "lineNumber": 8,
+    "lineNumber": 9,
     "columnNumber": 9
   }
 ]

--- a/testing/integration/error_source_maps_with_prepare_stack_trace/error_source_maps_with_prepare_stack_trace.ts
+++ b/testing/integration/error_source_maps_with_prepare_stack_trace/error_source_maps_with_prepare_stack_trace.ts
@@ -1,4 +1,5 @@
-// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2025 the Deno authors. MIT license.
+
 // deno-lint-ignore-file no-explicit-any
 type Thing = {
   name: string;


### PR DESCRIPTION
See https://github.com/denoland/deno_core/actions/runs/12589761265/job/35090134069

Looks like #1008 missed a file, don't know why CI passed in the PR though 🤔