### PR TITLE
Allow object wrap without constructor

### DIFF
--- a/core/extension_set.rs
+++ b/core/extension_set.rs
@@ -166,10 +166,13 @@ pub fn create_op_ctxs(
   };
 
   for (index, decl) in op_method_decls.iter_mut().enumerate() {
-    decl.constructor.name = decl.name.0;
-    decl.constructor.name_fast = decl.name.1;
+    if let Some(mut constructor) = decl.constructor {
+      constructor.name = decl.name.0;
+      constructor.name_fast = decl.name.1;
 
-    op_ctxs.push(create_ctx(index, decl.constructor));
+      op_ctxs.push(create_ctx(index, constructor));
+    }
+
     for method in decl.methods {
       op_ctxs.push(create_ctx(index, *method));
     }

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -182,7 +182,7 @@ const NOOP_FN: CFunction = CFunction::new(
 pub struct OpMethodDecl {
   pub type_name: fn() -> &'static str,
   pub name: (&'static str, FastStaticString),
-  pub constructor: OpDecl,
+  pub constructor: Option<OpDecl>,
   pub methods: &'static [OpDecl],
   pub static_methods: &'static [OpDecl],
 }

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -376,7 +376,7 @@ pub(crate) fn initialize_deno_core_ops_bindings<'s>(
       break;
     }
 
-    let tmpl = if let Some(_) = decl.constructor {
+    let tmpl = if decl.constructor.is_some() {
       let constructor_ctx = &op_ctxs[index];
 
       let tmpl = op_ctx_template(scope, constructor_ctx);

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -375,14 +375,22 @@ pub(crate) fn initialize_deno_core_ops_bindings<'s>(
     if index == methods_ctx_offset {
       break;
     }
-    let constructor_ctx = &op_ctxs[index];
 
-    let tmpl = op_ctx_template(scope, constructor_ctx);
+    let tmpl = if let Some(_) = decl.constructor {
+      let constructor_ctx = &op_ctxs[index];
+
+      let tmpl = op_ctx_template(scope, constructor_ctx);
+
+      index += 1;
+
+      tmpl
+    } else {
+      crate::cppgc::make_cppgc_template(scope)
+    };
+
+    let key = decl.name.1.v8_string(scope).unwrap();
+
     let prototype = tmpl.prototype_template(scope);
-    let key = decl.constructor.name_fast.v8_string(scope).unwrap();
-
-    index += 1;
-
     let method_ctxs = &op_ctxs[index..index + decl.methods.len()];
 
     let accessor_store = create_accessor_store(method_ctxs);
@@ -1030,12 +1038,16 @@ pub fn create_exports_for_ops_virtual_module<'s>(
     if index == methods_ctx_offset {
       break;
     }
-    let constructor_ctx = &op_ctxs[index];
 
-    let op_fn = get(scope, ops_obj, constructor_ctx.decl.name_fast, "op");
-    exports.push((constructor_ctx.decl.name_fast, op_fn));
+    if decl.constructor.is_some() {
+      index += 1;
+    }
 
-    index += 1 + decl.methods.len() + decl.static_methods.len();
+    let name = decl.name.1;
+    let op_fn = get(scope, ops_obj, name, "op");
+    exports.push((name, op_fn));
+
+    index += decl.methods.len() + decl.static_methods.len();
   }
 
   let op_ctxs = &op_ctxs[index..];

--- a/ops/op2/object_wrap.rs
+++ b/ops/op2/object_wrap.rs
@@ -134,6 +134,12 @@ pub(crate) fn generate_impl_ops(
     }
   }
 
+  let constructor = if let Some(constructor) = constructor {
+    quote! { Some(#self_ty::#constructor()) }
+  } else {
+    quote! { None }
+  };
+
   let res = quote! {
       impl #self_ty {
         pub const DECL: deno_core::_ops::OpMethodDecl = deno_core::_ops::OpMethodDecl {
@@ -147,7 +153,7 @@ pub(crate) fn generate_impl_ops(
               #self_ty::#static_methods(),
             )*
           ],
-          constructor: #self_ty::#constructor(),
+          constructor: #constructor,
           name: ::deno_core::__op_name_fast!(#self_ty),
           type_name: || std::any::type_name::<#self_ty>(),
         };

--- a/ops/op2/test_cases/sync/object_wrap.out
+++ b/ops/op2/test_cases/sync/object_wrap.out
@@ -10,7 +10,7 @@ impl Foo {
             Foo::doThing(),
         ],
         static_methods: &[Foo::__static_doThing()],
-        constructor: Foo::constructor(),
+        constructor: Some(Foo::constructor()),
         name: ::deno_core::__op_name_fast!(Foo),
         type_name: || std::any::type_name::<Foo>(),
     };

--- a/testing/checkin/runner/extensions.rs
+++ b/testing/checkin/runner/extensions.rs
@@ -52,7 +52,8 @@ deno_core::extension!(
   ],
   objects = [
     ops::DOMPoint,
-    ops::TestObjectWrap
+    ops::TestObjectWrap,
+    ops::TestEnumWrap
   ],
   esm_entry_point = "ext:checkin_runtime/__init.js",
   esm = [

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -216,7 +216,10 @@ impl DOMPoint {
 
 #[repr(u8)]
 #[derive(Clone, Copy)]
-pub enum TestEnumWrap {}
+pub enum TestEnumWrap {
+  #[allow(dead_code)]
+  A,
+}
 
 impl GarbageCollected for TestEnumWrap {}
 

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -214,6 +214,20 @@ impl DOMPoint {
   fn with_symbol(&self) {}
 }
 
+#[repr(u8)]
+#[derive(Clone, Copy)]
+pub enum TestEnumWrap {}
+
+impl GarbageCollected for TestEnumWrap {}
+
+#[op2]
+impl TestEnumWrap {
+  #[getter]
+  fn as_int(&self) -> u8 {
+    *self as u8
+  }
+}
+
 #[op2(fast)]
 pub fn op_nop_generic<T: SomeType + 'static>(state: &mut OpState) {
   state.take::<T>();

--- a/testing/checkin/runtime/object.ts
+++ b/testing/checkin/runtime/object.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-import { DOMPoint, TestObjectWrap } from "ext:core/ops";
+import { DOMPoint, TestEnumWrap, TestObjectWrap } from "ext:core/ops";
 
-export { DOMPoint, TestObjectWrap };
+export { DOMPoint, TestEnumWrap, TestObjectWrap };

--- a/testing/ops.d.ts
+++ b/testing/ops.d.ts
@@ -41,3 +41,5 @@ export class TestObjectWrap {
   with_RENAME(): void;
   withAsyncFn(ms: number): Promise<void>;
 }
+
+export class TestEnumWrap {}

--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 import { assert, assertArrayEquals, assertEquals, test } from "checkin:testing";
-import { DOMPoint, TestObjectWrap } from "checkin:object";
+import { DOMPoint, TestEnumWrap, TestObjectWrap } from "checkin:object";
 
 const {
   op_pipe_create,
@@ -110,4 +110,6 @@ test(async function testDomPoint() {
   assert(promise instanceof Promise);
 
   await promise;
+
+  new TestEnumWrap();
 });


### PR DESCRIPTION
Use the default template when no constructor is defined.