### PR TITLE
feat(webidl): distinguish Nullable from Option, allow setting default value in webidl op2 macro attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2755,9 +2755,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "130.0.4"
+version = "130.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b61316a57fcd7e5f3840fe085f13e6dfd37e92d73b040033d2f598c7a1984c3"
+checksum = "eefb620efa1e8f2d0f4dd1b2a72b0924a0a0e8b710e27e7ce7da7fac95c7aae5"
 dependencies = [
  "bindgen",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde_v8 = { version = "0.237.0", path = "./serde_v8" }
 deno_ast = { version = "=0.40.0", features = ["transpiling"] }
 deno_core_icudata = "0.74.0"
 deno_unsync = "0.4.1"
-v8 = { version = "130.0.4", default-features = false }
+v8 = { version = "130.0.5", default-features = false }
 
 anyhow = "1"
 bencher = "0.1"

--- a/core/webidl.rs
+++ b/core/webidl.rs
@@ -1349,9 +1349,12 @@ mod tests {
     let mut runtime = JsRuntime::new(Default::default());
     let scope = &mut runtime.handle_scope();
 
+    let obj = v8::Object::new(scope);
     let key = v8::String::new(scope, "foo").unwrap();
     let val = v8::Number::new(scope, 1.0);
-    let obj = v8::Object::new(scope);
+    obj.set(scope, key.into(), val.into());
+    let key = v8::String::new(scope, "bar").unwrap();
+    let val = v8::Number::new(scope, 2.0);
     obj.set(scope, key.into(), val.into());
 
     let converted = IndexMap::<String, u8>::convert(
@@ -1360,11 +1363,10 @@ mod tests {
       "prefix".into(),
       || "context".into(),
       &Default::default(),
-    );
-    assert_eq!(
-      converted.unwrap(),
-      IndexMap::from([(String::from("foo"), 1)])
-    );
+    )
+    .unwrap();
+    assert_eq!(converted.get_index(0).unwrap(), (&String::from("foo"), &1));
+    assert_eq!(converted.get_index(1).unwrap(), (&String::from("bar"), &2));
   }
 
   #[test]
@@ -1380,7 +1382,6 @@ mod tests {
       #[webidl(rename = "e")]
       d: u16,
       f: IndexMap<String, u32>,
-      #[webidl(required)]
       g: Option<u32>,
     }
 

--- a/core/webidl.rs
+++ b/core/webidl.rs
@@ -180,7 +180,7 @@ pub enum Nullable<T> {
   Null,
 }
 impl<T> Nullable<T> {
-  fn into_option(self) -> Option<T> {
+  pub fn into_option(self) -> Option<T> {
     match self {
       Nullable::Value(v) => Some(v),
       Nullable::Null => None,

--- a/core/webidl.rs
+++ b/core/webidl.rs
@@ -110,9 +110,6 @@ pub fn type_of<'a>(
     "string" => Type::String,
     "symbol" => Type::Symbol,
     "bigint" => Type::BigInt,
-    // Per ES spec, typeof returns an implementation-defined value that is not any of the existing ones for
-    // uncallable non-standard exotic objects. Yet Type() which the Web IDL spec depends on returns Object for
-    // such cases. So treat the default case as an object.
     "object" | "function" | _ => Type::Object,
   }
 }

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -904,7 +904,7 @@ fn map_arg_to_v8_fastcall_type(
     | Arg::OptionBuffer(..)
     | Arg::SerdeV8(_)
     | Arg::FromV8(_)
-    | Arg::WebIDL(_, _)
+    | Arg::WebIDL(_, _, _)
     | Arg::Ref(..) => return Ok(None),
     // We don't support v8 global arguments
     Arg::V8Global(_) | Arg::OptionV8Global(_) => return Ok(None),
@@ -958,7 +958,7 @@ fn map_retval_to_v8_fastcall_type(
     Arg::OptionNumeric(..)
     | Arg::SerdeV8(_)
     | Arg::ToV8(_)
-    | Arg::WebIDL(_, _) => return Ok(None),
+    | Arg::WebIDL(_, _, _) => return Ok(None),
     Arg::Void => V8FastCallType::Void,
     Arg::Numeric(NumericArg::bool, _) => V8FastCallType::Bool,
     Arg::Numeric(NumericArg::u32, _)

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -681,8 +681,12 @@ pub fn from_arg(
       let default = if let Some(default) = default {
         let tokens = default.0.to_token_stream();
         let default = if let Ok(lit) = parse2::<syn::LitStr>(tokens) {
-          quote! {
-            v8::String::new(&mut #scope, #lit).unwrap()
+          if lit.value().is_empty() {
+            quote! {
+              v8::String::empty(&mut #scope)
+            }
+          } else {
+            return Err("unsupported WebIDL default value");
           }
         } else {
           return Err("unsupported WebIDL default value");

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -27,9 +27,11 @@ use super::V8MappingError;
 use super::V8SignatureMappingError;
 use proc_macro2::Ident;
 use proc_macro2::TokenStream;
+use quote::format_ident;
 use quote::quote;
-use quote::{format_ident, ToTokens};
-use syn::{parse2, Type};
+use quote::ToTokens;
+use syn::parse2;
+use syn::Type;
 
 pub(crate) fn generate_dispatch_slow_call(
   generator_state: &mut GeneratorState,

--- a/ops/webidl/dictionary.rs
+++ b/ops/webidl/dictionary.rs
@@ -101,30 +101,21 @@ pub fn get_body(
 
     let new_context = format!("'{string_name}' of '{ident_string}'");
 
-    let convert = quote! {
-      let val = ::deno_core::webidl::WebIdlConverter::convert(
-        __scope,
-        __value,
-        __prefix.clone(),
-        || format!("{} ({})", #new_context, __context()).into(),
-        &#options,
-      )?;
-    };
-
-    let convert_body = if field.option_is_required {
-      quote! {
-        #convert
-        val
-      }
-    } else {
-      let val = if field.is_option  {
+    let convert_body = {
+      let val = if field.is_option && !field.option_is_required  {
         quote!(Some(val))
       } else {
         quote!(val)
       };
 
       quote! {
-        #convert
+        let val = ::deno_core::webidl::WebIdlConverter::convert(
+          __scope,
+          __value,
+          __prefix.clone(),
+          || format!("{} ({})", #new_context, __context()).into(),
+          &#options,
+        )?;
         #val
       }
     };

--- a/ops/webidl/dictionary.rs
+++ b/ops/webidl/dictionary.rs
@@ -99,27 +99,6 @@ pub fn get_body(
       }
     };
 
-    let new_context = format!("'{string_name}' of '{ident_string}'");
-
-    let convert_body = {
-      let val = if field.is_option && !field.option_is_required  {
-        quote!(Some(val))
-      } else {
-        quote!(val)
-      };
-
-      quote! {
-        let val = ::deno_core::webidl::WebIdlConverter::convert(
-          __scope,
-          __value,
-          __prefix.clone(),
-          || format!("{} ({})", #new_context, __context()).into(),
-          &#options,
-        )?;
-        #val
-      }
-    };
-
     let undefined_as_none = if field.default_value.is_some() {
       quote! {
         .and_then(|__value| {
@@ -149,6 +128,8 @@ pub fn get_body(
       }
     };
 
+    let new_context = format!("'{string_name}' of '{ident_string}'");
+
     quote! {
       let #original_name = {
         let __key = #v8_eternal_name
@@ -166,7 +147,13 @@ pub fn get_body(
           .into();
 
         if let Some(__value) = __obj.as_ref().and_then(|__obj| __obj.get(__scope, __key))#undefined_as_none {
-          #convert_body
+          ::deno_core::webidl::WebIdlConverter::convert(
+            __scope,
+            __value,
+            __prefix.clone(),
+            || format!("{} ({})", #new_context, __context()).into(),
+            &#options,
+          )?
         } else {
           #required_or_default
         }
@@ -210,8 +197,6 @@ struct DictionaryField {
   name: Ident,
   rename: Option<String>,
   default_value: Option<Expr>,
-  is_option: bool,
-  option_is_required: bool,
   converter_options: std::collections::HashMap<Ident, Expr>,
   ty: Type,
 }
@@ -234,7 +219,6 @@ impl TryFrom<Field> for DictionaryField {
     let span = value.span();
     let mut default_value: Option<Expr> = None;
     let mut rename: Option<String> = None;
-    let mut option_is_required = false;
     let mut converter_options = std::collections::HashMap::new();
 
     for attr in value.attrs {
@@ -251,9 +235,6 @@ impl TryFrom<Field> for DictionaryField {
             }
             DictionaryFieldArgument::Rename { value, .. } => {
               rename = Some(value.value())
-            }
-            DictionaryFieldArgument::Required { .. } => {
-              option_is_required = true
             }
           }
         }
@@ -275,37 +256,11 @@ impl TryFrom<Field> for DictionaryField {
       }
     }
 
-    let is_option = if let Type::Path(path) = &value.ty {
-      if let Some(last) = path.path.segments.last() {
-        last.ident == "Option"
-      } else {
-        false
-      }
-    } else {
-      false
-    };
-
-    if option_is_required && !is_option {
-      return Err(Error::new(
-        span,
-        "Required option can only be used with an Option",
-      ));
-    }
-
-    if option_is_required && default_value.is_some() {
-      return Err(Error::new(
-        span,
-        "Required option and default value cannot be used together",
-      ));
-    }
-
     Ok(Self {
       span,
       name: value.ident.unwrap(),
       rename,
       default_value,
-      is_option,
-      option_is_required,
       converter_options,
       ty: value.ty,
     })
@@ -324,9 +279,6 @@ enum DictionaryFieldArgument {
     eq_token: Token![=],
     value: LitStr,
   },
-  Required {
-    name_token: kw::required,
-  },
 }
 
 impl Parse for DictionaryFieldArgument {
@@ -343,10 +295,6 @@ impl Parse for DictionaryFieldArgument {
         name_token: input.parse()?,
         eq_token: input.parse()?,
         value: input.parse()?,
-      })
-    } else if lookahead.peek(kw::required) {
-      Ok(DictionaryFieldArgument::Required {
-        name_token: input.parse()?,
       })
     } else {
       Err(lookahead.error())

--- a/ops/webidl/mod.rs
+++ b/ops/webidl/mod.rs
@@ -30,22 +30,7 @@ pub fn webidl(item: TokenStream) -> Result<TokenStream, Error> {
   let out = match input.data {
     Data::Struct(data) => match converter {
       ConverterType::Dictionary => {
-        let (body, v8_static_strings, v8_lazy_strings) =
-          dictionary::get_body(ident_string, span, data)?;
-
-        let implementation = create_impl(ident, body);
-
-        quote! {
-          ::deno_core::v8_static_strings! {
-            #(#v8_static_strings),*
-          }
-
-          thread_local! {
-            #(#v8_lazy_strings)*
-          }
-
-          #implementation
-        }
+        create_impl(ident, dictionary::get_body(ident_string, span, data)?)
       }
       ConverterType::Enum => {
         return Err(Error::new(span, "Structs do not support enum converters"));

--- a/ops/webidl/test_cases/dict.out
+++ b/ops/webidl/test_cases/dict.out
@@ -62,14 +62,13 @@ impl<'a> ::deno_core::webidl::WebIdlConverter<'a> for Dict {
                 .as_ref()
                 .and_then(|__obj| __obj.get(__scope, __key))
             {
-                let val = ::deno_core::webidl::WebIdlConverter::convert(
+                ::deno_core::webidl::WebIdlConverter::convert(
                     __scope,
                     __value,
                     __prefix.clone(),
                     || format!("{} ({})", "'a' of 'Dict'", __context()).into(),
                     &Default::default(),
-                )?;
-                val
+                )?
             } else {
                 return Err(
                     ::deno_core::webidl::WebIdlError::new(
@@ -105,7 +104,7 @@ impl<'a> ::deno_core::webidl::WebIdlConverter<'a> for Dict {
                 .as_ref()
                 .and_then(|__obj| __obj.get(__scope, __key))
             {
-                let val = ::deno_core::webidl::WebIdlConverter::convert(
+                ::deno_core::webidl::WebIdlConverter::convert(
                     __scope,
                     __value,
                     __prefix.clone(),
@@ -119,8 +118,7 @@ impl<'a> ::deno_core::webidl::WebIdlConverter<'a> for Dict {
                             ..Default::default()
                         }
                     },
-                )?;
-                val
+                )?
             } else {
                 return Err(
                     ::deno_core::webidl::WebIdlError::new(
@@ -159,14 +157,13 @@ impl<'a> ::deno_core::webidl::WebIdlConverter<'a> for Dict {
                     if __value.is_undefined() { None } else { Some(__value) }
                 })
             {
-                let val = ::deno_core::webidl::WebIdlConverter::convert(
+                ::deno_core::webidl::WebIdlConverter::convert(
                     __scope,
                     __value,
                     __prefix.clone(),
                     || format!("{} ({})", "'c' of 'Dict'", __context()).into(),
                     &Default::default(),
-                )?;
-                Some(val)
+                )?
             } else {
                 Some(3)
             }
@@ -193,14 +190,13 @@ impl<'a> ::deno_core::webidl::WebIdlConverter<'a> for Dict {
                 .as_ref()
                 .and_then(|__obj| __obj.get(__scope, __key))
             {
-                let val = ::deno_core::webidl::WebIdlConverter::convert(
+                ::deno_core::webidl::WebIdlConverter::convert(
                     __scope,
                     __value,
                     __prefix.clone(),
                     || format!("{} ({})", "'e' of 'Dict'", __context()).into(),
                     &Default::default(),
-                )?;
-                val
+                )?
             } else {
                 return Err(
                     ::deno_core::webidl::WebIdlError::new(
@@ -236,14 +232,13 @@ impl<'a> ::deno_core::webidl::WebIdlConverter<'a> for Dict {
                 .as_ref()
                 .and_then(|__obj| __obj.get(__scope, __key))
             {
-                let val = ::deno_core::webidl::WebIdlConverter::convert(
+                ::deno_core::webidl::WebIdlConverter::convert(
                     __scope,
                     __value,
                     __prefix.clone(),
                     || format!("{} ({})", "'f' of 'Dict'", __context()).into(),
                     &Default::default(),
-                )?;
-                val
+                )?
             } else {
                 return Err(
                     ::deno_core::webidl::WebIdlError::new(

--- a/ops/webidl/test_cases/dict.out
+++ b/ops/webidl/test_cases/dict.out
@@ -1,15 +1,3 @@
-::deno_core::v8_static_strings! {
-    __v8_static_a = "a", __v8_static_b = "b", __v8_static_c = "c", __v8_static_e = "e",
-    __v8_static_f = "f", __v8_static_g = "g"
-}
-thread_local! {
-    static __v8_a_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
-    static __v8_b_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
-    static __v8_c_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
-    static __v8_e_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
-    static __v8_f_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
-    static __v8_g_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
-}
 impl<'a> ::deno_core::webidl::WebIdlConverter<'a> for Dict {
     type Options = ();
     fn convert<C>(
@@ -22,6 +10,17 @@ impl<'a> ::deno_core::webidl::WebIdlConverter<'a> for Dict {
     where
         C: Fn() -> std::borrow::Cow<'static, str>,
     {
+        ::deno_core::v8_static_strings! {
+            __v8_static_a = "a", __v8_static_b = "b", __v8_static_c = "c", __v8_static_e
+            = "e", __v8_static_f = "f"
+        }
+        thread_local! {
+            static __v8_a_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
+            static __v8_b_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
+            static __v8_c_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
+            static __v8_e_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
+            static __v8_f_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
+        }
         let __obj: Option<::deno_core::v8::Local<::deno_core::v8::Object>> = if __value
             .is_undefined() || __value.is_null()
         {
@@ -258,53 +257,6 @@ impl<'a> ::deno_core::webidl::WebIdlConverter<'a> for Dict {
                 );
             }
         };
-        let g = {
-            let __key = __v8_g_eternal
-                .with(|__eternal| {
-                    if let Some(__key) = __eternal.get(__scope) {
-                        Ok(__key)
-                    } else {
-                        let __key = __v8_static_g
-                            .v8_string(__scope)
-                            .map_err(|e| ::deno_core::webidl::WebIdlError::other(
-                                __prefix.clone(),
-                                &__context,
-                                e,
-                            ))?;
-                        __eternal.set(__scope, __key);
-                        Ok(__key)
-                    }
-                })?
-                .into();
-            if let Some(__value) = __obj
-                .as_ref()
-                .and_then(|__obj| __obj.get(__scope, __key))
-            {
-                if __value.is_undefined() {
-                    None
-                } else {
-                    let val = ::deno_core::webidl::WebIdlConverter::convert(
-                        __scope,
-                        __value,
-                        __prefix.clone(),
-                        || format!("{} ({})", "'g' of 'Dict'", __context()).into(),
-                        &Default::default(),
-                    )?;
-                    Some(val)
-                }
-            } else {
-                return Err(
-                    ::deno_core::webidl::WebIdlError::new(
-                        __prefix,
-                        &__context,
-                        ::deno_core::webidl::WebIdlErrorKind::DictionaryCannotConvertKey {
-                            converter: "Dict",
-                            key: "g",
-                        },
-                    ),
-                );
-            }
-        };
-        Ok(Self { a, b, c, d, f, g })
+        Ok(Self { a, b, c, d, f })
     }
 }

--- a/ops/webidl/test_cases/dict.rs
+++ b/ops/webidl/test_cases/dict.rs
@@ -13,7 +13,6 @@ pub struct Dict {
   c: Option<u32>,
   #[webidl(rename = "e")]
   d: u64,
-  f: std::collections::HashMap<String, f32>,
   #[webidl(required)]
-  g: Option<u32>,
+  f: Option<u32>,
 }

--- a/ops/webidl/test_cases/dict.rs
+++ b/ops/webidl/test_cases/dict.rs
@@ -13,6 +13,5 @@ pub struct Dict {
   c: Option<u32>,
   #[webidl(rename = "e")]
   d: u64,
-  #[webidl(required)]
   f: Option<u32>,
 }


### PR DESCRIPTION
replaces hashmap with indexmap for records, and some minor fixes
And adds a `SameObject` utility to cppgc