### PR TITLE
ci: pin nightly to `2025-01-02`

### DIFF
--- a/.github/workflows/ci-lint-deps/action.yml
+++ b/.github/workflows/ci-lint-deps/action.yml
@@ -3,7 +3,9 @@ runs:
   using: "composite"
   steps:
     - name: Install Rust (nightly)
-      uses: dtolnay/rust-toolchain@nightly
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly-2025-01-02
     - name: Lint deps
       shell: bash
       run: |

--- a/.github/workflows/ci-lint-deps/action.yml
+++ b/.github/workflows/ci-lint-deps/action.yml
@@ -12,4 +12,4 @@ runs:
         cargo install cargo-machete --locked
         cargo machete
         cargo install cargo-udeps --locked
-        cargo +nightly udeps
+        cargo +nightly-2025-01-02 udeps

--- a/.github/workflows/ci-test-miri/action.yml
+++ b/.github/workflows/ci-test-miri/action.yml
@@ -11,6 +11,6 @@ runs:
       run: |
         # Install and run miri tests
         cargo clean
-        rustup component add --toolchain nightly miri
+        rustup component add --toolchain nightly-2025-01-02 miri
         # This somehow prints errors in CI that don't show up locally
-        RUSTFLAGS=-Awarnings cargo +nightly miri test -p deno_core
+        RUSTFLAGS=-Awarnings cargo +nightly-2025-01-02 miri test -p deno_core

--- a/.github/workflows/ci-test-miri/action.yml
+++ b/.github/workflows/ci-test-miri/action.yml
@@ -3,7 +3,9 @@ runs:
   using: "composite"
   steps:
     - name: Install Rust (nightly)
-      uses: dtolnay/rust-toolchain@nightly
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly-2025-01-02
     - name: Cargo test (miri)
       shell: bash
       run: |


### PR DESCRIPTION
Pin the nightly version for now. Starting from nightly 2025-01-03, all cfg(tests) produce compiler error:

```
error: unexpected `cfg` condition name: `test`
   --> ops/op2/mod.rs:363:7
    |
363 | #[cfg(test)]
    |       ^^^^
    |
    = help: expected names are: `clippy`, `debug_assertions`, `doc`, `docsrs`, `doctest`, `feature`, `fmt_debug`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `ub_checks`, `unix`, and `windows`
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]
             unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }
    = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(test)");` to the top of the `build.rs`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: `-D unexpected-cfgs` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unexpected_cfgs)]`
```

Seems related to https://github.com/rust-lang/rust/pull/131729 and maybe some changes haven't propagated to cargo yet?