### PR TITLE
perf: reduce generated error handling code in ops

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -1723,6 +1723,36 @@ pub fn format_frame<F: ErrorFormat>(frame: &JsStackFrame) -> String {
   result
 }
 
+pub fn throw_error_one_byte_info(
+  info: &v8::FunctionCallbackInfo,
+  message: &str,
+) {
+  let mut scope = unsafe { v8::CallbackScope::new(info) };
+  throw_error_one_byte(&mut scope, message);
+}
+
+pub fn throw_error_anyhow<S>(scope: &mut v8::CallbackScope<'_>, message: S)
+where
+  S: Into<deno_core::anyhow::Error>,
+{
+  // TODO(mmastrac): This might be allocating too much, even if it's on the error path
+  let e: deno_core::anyhow::Error = message.into();
+  let msg = deno_core::v8::String::new(scope, &format!("{}", e)).unwrap();
+  let exc = deno_core::v8::Exception::type_error(scope, msg);
+  scope.throw_exception(exc);
+}
+
+pub fn throw_error_one_byte(scope: &mut v8::CallbackScope, message: &str) {
+  let msg = deno_core::v8::String::new_from_one_byte(
+    scope,
+    message.as_bytes(),
+    deno_core::v8::NewStringType::Normal,
+  )
+  .unwrap();
+  let exc = deno_core::v8::Exception::type_error(scope, msg);
+  scope.throw_exception(exc);
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -177,6 +177,9 @@ extern crate self as deno_core;
 pub mod _ops {
   pub use super::cppgc::make_cppgc_object;
   pub use super::cppgc::try_unwrap_cppgc_object;
+  pub use super::error::throw_error_anyhow;
+  pub use super::error::throw_error_one_byte;
+  pub use super::error::throw_error_one_byte_info;
   pub use super::error::throw_type_error;
   pub use super::error_codes::get_error_code;
   pub use super::extensions::Op;
@@ -193,33 +196,6 @@ pub mod _ops {
   pub use super::runtime::ops_rust_to_v8::*;
   pub use super::runtime::V8_WRAPPER_OBJECT_INDEX;
   pub use super::runtime::V8_WRAPPER_TYPE_INDEX;
-
-  pub fn throw_error1(info: &v8::FunctionCallbackInfo, message: &str) {
-    let mut scope = unsafe { v8::CallbackScope::new(info) };
-    throw_error3(&mut scope, message);
-  }
-
-  pub fn throw_error2<S>(scope: &mut v8::CallbackScope<'_>, message: S)
-  where
-    S: Into<deno_core::anyhow::Error>,
-  {
-    // TODO(mmastrac): This might be allocating too much, even if it's on the error path
-    let e: deno_core::anyhow::Error = message.into();
-    let msg = deno_core::v8::String::new(scope, &format!("{}", e)).unwrap();
-    let exc = deno_core::v8::Exception::type_error(scope, msg);
-    scope.throw_exception(exc);
-  }
-
-  pub fn throw_error3(scope: &mut v8::CallbackScope, message: &str) {
-    let msg = deno_core::v8::String::new_from_one_byte(
-      scope,
-      message.as_bytes(),
-      deno_core::v8::NewStringType::Normal,
-    )
-    .unwrap();
-    let exc = deno_core::v8::Exception::type_error(scope, msg);
-    scope.throw_exception(exc);
-  }
 }
 
 pub mod snapshot {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -194,15 +194,9 @@ pub mod _ops {
   pub use super::runtime::V8_WRAPPER_OBJECT_INDEX;
   pub use super::runtime::V8_WRAPPER_TYPE_INDEX;
 
-  pub fn throw_error1(scope: &mut v8::CallbackScope<'_>, message: &str) {
-    let msg = deno_core::v8::String::new_from_one_byte(
-      scope,
-      message.as_bytes(),
-      deno_core::v8::NewStringType::Normal,
-    )
-    .unwrap();
-    let exc = deno_core::v8::Exception::type_error(scope, msg);
-    scope.throw_exception(exc);
+  pub fn throw_error1(info: &v8::FunctionCallbackInfo, message: &str) {
+    let mut scope = unsafe { v8::CallbackScope::new(info) };
+    throw_error3(&mut scope, message);
   }
 
   pub fn throw_error2<S>(scope: &mut v8::CallbackScope<'_>, message: S)
@@ -212,6 +206,17 @@ pub mod _ops {
     // TODO(mmastrac): This might be allocating too much, even if it's on the error path
     let e: deno_core::anyhow::Error = message.into();
     let msg = deno_core::v8::String::new(scope, &format!("{}", e)).unwrap();
+    let exc = deno_core::v8::Exception::type_error(scope, msg);
+    scope.throw_exception(exc);
+  }
+
+  pub fn throw_error3(scope: &mut v8::CallbackScope, message: &str) {
+    let msg = deno_core::v8::String::new_from_one_byte(
+      scope,
+      message.as_bytes(),
+      deno_core::v8::NewStringType::Normal,
+    )
+    .unwrap();
     let exc = deno_core::v8::Exception::type_error(scope, msg);
     scope.throw_exception(exc);
   }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -195,14 +195,23 @@ pub mod _ops {
   pub use super::runtime::V8_WRAPPER_TYPE_INDEX;
 
   pub fn throw_error1(scope: &mut v8::CallbackScope<'_>, message: &str) {
-    let msg = deno_core::v8::String::new_from_one_byte(scope, message.as_bytes(), deno_core::v8::NewStringType::Normal).unwrap();
+    let msg = deno_core::v8::String::new_from_one_byte(
+      scope,
+      message.as_bytes(),
+      deno_core::v8::NewStringType::Normal,
+    )
+    .unwrap();
     let exc = deno_core::v8::Exception::type_error(scope, msg);
     scope.throw_exception(exc);
   }
 
-  pub fn throw_error2(scope: &mut v8::CallbackScope<'_>, message: deno_core::anyhow::Error) {
+  pub fn throw_error2<S>(scope: &mut v8::CallbackScope<'_>, message: S)
+  where
+    S: Into<deno_core::anyhow::Error>,
+  {
     // TODO(mmastrac): This might be allocating too much, even if it's on the error path
-    let msg = deno_core::v8::String::new(scope, &format!("{}", message)).unwrap();
+    let e: deno_core::anyhow::Error = message.into();
+    let msg = deno_core::v8::String::new(scope, &format!("{}", e)).unwrap();
     let exc = deno_core::v8::Exception::type_error(scope, msg);
     scope.throw_exception(exc);
   }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -193,6 +193,19 @@ pub mod _ops {
   pub use super::runtime::ops_rust_to_v8::*;
   pub use super::runtime::V8_WRAPPER_OBJECT_INDEX;
   pub use super::runtime::V8_WRAPPER_TYPE_INDEX;
+
+  pub fn throw_error1(scope: &mut v8::CallbackScope<'_>, message: &str) {
+    let msg = deno_core::v8::String::new_from_one_byte(scope, message.as_bytes(), deno_core::v8::NewStringType::Normal).unwrap();
+    let exc = deno_core::v8::Exception::type_error(scope, msg);
+    scope.throw_exception(exc);
+  }
+
+  pub fn throw_error2(scope: &mut v8::CallbackScope<'_>, message: deno_core::anyhow::Error) {
+    // TODO(mmastrac): This might be allocating too much, even if it's on the error path
+    let msg = deno_core::v8::String::new(scope, &format!("{}", message)).unwrap();
+    let exc = deno_core::v8::Exception::type_error(scope, msg);
+    scope.throw_exception(exc);
+  }
 }
 
 pub mod snapshot {

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -332,7 +332,7 @@ fn throw_type_error(
   let message = format!("{message}");
   quote!({
     let mut scope = #create_scope;
-    deno_core::_ops::throw_error1(&mut scope, #message);
+    deno_core::_ops::throw_error3(&mut scope, #message);
     // SAFETY: All fast return types have zero as a valid value
     return unsafe { std::mem::zeroed() };
   })

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -332,9 +332,7 @@ fn throw_type_error(
   let message = format!("{message}");
   quote!({
     let mut scope = #create_scope;
-    let msg = deno_core::v8::String::new_from_one_byte(&mut scope, #message.as_bytes(), deno_core::v8::NewStringType::Normal).unwrap();
-    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-    scope.throw_exception(exc);
+    deno_core::_ops::throw_error1(&mut scope, #message);
     // SAFETY: All fast return types have zero as a valid value
     return unsafe { std::mem::zeroed() };
   })

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -332,7 +332,7 @@ fn throw_type_error(
   let message = format!("{message}");
   quote!({
     let mut scope = #create_scope;
-    deno_core::_ops::throw_error3(&mut scope, #message);
+    deno_core::_ops::throw_error_one_byte(&mut scope, #message);
     // SAFETY: All fast return types have zero as a valid value
     return unsafe { std::mem::zeroed() };
   })

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -1216,7 +1216,7 @@ fn throw_type_error_string(
 
   Ok(gs_quote!(generator_state(scope) => {
     #maybe_scope
-    deno_core::_ops::throw_error2(&mut #scope, deno_core::anyhow::Error::from(#message));
+    deno_core::_ops::throw_error2(&mut #scope, #message);
     return 1;
   }))
 }

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -1191,7 +1191,7 @@ fn throw_type_error(
   debug_assert!(message.is_ascii() && message.len() < 1024);
 
   Ok(gs_quote!(generator_state(info) => {
-    deno_core::_ops::throw_error1(&#info, #message);
+    deno_core::_ops::throw_error_one_byte_info(&#info, #message);
     return 1;
   }))
 }
@@ -1209,7 +1209,7 @@ fn throw_type_error_string(
 
   Ok(gs_quote!(generator_state(scope) => {
     #maybe_scope
-    deno_core::_ops::throw_error2(&mut #scope, #message);
+    deno_core::_ops::throw_error_anyhow(&mut #scope, #message);
     return 1;
   }))
 }
@@ -1220,7 +1220,7 @@ fn throw_type_error_static_string(
   message: &Ident,
 ) -> Result<TokenStream, V8MappingError> {
   Ok(gs_quote!(generator_state(info) => {
-    deno_core::_ops::throw_error1(&#info, #message);
+    deno_core::_ops::throw_error_one_byte_info(&#info, #message);
     return 1;
   }))
 }

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -1190,15 +1190,8 @@ fn throw_type_error(
   // Sanity check ASCII and a valid/reasonable message size
   debug_assert!(message.is_ascii() && message.len() < 1024);
 
-  let maybe_scope = if generator_state.needs_scope {
-    quote!()
-  } else {
-    with_scope(generator_state)
-  };
-
-  Ok(gs_quote!(generator_state(scope) => {
-    #maybe_scope
-    deno_core::_ops::throw_error1(&mut #scope, #message);
+  Ok(gs_quote!(generator_state(info) => {
+    deno_core::_ops::throw_error1(&#info, #message);
     return 1;
   }))
 }
@@ -1226,15 +1219,8 @@ fn throw_type_error_static_string(
   generator_state: &mut GeneratorState,
   message: &Ident,
 ) -> Result<TokenStream, V8MappingError> {
-  let maybe_scope = if generator_state.needs_scope {
-    quote!()
-  } else {
-    with_scope(generator_state)
-  };
-
-  Ok(gs_quote!(generator_state(scope) => {
-    #maybe_scope
-    deno_core::_ops::throw_error1(&mut #scope, #message);
+  Ok(gs_quote!(generator_state(info) => {
+    deno_core::_ops::throw_error1(&#info, #message);
     return 1;
   }))
 }

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -1198,9 +1198,7 @@ fn throw_type_error(
 
   Ok(gs_quote!(generator_state(scope) => {
     #maybe_scope
-    let msg = deno_core::v8::String::new_from_one_byte(&mut #scope, #message.as_bytes(), deno_core::v8::NewStringType::Normal).unwrap();
-    let exc = deno_core::v8::Exception::type_error(&mut #scope, msg);
-    #scope.throw_exception(exc);
+    deno_core::_ops::throw_error1(&mut #scope, #message);
     return 1;
   }))
 }
@@ -1218,10 +1216,7 @@ fn throw_type_error_string(
 
   Ok(gs_quote!(generator_state(scope) => {
     #maybe_scope
-    // TODO(mmastrac): This might be allocating too much, even if it's on the error path
-    let msg = deno_core::v8::String::new(&mut #scope, &format!("{}", deno_core::anyhow::Error::from(#message))).unwrap();
-    let exc = deno_core::v8::Exception::type_error(&mut #scope, msg);
-    #scope.throw_exception(exc);
+    deno_core::_ops::throw_error2(&mut #scope, deno_core::anyhow::Error::from(#message));
     return 1;
   }))
 }
@@ -1239,9 +1234,7 @@ fn throw_type_error_static_string(
 
   Ok(gs_quote!(generator_state(scope) => {
     #maybe_scope
-    let msg = deno_core::v8::String::new_from_one_byte(&mut #scope, #message.as_bytes(), deno_core::v8::NewStringType::Normal).unwrap();
-    let exc = deno_core::v8::Exception::type_error(&mut #scope, msg);
-    #scope.throw_exception(exc);
+    deno_core::_ops::throw_error1(&mut #scope, #message);
     return 1;
   }))
 }

--- a/ops/op2/test_cases/async/async_arg_return.out
+++ b/ops/op2/test_cases/async/async_arg_return.out
@@ -47,8 +47,7 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(1usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
+                    deno_core::_ops::throw_error1(&info, "expected i32");
                     return 1;
                 };
                 let arg0 = arg0 as _;

--- a/ops/op2/test_cases/async/async_arg_return.out
+++ b/ops/op2/test_cases/async/async_arg_return.out
@@ -48,14 +48,7 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                 let arg0 = args.get(1usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected i32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
                     return 1;
                 };
                 let arg0 = arg0 as _;

--- a/ops/op2/test_cases/async/async_arg_return.out
+++ b/ops/op2/test_cases/async/async_arg_return.out
@@ -47,7 +47,7 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(1usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected i32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected i32");
                     return 1;
                 };
                 let arg0 = arg0 as _;

--- a/ops/op2/test_cases/async/async_arg_return_result.out
+++ b/ops/op2/test_cases/async/async_arg_return_result.out
@@ -47,8 +47,7 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(1usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
+                    deno_core::_ops::throw_error1(&info, "expected i32");
                     return 1;
                 };
                 let arg0 = arg0 as _;

--- a/ops/op2/test_cases/async/async_arg_return_result.out
+++ b/ops/op2/test_cases/async/async_arg_return_result.out
@@ -48,14 +48,7 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                 let arg0 = args.get(1usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected i32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
                     return 1;
                 };
                 let arg0 = arg0 as _;

--- a/ops/op2/test_cases/async/async_arg_return_result.out
+++ b/ops/op2/test_cases/async/async_arg_return_result.out
@@ -47,7 +47,7 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(1usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected i32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected i32");
                     return 1;
                 };
                 let arg0 = arg0 as _;

--- a/ops/op2/test_cases/async/async_cppgc.out
+++ b/ops/op2/test_cases/async/async_cppgc.out
@@ -175,7 +175,7 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 let Some(mut arg0) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Wrap,
                 >(&mut scope, arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected Wrap");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected Wrap");
                     return 1;
                 };
                 arg0.root();
@@ -298,7 +298,7 @@ const fn op_use_optional_cppgc_object() -> ::deno_core::_ops::OpDecl {
                     arg0.root();
                     Some(arg0)
                 } else {
-                    deno_core::_ops::throw_error1(&info, "expected Wrap");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected Wrap");
                     return 1;
                 };
                 async move {

--- a/ops/op2/test_cases/async/async_cppgc.out
+++ b/ops/op2/test_cases/async/async_cppgc.out
@@ -175,7 +175,7 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 let Some(mut arg0) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Wrap,
                 >(&mut scope, arg0) else {
-                    deno_core::_ops::throw_error1(&mut scope, "expected Wrap");
+                    deno_core::_ops::throw_error1(&info, "expected Wrap");
                     return 1;
                 };
                 arg0.root();
@@ -298,7 +298,7 @@ const fn op_use_optional_cppgc_object() -> ::deno_core::_ops::OpDecl {
                     arg0.root();
                     Some(arg0)
                 } else {
-                    deno_core::_ops::throw_error1(&mut scope, "expected Wrap");
+                    deno_core::_ops::throw_error1(&info, "expected Wrap");
                     return 1;
                 };
                 async move {

--- a/ops/op2/test_cases/async/async_cppgc.out
+++ b/ops/op2/test_cases/async/async_cppgc.out
@@ -175,14 +175,7 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 let Some(mut arg0) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Wrap,
                 >(&mut scope, arg0) else {
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected Wrap".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected Wrap");
                     return 1;
                 };
                 arg0.root();
@@ -305,14 +298,7 @@ const fn op_use_optional_cppgc_object() -> ::deno_core::_ops::OpDecl {
                     arg0.root();
                     Some(arg0)
                 } else {
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected Wrap".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected Wrap");
                     return 1;
                 };
                 async move {

--- a/ops/op2/test_cases/async/async_jsbuffer.out
+++ b/ops/op2/test_cases/async/async_jsbuffer.out
@@ -54,14 +54,7 @@ pub const fn op_async_v8_buffer() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                arg0_err.as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, arg0_err);
                         return 1;
                     }
                 };
@@ -86,13 +79,10 @@ pub const fn op_async_v8_buffer() -> ::deno_core::_ops::OpDecl {
                 ) {
                     Ok(v) => rv.set(v),
                     Err(rv_err) => {
-                        let msg = deno_core::v8::String::new(
-                                &mut scope,
-                                &format!("{}", deno_core::anyhow::Error::from(rv_err)),
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error2(
+                            &mut scope,
+                            deno_core::anyhow::Error::from(rv_err),
+                        );
                         return 1;
                     }
                 };

--- a/ops/op2/test_cases/async/async_jsbuffer.out
+++ b/ops/op2/test_cases/async/async_jsbuffer.out
@@ -51,7 +51,7 @@ pub const fn op_async_v8_buffer() -> ::deno_core::_ops::OpDecl {
                 arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
-                        deno_core::_ops::throw_error1(&info, arg0_err);
+                        deno_core::_ops::throw_error_one_byte_info(&info, arg0_err);
                         return 1;
                     }
                 };
@@ -76,7 +76,7 @@ pub const fn op_async_v8_buffer() -> ::deno_core::_ops::OpDecl {
                 ) {
                     Ok(v) => rv.set(v),
                     Err(rv_err) => {
-                        deno_core::_ops::throw_error2(&mut scope, rv_err);
+                        deno_core::_ops::throw_error_anyhow(&mut scope, rv_err);
                         return 1;
                     }
                 };

--- a/ops/op2/test_cases/async/async_jsbuffer.out
+++ b/ops/op2/test_cases/async/async_jsbuffer.out
@@ -79,10 +79,7 @@ pub const fn op_async_v8_buffer() -> ::deno_core::_ops::OpDecl {
                 ) {
                     Ok(v) => rv.set(v),
                     Err(rv_err) => {
-                        deno_core::_ops::throw_error2(
-                            &mut scope,
-                            deno_core::anyhow::Error::from(rv_err),
-                        );
+                        deno_core::_ops::throw_error2(&mut scope, rv_err);
                         return 1;
                     }
                 };

--- a/ops/op2/test_cases/async/async_jsbuffer.out
+++ b/ops/op2/test_cases/async/async_jsbuffer.out
@@ -51,10 +51,7 @@ pub const fn op_async_v8_buffer() -> ::deno_core::_ops::OpDecl {
                 arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, arg0_err);
+                        deno_core::_ops::throw_error1(&info, arg0_err);
                         return 1;
                     }
                 };

--- a/ops/op2/test_cases/async/async_result_impl.out
+++ b/ops/op2/test_cases/async/async_result_impl.out
@@ -47,7 +47,7 @@ pub const fn op_async_result_impl() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(1usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected i32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected i32");
                     return 1;
                 };
                 let arg0 = arg0 as _;

--- a/ops/op2/test_cases/async/async_result_impl.out
+++ b/ops/op2/test_cases/async/async_result_impl.out
@@ -48,14 +48,7 @@ pub const fn op_async_result_impl() -> ::deno_core::_ops::OpDecl {
                 let arg0 = args.get(1usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected i32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
                     return 1;
                 };
                 let arg0 = arg0 as _;

--- a/ops/op2/test_cases/async/async_result_impl.out
+++ b/ops/op2/test_cases/async/async_result_impl.out
@@ -47,8 +47,7 @@ pub const fn op_async_result_impl() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(1usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
+                    deno_core::_ops::throw_error1(&info, "expected i32");
                     return 1;
                 };
                 let arg0 = arg0 as _;

--- a/ops/op2/test_cases/async/async_result_smi.out
+++ b/ops/op2/test_cases/async/async_result_smi.out
@@ -47,8 +47,7 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(1usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
+                    deno_core::_ops::throw_error1(&info, "expected i32");
                     return 1;
                 };
                 let arg0 = arg0 as _;

--- a/ops/op2/test_cases/async/async_result_smi.out
+++ b/ops/op2/test_cases/async/async_result_smi.out
@@ -48,14 +48,7 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                 let arg0 = args.get(1usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected i32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
                     return 1;
                 };
                 let arg0 = arg0 as _;

--- a/ops/op2/test_cases/async/async_result_smi.out
+++ b/ops/op2/test_cases/async/async_result_smi.out
@@ -47,7 +47,7 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(1usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected i32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected i32");
                     return 1;
                 };
                 let arg0 = arg0 as _;

--- a/ops/op2/test_cases/async/async_v8_global.out
+++ b/ops/op2/test_cases/async/async_v8_global.out
@@ -51,14 +51,7 @@ pub const fn op_async_v8_global() -> ::deno_core::_ops::OpDecl {
                     deno_core::v8::String,
                 >(arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected String".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected String");
                     return 1;
                 };
                 let arg0 = deno_core::v8::Global::new(&mut scope, arg0);

--- a/ops/op2/test_cases/async/async_v8_global.out
+++ b/ops/op2/test_cases/async/async_v8_global.out
@@ -50,8 +50,7 @@ pub const fn op_async_v8_global() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::String,
                 >(arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected String");
+                    deno_core::_ops::throw_error1(&info, "expected String");
                     return 1;
                 };
                 let arg0 = deno_core::v8::Global::new(&mut scope, arg0);

--- a/ops/op2/test_cases/async/async_v8_global.out
+++ b/ops/op2/test_cases/async/async_v8_global.out
@@ -50,7 +50,7 @@ pub const fn op_async_v8_global() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::String,
                 >(arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected String");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected String");
                     return 1;
                 };
                 let arg0 = deno_core::v8::Global::new(&mut scope, arg0);

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -143,28 +143,14 @@ const fn op_add() -> ::deno_core::_ops::OpDecl {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected u32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected u32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
                     return 1;
                 };
                 let arg1 = arg1 as _;

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -142,15 +142,13 @@ const fn op_add() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
+                    deno_core::_ops::throw_error1(&info, "expected u32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
+                    deno_core::_ops::throw_error1(&info, "expected u32");
                     return 1;
                 };
                 let arg1 = arg1 as _;

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -142,13 +142,13 @@ const fn op_add() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected u32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected u32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                    deno_core::_ops::throw_error1(&info, "expected u32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected u32");
                     return 1;
                 };
                 let arg1 = arg1 as _;

--- a/ops/op2/test_cases/sync/add_options.out
+++ b/ops/op2/test_cases/sync/add_options.out
@@ -41,8 +41,7 @@ pub const fn op_test_add_option() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
+                    deno_core::_ops::throw_error1(&info, "expected u32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
@@ -51,10 +50,7 @@ pub const fn op_test_add_option() -> ::deno_core::_ops::OpDecl {
                     None
                 } else {
                     let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, "expected u32");
+                        deno_core::_ops::throw_error1(&info, "expected u32");
                         return 1;
                     };
                     let arg1 = arg1 as _;

--- a/ops/op2/test_cases/sync/add_options.out
+++ b/ops/op2/test_cases/sync/add_options.out
@@ -42,14 +42,7 @@ pub const fn op_test_add_option() -> ::deno_core::_ops::OpDecl {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected u32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
@@ -61,14 +54,7 @@ pub const fn op_test_add_option() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                "expected u32".as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, "expected u32");
                         return 1;
                     };
                     let arg1 = arg1 as _;

--- a/ops/op2/test_cases/sync/add_options.out
+++ b/ops/op2/test_cases/sync/add_options.out
@@ -41,7 +41,7 @@ pub const fn op_test_add_option() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected u32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected u32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
@@ -50,7 +50,10 @@ pub const fn op_test_add_option() -> ::deno_core::_ops::OpDecl {
                     None
                 } else {
                     let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                        deno_core::_ops::throw_error1(&info, "expected u32");
+                        deno_core::_ops::throw_error_one_byte_info(
+                            &info,
+                            "expected u32",
+                        );
                         return 1;
                     };
                     let arg1 = arg1 as _;

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -151,10 +151,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, arg0_err);
+                        deno_core::_ops::throw_error1(&info, arg0_err);
                         return 1;
                     }
                 };
@@ -164,10 +161,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg1) } {
                     Ok(arg1) => arg1,
                     Err(arg1_err) => {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, arg1_err);
+                        deno_core::_ops::throw_error1(&info, arg1_err);
                         return 1;
                     }
                 };
@@ -177,10 +171,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 arg2_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg2) } {
                     Ok(arg2) => arg2,
                     Err(arg2_err) => {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, arg2_err);
+                        deno_core::_ops::throw_error1(&info, arg2_err);
                         return 1;
                     }
                 };
@@ -194,10 +185,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 arg3_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg3) } {
                     Ok(arg3) => arg3,
                     Err(arg3_err) => {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, arg3_err);
+                        deno_core::_ops::throw_error1(&info, arg3_err);
                         return 1;
                     }
                 };
@@ -406,10 +394,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg0) } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, arg0_err);
+                        deno_core::_ops::throw_error1(&info, arg0_err);
                         return 1;
                     }
                 };
@@ -419,10 +404,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg1) } {
                     Ok(arg1) => arg1,
                     Err(arg1_err) => {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, arg1_err);
+                        deno_core::_ops::throw_error1(&info, arg1_err);
                         return 1;
                     }
                 };
@@ -432,10 +414,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 arg2_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg2) } {
                     Ok(arg2) => arg2,
                     Err(arg2_err) => {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, arg2_err);
+                        deno_core::_ops::throw_error1(&info, arg2_err);
                         return 1;
                     }
                 };
@@ -449,10 +428,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 arg3_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg3) } {
                     Ok(arg3) => arg3,
                     Err(arg3_err) => {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, arg3_err);
+                        deno_core::_ops::throw_error1(&info, arg3_err);
                         return 1;
                     }
                 };
@@ -559,10 +535,7 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
                     } {
                         Ok(arg0) => arg0,
                         Err(arg0_err) => {
-                            let mut scope = unsafe {
-                                deno_core::v8::CallbackScope::new(info)
-                            };
-                            deno_core::_ops::throw_error1(&mut scope, arg0_err);
+                            deno_core::_ops::throw_error1(&info, arg0_err);
                             return 1;
                         }
                     };
@@ -579,10 +552,7 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
                     } {
                         Ok(arg1) => arg1,
                         Err(arg1_err) => {
-                            let mut scope = unsafe {
-                                deno_core::v8::CallbackScope::new(info)
-                            };
-                            deno_core::_ops::throw_error1(&mut scope, arg1_err);
+                            deno_core::_ops::throw_error1(&info, arg1_err);
                             return 1;
                         }
                     };

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -154,14 +154,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                arg0_err.as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, arg0_err);
                         return 1;
                     }
                 };
@@ -174,14 +167,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                arg1_err.as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, arg1_err);
                         return 1;
                     }
                 };
@@ -194,14 +180,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                arg2_err.as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, arg2_err);
                         return 1;
                     }
                 };
@@ -218,14 +197,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                arg3_err.as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, arg3_err);
                         return 1;
                     }
                 };
@@ -437,14 +409,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                arg0_err.as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, arg0_err);
                         return 1;
                     }
                 };
@@ -457,14 +422,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                arg1_err.as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, arg1_err);
                         return 1;
                     }
                 };
@@ -477,14 +435,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                arg2_err.as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, arg2_err);
                         return 1;
                     }
                 };
@@ -501,14 +452,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                arg3_err.as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, arg3_err);
                         return 1;
                     }
                 };
@@ -618,17 +562,7 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
                             let mut scope = unsafe {
                                 deno_core::v8::CallbackScope::new(info)
                             };
-                            let msg = deno_core::v8::String::new_from_one_byte(
-                                    &mut scope,
-                                    arg0_err.as_bytes(),
-                                    deno_core::v8::NewStringType::Normal,
-                                )
-                                .unwrap();
-                            let exc = deno_core::v8::Exception::type_error(
-                                &mut scope,
-                                msg,
-                            );
-                            scope.throw_exception(exc);
+                            deno_core::_ops::throw_error1(&mut scope, arg0_err);
                             return 1;
                         }
                     };
@@ -648,17 +582,7 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
                             let mut scope = unsafe {
                                 deno_core::v8::CallbackScope::new(info)
                             };
-                            let msg = deno_core::v8::String::new_from_one_byte(
-                                    &mut scope,
-                                    arg1_err.as_bytes(),
-                                    deno_core::v8::NewStringType::Normal,
-                                )
-                                .unwrap();
-                            let exc = deno_core::v8::Exception::type_error(
-                                &mut scope,
-                                msg,
-                            );
-                            scope.throw_exception(exc);
+                            deno_core::_ops::throw_error1(&mut scope, arg1_err);
                             return 1;
                         }
                     };

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -151,7 +151,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
-                        deno_core::_ops::throw_error1(&info, arg0_err);
+                        deno_core::_ops::throw_error_one_byte_info(&info, arg0_err);
                         return 1;
                     }
                 };
@@ -161,7 +161,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg1) } {
                     Ok(arg1) => arg1,
                     Err(arg1_err) => {
-                        deno_core::_ops::throw_error1(&info, arg1_err);
+                        deno_core::_ops::throw_error_one_byte_info(&info, arg1_err);
                         return 1;
                     }
                 };
@@ -171,7 +171,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 arg2_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg2) } {
                     Ok(arg2) => arg2,
                     Err(arg2_err) => {
-                        deno_core::_ops::throw_error1(&info, arg2_err);
+                        deno_core::_ops::throw_error_one_byte_info(&info, arg2_err);
                         return 1;
                     }
                 };
@@ -185,7 +185,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 arg3_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg3) } {
                     Ok(arg3) => arg3,
                     Err(arg3_err) => {
-                        deno_core::_ops::throw_error1(&info, arg3_err);
+                        deno_core::_ops::throw_error_one_byte_info(&info, arg3_err);
                         return 1;
                     }
                 };
@@ -394,7 +394,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg0) } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
-                        deno_core::_ops::throw_error1(&info, arg0_err);
+                        deno_core::_ops::throw_error_one_byte_info(&info, arg0_err);
                         return 1;
                     }
                 };
@@ -404,7 +404,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg1) } {
                     Ok(arg1) => arg1,
                     Err(arg1_err) => {
-                        deno_core::_ops::throw_error1(&info, arg1_err);
+                        deno_core::_ops::throw_error_one_byte_info(&info, arg1_err);
                         return 1;
                     }
                 };
@@ -414,7 +414,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 arg2_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg2) } {
                     Ok(arg2) => arg2,
                     Err(arg2_err) => {
-                        deno_core::_ops::throw_error1(&info, arg2_err);
+                        deno_core::_ops::throw_error_one_byte_info(&info, arg2_err);
                         return 1;
                     }
                 };
@@ -428,7 +428,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 arg3_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg3) } {
                     Ok(arg3) => arg3,
                     Err(arg3_err) => {
-                        deno_core::_ops::throw_error1(&info, arg3_err);
+                        deno_core::_ops::throw_error_one_byte_info(&info, arg3_err);
                         return 1;
                     }
                 };
@@ -535,7 +535,7 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
                     } {
                         Ok(arg0) => arg0,
                         Err(arg0_err) => {
-                            deno_core::_ops::throw_error1(&info, arg0_err);
+                            deno_core::_ops::throw_error_one_byte_info(&info, arg0_err);
                             return 1;
                         }
                     };
@@ -552,7 +552,7 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
                     } {
                         Ok(arg1) => arg1,
                         Err(arg1_err) => {
-                            deno_core::_ops::throw_error1(&info, arg1_err);
+                            deno_core::_ops::throw_error_one_byte_info(&info, arg1_err);
                             return 1;
                         }
                     };

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -135,7 +135,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
-                        deno_core::_ops::throw_error1(&info, arg0_err);
+                        deno_core::_ops::throw_error_one_byte_info(&info, arg0_err);
                         return 1;
                     }
                 };
@@ -145,7 +145,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg1) } {
                     Ok(arg1) => arg1,
                     Err(arg1_err) => {
-                        deno_core::_ops::throw_error1(&info, arg1_err);
+                        deno_core::_ops::throw_error_one_byte_info(&info, arg1_err);
                         return 1;
                     }
                 };
@@ -155,7 +155,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 arg2_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg2) } {
                     Ok(arg2) => arg2,
                     Err(arg2_err) => {
-                        deno_core::_ops::throw_error1(&info, arg2_err);
+                        deno_core::_ops::throw_error_one_byte_info(&info, arg2_err);
                         return 1;
                     }
                 };
@@ -336,7 +336,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg0) } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
-                        deno_core::_ops::throw_error1(&info, arg0_err);
+                        deno_core::_ops::throw_error_one_byte_info(&info, arg0_err);
                         return 1;
                     }
                 };
@@ -346,7 +346,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg1) } {
                     Ok(arg1) => arg1,
                     Err(arg1_err) => {
-                        deno_core::_ops::throw_error1(&info, arg1_err);
+                        deno_core::_ops::throw_error_one_byte_info(&info, arg1_err);
                         return 1;
                     }
                 };

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -135,10 +135,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, arg0_err);
+                        deno_core::_ops::throw_error1(&info, arg0_err);
                         return 1;
                     }
                 };
@@ -148,10 +145,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg1) } {
                     Ok(arg1) => arg1,
                     Err(arg1_err) => {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, arg1_err);
+                        deno_core::_ops::throw_error1(&info, arg1_err);
                         return 1;
                     }
                 };
@@ -161,10 +155,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 arg2_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg2) } {
                     Ok(arg2) => arg2,
                     Err(arg2_err) => {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, arg2_err);
+                        deno_core::_ops::throw_error1(&info, arg2_err);
                         return 1;
                     }
                 };
@@ -345,10 +336,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg0) } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, arg0_err);
+                        deno_core::_ops::throw_error1(&info, arg0_err);
                         return 1;
                     }
                 };
@@ -358,10 +346,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 arg1_temp = match unsafe { deno_core::_ops::to_v8_slice::<u32>(arg1) } {
                     Ok(arg1) => arg1,
                     Err(arg1_err) => {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, arg1_err);
+                        deno_core::_ops::throw_error1(&info, arg1_err);
                         return 1;
                     }
                 };

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -138,14 +138,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                arg0_err.as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, arg0_err);
                         return 1;
                     }
                 };
@@ -158,14 +151,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                arg1_err.as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, arg1_err);
                         return 1;
                     }
                 };
@@ -178,14 +164,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                arg2_err.as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, arg2_err);
                         return 1;
                     }
                 };
@@ -369,14 +348,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                arg0_err.as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, arg0_err);
                         return 1;
                     }
                 };
@@ -389,14 +361,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                arg1_err.as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, arg1_err);
                         return 1;
                     }
                 };

--- a/ops/op2/test_cases/sync/buffers_out.out
+++ b/ops/op2/test_cases/sync/buffers_out.out
@@ -45,10 +45,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, arg0_err);
+                        deno_core::_ops::throw_error1(&info, arg0_err);
                         return 1;
                     }
                 };
@@ -160,10 +157,7 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
                     } {
                         Ok(arg0) => arg0,
                         Err(arg0_err) => {
-                            let mut scope = unsafe {
-                                deno_core::v8::CallbackScope::new(info)
-                            };
-                            deno_core::_ops::throw_error1(&mut scope, arg0_err);
+                            deno_core::_ops::throw_error1(&info, arg0_err);
                             return 1;
                         }
                     };
@@ -272,10 +266,7 @@ const fn op_arraybuffers() -> ::deno_core::_ops::OpDecl {
                 arg0_temp = match unsafe { deno_core::_ops::to_v8_slice_buffer(arg0) } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, arg0_err);
+                        deno_core::_ops::throw_error1(&info, arg0_err);
                         return 1;
                     }
                 };

--- a/ops/op2/test_cases/sync/buffers_out.out
+++ b/ops/op2/test_cases/sync/buffers_out.out
@@ -58,10 +58,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    deno_core::_ops::throw_error2(
-                        &mut scope,
-                        deno_core::anyhow::Error::from(rv_err),
-                    );
+                    deno_core::_ops::throw_error2(&mut scope, rv_err);
                     return 1;
                 }
             };
@@ -178,10 +175,7 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    deno_core::_ops::throw_error2(
-                        &mut scope,
-                        deno_core::anyhow::Error::from(rv_err),
-                    );
+                    deno_core::_ops::throw_error2(&mut scope, rv_err);
                     return 1;
                 }
             };

--- a/ops/op2/test_cases/sync/buffers_out.out
+++ b/ops/op2/test_cases/sync/buffers_out.out
@@ -48,14 +48,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                arg0_err.as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, arg0_err);
                         return 1;
                     }
                 };
@@ -65,13 +58,10 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    let msg = deno_core::v8::String::new(
-                            &mut scope,
-                            &format!("{}", deno_core::anyhow::Error::from(rv_err)),
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error2(
+                        &mut scope,
+                        deno_core::anyhow::Error::from(rv_err),
+                    );
                     return 1;
                 }
             };
@@ -176,17 +166,7 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
                             let mut scope = unsafe {
                                 deno_core::v8::CallbackScope::new(info)
                             };
-                            let msg = deno_core::v8::String::new_from_one_byte(
-                                    &mut scope,
-                                    arg0_err.as_bytes(),
-                                    deno_core::v8::NewStringType::Normal,
-                                )
-                                .unwrap();
-                            let exc = deno_core::v8::Exception::type_error(
-                                &mut scope,
-                                msg,
-                            );
-                            scope.throw_exception(exc);
+                            deno_core::_ops::throw_error1(&mut scope, arg0_err);
                             return 1;
                         }
                     };
@@ -198,13 +178,10 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    let msg = deno_core::v8::String::new(
-                            &mut scope,
-                            &format!("{}", deno_core::anyhow::Error::from(rv_err)),
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error2(
+                        &mut scope,
+                        deno_core::anyhow::Error::from(rv_err),
+                    );
                     return 1;
                 }
             };
@@ -304,14 +281,7 @@ const fn op_arraybuffers() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                arg0_err.as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, arg0_err);
                         return 1;
                     }
                 };

--- a/ops/op2/test_cases/sync/buffers_out.out
+++ b/ops/op2/test_cases/sync/buffers_out.out
@@ -45,7 +45,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 arg0_temp = match unsafe { deno_core::_ops::to_v8_slice::<u8>(arg0) } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
-                        deno_core::_ops::throw_error1(&info, arg0_err);
+                        deno_core::_ops::throw_error_one_byte_info(&info, arg0_err);
                         return 1;
                     }
                 };
@@ -55,7 +55,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    deno_core::_ops::throw_error2(&mut scope, rv_err);
+                    deno_core::_ops::throw_error_anyhow(&mut scope, rv_err);
                     return 1;
                 }
             };
@@ -157,7 +157,7 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
                     } {
                         Ok(arg0) => arg0,
                         Err(arg0_err) => {
-                            deno_core::_ops::throw_error1(&info, arg0_err);
+                            deno_core::_ops::throw_error_one_byte_info(&info, arg0_err);
                             return 1;
                         }
                     };
@@ -169,7 +169,7 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    deno_core::_ops::throw_error2(&mut scope, rv_err);
+                    deno_core::_ops::throw_error_anyhow(&mut scope, rv_err);
                     return 1;
                 }
             };
@@ -266,7 +266,7 @@ const fn op_arraybuffers() -> ::deno_core::_ops::OpDecl {
                 arg0_temp = match unsafe { deno_core::_ops::to_v8_slice_buffer(arg0) } {
                     Ok(arg0) => arg0,
                     Err(arg0_err) => {
-                        deno_core::_ops::throw_error1(&info, arg0_err);
+                        deno_core::_ops::throw_error_one_byte_info(&info, arg0_err);
                         return 1;
                     }
                 };

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -111,7 +111,7 @@ const fn op_cppgc_object() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        deno_core::_ops::throw_error1(
+                        deno_core::_ops::throw_error3(
                             &mut scope,
                             "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }",
                         );
@@ -140,7 +140,7 @@ const fn op_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 let Some(arg0) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Wrap,
                 >(&mut scope, arg0) else {
-                    deno_core::_ops::throw_error1(&mut scope, "expected Wrap");
+                    deno_core::_ops::throw_error1(&info, "expected Wrap");
                     return 1;
                 };
                 let arg0 = &*arg0;
@@ -308,7 +308,7 @@ const fn op_option_cppgc_object() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        deno_core::_ops::throw_error1(
+                        deno_core::_ops::throw_error3(
                             &mut scope,
                             "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }",
                         );
@@ -341,7 +341,7 @@ const fn op_option_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 >(&mut scope, arg0) {
                     Some(arg0)
                 } else {
-                    deno_core::_ops::throw_error1(&mut scope, "expected Wrap");
+                    deno_core::_ops::throw_error1(&info, "expected Wrap");
                     return 1;
                 };
                 let arg0 = arg0.as_deref();
@@ -599,7 +599,7 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        deno_core::_ops::throw_error1(
+                        deno_core::_ops::throw_error3(
                             &mut scope,
                             "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }",
                         );
@@ -628,7 +628,7 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 let Some(arg0) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Wrap,
                 >(&mut scope, arg0) else {
-                    deno_core::_ops::throw_error1(&mut scope, "expected Wrap");
+                    deno_core::_ops::throw_error1(&info, "expected Wrap");
                     return 1;
                 };
                 let arg0 = &*arg0;
@@ -889,7 +889,7 @@ const fn op_use_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        deno_core::_ops::throw_error1(
+                        deno_core::_ops::throw_error3(
                             &mut scope,
                             "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }",
                         );
@@ -918,7 +918,7 @@ const fn op_use_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
                 let Some(arg0) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Wrap,
                 >(&mut scope, arg0) else {
-                    deno_core::_ops::throw_error1(&mut scope, "expected Wrap");
+                    deno_core::_ops::throw_error1(&info, "expected Wrap");
                     return 1;
                 };
                 let arg0 = &*arg0;

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -111,15 +111,10 @@ const fn op_cppgc_object() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }"
-                                    .as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        crate::_ops::throw_error1(
+                            &mut scope,
+                            "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }",
+                        );
                         return unsafe { std::mem::zeroed() };
                     }
                 };
@@ -313,15 +308,10 @@ const fn op_option_cppgc_object() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }"
-                                    .as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        crate::_ops::throw_error1(
+                            &mut scope,
+                            "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }",
+                        );
                         return unsafe { std::mem::zeroed() };
                     }
                 };
@@ -609,15 +599,10 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }"
-                                    .as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        crate::_ops::throw_error1(
+                            &mut scope,
+                            "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }",
+                        );
                         return unsafe { std::mem::zeroed() };
                     }
                 };
@@ -904,15 +889,10 @@ const fn op_use_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }"
-                                    .as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        crate::_ops::throw_error1(
+                            &mut scope,
+                            "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }",
+                        );
                         return unsafe { std::mem::zeroed() };
                     }
                 };

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -111,7 +111,7 @@ const fn op_cppgc_object() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        crate::_ops::throw_error1(
+                        deno_core::_ops::throw_error1(
                             &mut scope,
                             "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }",
                         );
@@ -308,7 +308,7 @@ const fn op_option_cppgc_object() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        crate::_ops::throw_error1(
+                        deno_core::_ops::throw_error1(
                             &mut scope,
                             "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }",
                         );
@@ -599,7 +599,7 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        crate::_ops::throw_error1(
+                        deno_core::_ops::throw_error1(
                             &mut scope,
                             "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }",
                         );
@@ -889,7 +889,7 @@ const fn op_use_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        crate::_ops::throw_error1(
+                        deno_core::_ops::throw_error1(
                             &mut scope,
                             "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }",
                         );

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -111,7 +111,7 @@ const fn op_cppgc_object() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        deno_core::_ops::throw_error3(
+                        deno_core::_ops::throw_error_one_byte(
                             &mut scope,
                             "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }",
                         );
@@ -140,7 +140,7 @@ const fn op_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 let Some(arg0) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Wrap,
                 >(&mut scope, arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected Wrap");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected Wrap");
                     return 1;
                 };
                 let arg0 = &*arg0;
@@ -308,7 +308,7 @@ const fn op_option_cppgc_object() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        deno_core::_ops::throw_error3(
+                        deno_core::_ops::throw_error_one_byte(
                             &mut scope,
                             "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }",
                         );
@@ -341,7 +341,7 @@ const fn op_option_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 >(&mut scope, arg0) {
                     Some(arg0)
                 } else {
-                    deno_core::_ops::throw_error1(&info, "expected Wrap");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected Wrap");
                     return 1;
                 };
                 let arg0 = arg0.as_deref();
@@ -599,7 +599,7 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        deno_core::_ops::throw_error3(
+                        deno_core::_ops::throw_error_one_byte(
                             &mut scope,
                             "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }",
                         );
@@ -628,7 +628,7 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 let Some(arg0) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Wrap,
                 >(&mut scope, arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected Wrap");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected Wrap");
                     return 1;
                 };
                 let arg0 = &*arg0;
@@ -889,7 +889,7 @@ const fn op_use_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        deno_core::_ops::throw_error3(
+                        deno_core::_ops::throw_error_one_byte(
                             &mut scope,
                             "expected Path { leading_colon: None, segments: [PathSegment { ident: Ident(Wrap), arguments: PathArguments::None }] }",
                         );
@@ -918,7 +918,7 @@ const fn op_use_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
                 let Some(arg0) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Wrap,
                 >(&mut scope, arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected Wrap");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected Wrap");
                     return 1;
                 };
                 let arg0 = &*arg0;

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -145,14 +145,7 @@ const fn op_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 let Some(arg0) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Wrap,
                 >(&mut scope, arg0) else {
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected Wrap".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected Wrap");
                     return 1;
                 };
                 let arg0 = &*arg0;
@@ -358,14 +351,7 @@ const fn op_option_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 >(&mut scope, arg0) {
                     Some(arg0)
                 } else {
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected Wrap".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected Wrap");
                     return 1;
                 };
                 let arg0 = arg0.as_deref();
@@ -657,14 +643,7 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 let Some(arg0) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Wrap,
                 >(&mut scope, arg0) else {
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected Wrap".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected Wrap");
                     return 1;
                 };
                 let arg0 = &*arg0;
@@ -959,14 +938,7 @@ const fn op_use_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
                 let Some(arg0) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Wrap,
                 >(&mut scope, arg0) else {
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected Wrap".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected Wrap");
                     return 1;
                 };
                 let arg0 = &*arg0;

--- a/ops/op2/test_cases/sync/fast_alternative.out
+++ b/ops/op2/test_cases/sync/fast_alternative.out
@@ -42,13 +42,13 @@ const fn op_slow() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg1 = args.get(0usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                    deno_core::_ops::throw_error1(&info, "expected u32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected u32");
                     return 1;
                 };
                 let arg1 = arg1 as _;
                 let arg2 = args.get(1usize as i32);
                 let Some(arg2) = deno_core::_ops::to_u32_option(&arg2) else {
-                    deno_core::_ops::throw_error1(&info, "expected u32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected u32");
                     return 1;
                 };
                 let arg2 = arg2 as _;
@@ -246,13 +246,13 @@ const fn op_fast() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected u32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected u32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                    deno_core::_ops::throw_error1(&info, "expected u32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected u32");
                     return 1;
                 };
                 let arg1 = arg1 as _;
@@ -349,13 +349,13 @@ const fn op_slow_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg1 = args.get(0usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                    deno_core::_ops::throw_error1(&info, "expected u32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected u32");
                     return 1;
                 };
                 let arg1 = arg1 as _;
                 let arg2 = args.get(1usize as i32);
                 let Some(arg2) = deno_core::_ops::to_u32_option(&arg2) else {
-                    deno_core::_ops::throw_error1(&info, "expected u32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected u32");
                     return 1;
                 };
                 let arg2 = arg2 as _;
@@ -553,13 +553,13 @@ const fn op_fast_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected u32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected u32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                    deno_core::_ops::throw_error1(&info, "expected u32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected u32");
                     return 1;
                 };
                 let arg1 = arg1 as _;

--- a/ops/op2/test_cases/sync/fast_alternative.out
+++ b/ops/op2/test_cases/sync/fast_alternative.out
@@ -42,13 +42,13 @@ const fn op_slow() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg1 = args.get(0usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
+                    deno_core::_ops::throw_error1(&info, "expected u32");
                     return 1;
                 };
                 let arg1 = arg1 as _;
                 let arg2 = args.get(1usize as i32);
                 let Some(arg2) = deno_core::_ops::to_u32_option(&arg2) else {
-                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
+                    deno_core::_ops::throw_error1(&info, "expected u32");
                     return 1;
                 };
                 let arg2 = arg2 as _;
@@ -246,15 +246,13 @@ const fn op_fast() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
+                    deno_core::_ops::throw_error1(&info, "expected u32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
+                    deno_core::_ops::throw_error1(&info, "expected u32");
                     return 1;
                 };
                 let arg1 = arg1 as _;
@@ -351,13 +349,13 @@ const fn op_slow_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg1 = args.get(0usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
+                    deno_core::_ops::throw_error1(&info, "expected u32");
                     return 1;
                 };
                 let arg1 = arg1 as _;
                 let arg2 = args.get(1usize as i32);
                 let Some(arg2) = deno_core::_ops::to_u32_option(&arg2) else {
-                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
+                    deno_core::_ops::throw_error1(&info, "expected u32");
                     return 1;
                 };
                 let arg2 = arg2 as _;
@@ -555,15 +553,13 @@ const fn op_fast_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
+                    deno_core::_ops::throw_error1(&info, "expected u32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
+                    deno_core::_ops::throw_error1(&info, "expected u32");
                     return 1;
                 };
                 let arg1 = arg1 as _;

--- a/ops/op2/test_cases/sync/fast_alternative.out
+++ b/ops/op2/test_cases/sync/fast_alternative.out
@@ -42,27 +42,13 @@ const fn op_slow() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg1 = args.get(0usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected u32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
                     return 1;
                 };
                 let arg1 = arg1 as _;
                 let arg2 = args.get(1usize as i32);
                 let Some(arg2) = deno_core::_ops::to_u32_option(&arg2) else {
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected u32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
                     return 1;
                 };
                 let arg2 = arg2 as _;
@@ -261,28 +247,14 @@ const fn op_fast() -> ::deno_core::_ops::OpDecl {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected u32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected u32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
                     return 1;
                 };
                 let arg1 = arg1 as _;
@@ -379,27 +351,13 @@ const fn op_slow_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg1 = args.get(0usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected u32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
                     return 1;
                 };
                 let arg1 = arg1 as _;
                 let arg2 = args.get(1usize as i32);
                 let Some(arg2) = deno_core::_ops::to_u32_option(&arg2) else {
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected u32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
                     return 1;
                 };
                 let arg2 = arg2 as _;
@@ -598,28 +556,14 @@ const fn op_fast_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected u32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected u32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
                     return 1;
                 };
                 let arg1 = arg1 as _;

--- a/ops/op2/test_cases/sync/from_v8.out
+++ b/ops/op2/test_cases/sync/from_v8.out
@@ -44,13 +44,10 @@ pub const fn op_from_v8_arg() -> ::deno_core::_ops::OpDecl {
                 let arg0 = match <Foo as deno_core::FromV8>::from_v8(&mut scope, arg0) {
                     Ok(t) => t,
                     Err(arg0_err) => {
-                        let msg = deno_core::v8::String::new(
-                                &mut scope,
-                                &format!("{}", deno_core::anyhow::Error::from(arg0_err)),
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error2(
+                            &mut scope,
+                            deno_core::anyhow::Error::from(arg0_err),
+                        );
                         return 1;
                     }
                 };

--- a/ops/op2/test_cases/sync/from_v8.out
+++ b/ops/op2/test_cases/sync/from_v8.out
@@ -44,7 +44,7 @@ pub const fn op_from_v8_arg() -> ::deno_core::_ops::OpDecl {
                 let arg0 = match <Foo as deno_core::FromV8>::from_v8(&mut scope, arg0) {
                     Ok(t) => t,
                     Err(arg0_err) => {
-                        deno_core::_ops::throw_error2(&mut scope, arg0_err);
+                        deno_core::_ops::throw_error_anyhow(&mut scope, arg0_err);
                         return 1;
                     }
                 };

--- a/ops/op2/test_cases/sync/from_v8.out
+++ b/ops/op2/test_cases/sync/from_v8.out
@@ -44,10 +44,7 @@ pub const fn op_from_v8_arg() -> ::deno_core::_ops::OpDecl {
                 let arg0 = match <Foo as deno_core::FromV8>::from_v8(&mut scope, arg0) {
                     Ok(t) => t,
                     Err(arg0_err) => {
-                        deno_core::_ops::throw_error2(
-                            &mut scope,
-                            deno_core::anyhow::Error::from(arg0_err),
-                        );
+                        deno_core::_ops::throw_error2(&mut scope, arg0_err);
                         return 1;
                     }
                 };

--- a/ops/op2/test_cases/sync/nofast.out
+++ b/ops/op2/test_cases/sync/nofast.out
@@ -41,15 +41,13 @@ const fn op_nofast() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
+                    deno_core::_ops::throw_error1(&info, "expected u32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
+                    deno_core::_ops::throw_error1(&info, "expected u32");
                     return 1;
                 };
                 let arg1 = arg1 as _;

--- a/ops/op2/test_cases/sync/nofast.out
+++ b/ops/op2/test_cases/sync/nofast.out
@@ -42,28 +42,14 @@ const fn op_nofast() -> ::deno_core::_ops::OpDecl {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected u32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected u32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected u32");
                     return 1;
                 };
                 let arg1 = arg1 as _;

--- a/ops/op2/test_cases/sync/nofast.out
+++ b/ops/op2/test_cases/sync/nofast.out
@@ -41,13 +41,13 @@ const fn op_nofast() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected u32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected u32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_u32_option(&arg1) else {
-                    deno_core::_ops::throw_error1(&info, "expected u32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected u32");
                     return 1;
                 };
                 let arg1 = arg1 as _;

--- a/ops/op2/test_cases/sync/object_wrap.out
+++ b/ops/op2/test_cases/sync/object_wrap.out
@@ -63,7 +63,10 @@ impl Foo {
                         None
                     } else {
                         let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                            deno_core::_ops::throw_error1(&info, "expected u32");
+                            deno_core::_ops::throw_error_one_byte_info(
+                                &info,
+                                "expected u32",
+                            );
                             return 1;
                         };
                         let arg0 = arg0 as _;
@@ -178,7 +181,7 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    deno_core::_ops::throw_error1(&info, "expected Foo");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;
@@ -277,14 +280,17 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    deno_core::_ops::throw_error1(&info, "expected Foo");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;
                 let result = {
                     let arg0 = args.get(0usize as i32);
                     let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                        deno_core::_ops::throw_error1(&info, "expected u32");
+                        deno_core::_ops::throw_error_one_byte_info(
+                            &info,
+                            "expected u32",
+                        );
                         return 1;
                     };
                     let arg0 = arg0 as _;
@@ -402,14 +408,17 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    deno_core::_ops::throw_error1(&info, "expected Foo");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;
                 let result = {
                     let arg0 = args.get(0usize as i32);
                     let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                        deno_core::_ops::throw_error1(&info, "expected u32");
+                        deno_core::_ops::throw_error_one_byte_info(
+                            &info,
+                            "expected u32",
+                        );
                         return 1;
                     };
                     let arg0 = arg0 as _;
@@ -566,7 +575,10 @@ impl Foo {
                                 &*fast_api_callback_options,
                             )
                         };
-                        deno_core::_ops::throw_error3(&mut scope, "expected Foo");
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "expected Foo",
+                        );
                         return unsafe { std::mem::zeroed() };
                     }
                 };
@@ -591,7 +603,7 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    deno_core::_ops::throw_error1(&info, "expected Foo");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;
@@ -691,7 +703,7 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    deno_core::_ops::throw_error1(&info, "expected Foo");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;
@@ -794,7 +806,7 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    deno_core::_ops::throw_error1(&info, "expected Foo");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;
@@ -980,7 +992,7 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    deno_core::_ops::throw_error1(&info, "expected Foo");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;

--- a/ops/op2/test_cases/sync/object_wrap.out
+++ b/ops/op2/test_cases/sync/object_wrap.out
@@ -66,17 +66,7 @@ impl Foo {
                             let mut scope = unsafe {
                                 deno_core::v8::CallbackScope::new(info)
                             };
-                            let msg = deno_core::v8::String::new_from_one_byte(
-                                    &mut scope,
-                                    "expected u32".as_bytes(),
-                                    deno_core::v8::NewStringType::Normal,
-                                )
-                                .unwrap();
-                            let exc = deno_core::v8::Exception::type_error(
-                                &mut scope,
-                                msg,
-                            );
-                            scope.throw_exception(exc);
+                            deno_core::_ops::throw_error1(&mut scope, "expected u32");
                             return 1;
                         };
                         let arg0 = arg0 as _;
@@ -191,14 +181,7 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected Foo".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;
@@ -297,14 +280,7 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected Foo".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;
@@ -314,14 +290,7 @@ impl Foo {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                "expected u32".as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, "expected u32");
                         return 1;
                     };
                     let arg0 = arg0 as _;
@@ -423,10 +392,8 @@ impl Foo {
                 if args.length() < 1u8 as i32 {
                     let msg = format!(
                         "{}: {} {} required, but only {} present",
-                        "Failed to execute 'call' on 'Foo'",
-                        1u8,
-                        "argument",
-                        args.length(),
+                        "Failed to execute 'call' on 'Foo'", 1u8, "argument", args
+                        .length()
                     );
                     let msg = deno_core::v8::String::new(&mut scope, &msg).unwrap();
                     let exception = deno_core::v8::Exception::type_error(
@@ -439,14 +406,7 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected Foo".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;
@@ -456,14 +416,7 @@ impl Foo {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                "expected u32".as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, "expected u32");
                         return 1;
                     };
                     let arg0 = arg0 as _;
@@ -652,14 +605,7 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected Foo".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;
@@ -759,14 +705,7 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected Foo".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;
@@ -869,14 +808,7 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected Foo".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;
@@ -1062,14 +994,7 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected Foo".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;

--- a/ops/op2/test_cases/sync/object_wrap.out
+++ b/ops/op2/test_cases/sync/object_wrap.out
@@ -63,10 +63,7 @@ impl Foo {
                         None
                     } else {
                         let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                            let mut scope = unsafe {
-                                deno_core::v8::CallbackScope::new(info)
-                            };
-                            deno_core::_ops::throw_error1(&mut scope, "expected u32");
+                            deno_core::_ops::throw_error1(&info, "expected u32");
                             return 1;
                         };
                         let arg0 = arg0 as _;
@@ -181,7 +178,7 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    deno_core::_ops::throw_error1(&mut scope, "expected Foo");
+                    deno_core::_ops::throw_error1(&info, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;
@@ -280,17 +277,14 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    deno_core::_ops::throw_error1(&mut scope, "expected Foo");
+                    deno_core::_ops::throw_error1(&info, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;
                 let result = {
                     let arg0 = args.get(0usize as i32);
                     let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, "expected u32");
+                        deno_core::_ops::throw_error1(&info, "expected u32");
                         return 1;
                     };
                     let arg0 = arg0 as _;
@@ -408,17 +402,14 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    deno_core::_ops::throw_error1(&mut scope, "expected Foo");
+                    deno_core::_ops::throw_error1(&info, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;
                 let result = {
                     let arg0 = args.get(0usize as i32);
                     let Some(arg0) = deno_core::_ops::to_u32_option(&arg0) else {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, "expected u32");
+                        deno_core::_ops::throw_error1(&info, "expected u32");
                         return 1;
                     };
                     let arg0 = arg0 as _;
@@ -575,7 +566,7 @@ impl Foo {
                                 &*fast_api_callback_options,
                             )
                         };
-                        deno_core::_ops::throw_error1(&mut scope, "expected Foo");
+                        deno_core::_ops::throw_error3(&mut scope, "expected Foo");
                         return unsafe { std::mem::zeroed() };
                     }
                 };
@@ -600,7 +591,7 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    deno_core::_ops::throw_error1(&mut scope, "expected Foo");
+                    deno_core::_ops::throw_error1(&info, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;
@@ -700,7 +691,7 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    deno_core::_ops::throw_error1(&mut scope, "expected Foo");
+                    deno_core::_ops::throw_error1(&info, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;
@@ -803,7 +794,7 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    deno_core::_ops::throw_error1(&mut scope, "expected Foo");
+                    deno_core::_ops::throw_error1(&info, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;
@@ -989,7 +980,7 @@ impl Foo {
                 let Some(self_) = deno_core::_ops::try_unwrap_cppgc_object::<
                     Foo,
                 >(&mut scope, args.this().into()) else {
-                    deno_core::_ops::throw_error1(&mut scope, "expected Foo");
+                    deno_core::_ops::throw_error1(&info, "expected Foo");
                     return 1;
                 };
                 let self_ = &*self_;

--- a/ops/op2/test_cases/sync/object_wrap.out
+++ b/ops/op2/test_cases/sync/object_wrap.out
@@ -392,8 +392,10 @@ impl Foo {
                 if args.length() < 1u8 as i32 {
                     let msg = format!(
                         "{}: {} {} required, but only {} present",
-                        "Failed to execute 'call' on 'Foo'", 1u8, "argument", args
-                        .length()
+                        "Failed to execute 'call' on 'Foo'",
+                        1u8,
+                        "argument",
+                        args.length(),
                     );
                     let msg = deno_core::v8::String::new(&mut scope, &msg).unwrap();
                     let exception = deno_core::v8::Exception::type_error(

--- a/ops/op2/test_cases/sync/object_wrap.out
+++ b/ops/op2/test_cases/sync/object_wrap.out
@@ -573,7 +573,7 @@ impl Foo {
                                 &*fast_api_callback_options,
                             )
                         };
-                        crate::_ops::throw_error1(&mut scope, "expected Foo");
+                        deno_core::_ops::throw_error1(&mut scope, "expected Foo");
                         return unsafe { std::mem::zeroed() };
                     }
                 };

--- a/ops/op2/test_cases/sync/object_wrap.out
+++ b/ops/op2/test_cases/sync/object_wrap.out
@@ -573,14 +573,7 @@ impl Foo {
                                 &*fast_api_callback_options,
                             )
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                "expected Foo".as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        crate::_ops::throw_error1(&mut scope, "expected Foo");
                         return unsafe { std::mem::zeroed() };
                     }
                 };

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -394,14 +394,7 @@ const fn op_state_and_v8() -> ::deno_core::_ops::OpDecl {
                     deno_core::v8::Function,
                 >(arg1) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected Function".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected Function");
                     return 1;
                 };
                 let arg1 = deno_core::v8::Global::new(&mut scope, arg1);
@@ -612,14 +605,7 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
                     deno_core::v8::Function,
                 >(arg1) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected Function".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected Function");
                     return 1;
                 };
                 let arg1 = arg1;

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -393,7 +393,10 @@ const fn op_state_and_v8() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::Function,
                 >(arg1) else {
-                    deno_core::_ops::throw_error1(&info, "expected Function");
+                    deno_core::_ops::throw_error_one_byte_info(
+                        &info,
+                        "expected Function",
+                    );
                     return 1;
                 };
                 let arg1 = deno_core::v8::Global::new(&mut scope, arg1);
@@ -564,7 +567,10 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        deno_core::_ops::throw_error3(&mut scope, "expected Function");
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "expected Function",
+                        );
                         return unsafe { std::mem::zeroed() };
                     }
                 };
@@ -596,7 +602,10 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::Function,
                 >(arg1) else {
-                    deno_core::_ops::throw_error1(&info, "expected Function");
+                    deno_core::_ops::throw_error_one_byte_info(
+                        &info,
+                        "expected Function",
+                    );
                     return 1;
                 };
                 let arg1 = arg1;

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -393,8 +393,7 @@ const fn op_state_and_v8() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::Function,
                 >(arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected Function");
+                    deno_core::_ops::throw_error1(&info, "expected Function");
                     return 1;
                 };
                 let arg1 = deno_core::v8::Global::new(&mut scope, arg1);
@@ -565,7 +564,7 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        deno_core::_ops::throw_error1(&mut scope, "expected Function");
+                        deno_core::_ops::throw_error3(&mut scope, "expected Function");
                         return unsafe { std::mem::zeroed() };
                     }
                 };
@@ -597,8 +596,7 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::Function,
                 >(arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected Function");
+                    deno_core::_ops::throw_error1(&info, "expected Function");
                     return 1;
                 };
                 let arg1 = arg1;

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -565,14 +565,7 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                "expected Function".as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        crate::_ops::throw_error1(&mut scope, "expected Function");
                         return unsafe { std::mem::zeroed() };
                     }
                 };

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -565,7 +565,7 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        crate::_ops::throw_error1(&mut scope, "expected Function");
+                        deno_core::_ops::throw_error1(&mut scope, "expected Function");
                         return unsafe { std::mem::zeroed() };
                     }
                 };

--- a/ops/op2/test_cases/sync/serde_v8.out
+++ b/ops/op2/test_cases/sync/serde_v8.out
@@ -44,10 +44,7 @@ pub const fn op_serde_v8() -> ::deno_core::_ops::OpDecl {
                 let arg0 = match deno_core::_ops::serde_v8_to_rust(&mut scope, arg0) {
                     Ok(t) => t,
                     Err(arg0_err) => {
-                        deno_core::_ops::throw_error2(
-                            &mut scope,
-                            deno_core::anyhow::Error::from(arg0_err),
-                        );
+                        deno_core::_ops::throw_error2(&mut scope, arg0_err);
                         return 1;
                     }
                 };
@@ -62,10 +59,7 @@ pub const fn op_serde_v8() -> ::deno_core::_ops::OpDecl {
             ) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    deno_core::_ops::throw_error2(
-                        &mut scope,
-                        deno_core::anyhow::Error::from(rv_err),
-                    );
+                    deno_core::_ops::throw_error2(&mut scope, rv_err);
                     return 1;
                 }
             };

--- a/ops/op2/test_cases/sync/serde_v8.out
+++ b/ops/op2/test_cases/sync/serde_v8.out
@@ -44,7 +44,7 @@ pub const fn op_serde_v8() -> ::deno_core::_ops::OpDecl {
                 let arg0 = match deno_core::_ops::serde_v8_to_rust(&mut scope, arg0) {
                     Ok(t) => t,
                     Err(arg0_err) => {
-                        deno_core::_ops::throw_error2(&mut scope, arg0_err);
+                        deno_core::_ops::throw_error_anyhow(&mut scope, arg0_err);
                         return 1;
                     }
                 };
@@ -59,7 +59,7 @@ pub const fn op_serde_v8() -> ::deno_core::_ops::OpDecl {
             ) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    deno_core::_ops::throw_error2(&mut scope, rv_err);
+                    deno_core::_ops::throw_error_anyhow(&mut scope, rv_err);
                     return 1;
                 }
             };

--- a/ops/op2/test_cases/sync/serde_v8.out
+++ b/ops/op2/test_cases/sync/serde_v8.out
@@ -44,13 +44,10 @@ pub const fn op_serde_v8() -> ::deno_core::_ops::OpDecl {
                 let arg0 = match deno_core::_ops::serde_v8_to_rust(&mut scope, arg0) {
                     Ok(t) => t,
                     Err(arg0_err) => {
-                        let msg = deno_core::v8::String::new(
-                                &mut scope,
-                                &format!("{}", deno_core::anyhow::Error::from(arg0_err)),
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error2(
+                            &mut scope,
+                            deno_core::anyhow::Error::from(arg0_err),
+                        );
                         return 1;
                     }
                 };
@@ -65,13 +62,10 @@ pub const fn op_serde_v8() -> ::deno_core::_ops::OpDecl {
             ) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    let msg = deno_core::v8::String::new(
-                            &mut scope,
-                            &format!("{}", deno_core::anyhow::Error::from(rv_err)),
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error2(
+                        &mut scope,
+                        deno_core::anyhow::Error::from(rv_err),
+                    );
                     return 1;
                 }
             };

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -168,25 +168,25 @@ const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected i32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected i32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_i32_option(&arg1) else {
-                    deno_core::_ops::throw_error1(&info, "expected i32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected i32");
                     return 1;
                 };
                 let arg1 = arg1 as _;
                 let arg2 = args.get(2usize as i32);
                 let Some(arg2) = deno_core::_ops::to_i32_option(&arg2) else {
-                    deno_core::_ops::throw_error1(&info, "expected i32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected i32");
                     return 1;
                 };
                 let arg2 = arg2 as _;
                 let arg3 = args.get(3usize as i32);
                 let Some(arg3) = deno_core::_ops::to_i32_option(&arg3) else {
-                    deno_core::_ops::throw_error1(&info, "expected i32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected i32");
                     return 1;
                 };
                 let arg3 = arg3 as _;
@@ -415,25 +415,25 @@ const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected i32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected i32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_i32_option(&arg1) else {
-                    deno_core::_ops::throw_error1(&info, "expected i32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected i32");
                     return 1;
                 };
                 let arg1 = arg1 as _;
                 let arg2 = args.get(2usize as i32);
                 let Some(arg2) = deno_core::_ops::to_i32_option(&arg2) else {
-                    deno_core::_ops::throw_error1(&info, "expected i32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected i32");
                     return 1;
                 };
                 let arg2 = arg2 as _;
                 let arg3 = args.get(3usize as i32);
                 let Some(arg3) = deno_core::_ops::to_i32_option(&arg3) else {
-                    deno_core::_ops::throw_error1(&info, "expected i32");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected i32");
                     return 1;
                 };
                 let arg3 = arg3 as _;
@@ -538,7 +538,10 @@ const fn op_smi_option() -> ::deno_core::_ops::OpDecl {
                     None
                 } else {
                     let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                        deno_core::_ops::throw_error1(&info, "expected i32");
+                        deno_core::_ops::throw_error_one_byte_info(
+                            &info,
+                            "expected i32",
+                        );
                         return 1;
                     };
                     let arg0 = arg0 as _;

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -168,29 +168,25 @@ const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
+                    deno_core::_ops::throw_error1(&info, "expected i32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_i32_option(&arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
+                    deno_core::_ops::throw_error1(&info, "expected i32");
                     return 1;
                 };
                 let arg1 = arg1 as _;
                 let arg2 = args.get(2usize as i32);
                 let Some(arg2) = deno_core::_ops::to_i32_option(&arg2) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
+                    deno_core::_ops::throw_error1(&info, "expected i32");
                     return 1;
                 };
                 let arg2 = arg2 as _;
                 let arg3 = args.get(3usize as i32);
                 let Some(arg3) = deno_core::_ops::to_i32_option(&arg3) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
+                    deno_core::_ops::throw_error1(&info, "expected i32");
                     return 1;
                 };
                 let arg3 = arg3 as _;
@@ -419,29 +415,25 @@ const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
             let result = {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
+                    deno_core::_ops::throw_error1(&info, "expected i32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_i32_option(&arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
+                    deno_core::_ops::throw_error1(&info, "expected i32");
                     return 1;
                 };
                 let arg1 = arg1 as _;
                 let arg2 = args.get(2usize as i32);
                 let Some(arg2) = deno_core::_ops::to_i32_option(&arg2) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
+                    deno_core::_ops::throw_error1(&info, "expected i32");
                     return 1;
                 };
                 let arg2 = arg2 as _;
                 let arg3 = args.get(3usize as i32);
                 let Some(arg3) = deno_core::_ops::to_i32_option(&arg3) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
+                    deno_core::_ops::throw_error1(&info, "expected i32");
                     return 1;
                 };
                 let arg3 = arg3 as _;
@@ -546,10 +538,7 @@ const fn op_smi_option() -> ::deno_core::_ops::OpDecl {
                     None
                 } else {
                     let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, "expected i32");
+                        deno_core::_ops::throw_error1(&info, "expected i32");
                         return 1;
                     };
                     let arg0 = arg0 as _;

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -169,56 +169,28 @@ const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected i32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_i32_option(&arg1) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected i32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
                     return 1;
                 };
                 let arg1 = arg1 as _;
                 let arg2 = args.get(2usize as i32);
                 let Some(arg2) = deno_core::_ops::to_i32_option(&arg2) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected i32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
                     return 1;
                 };
                 let arg2 = arg2 as _;
                 let arg3 = args.get(3usize as i32);
                 let Some(arg3) = deno_core::_ops::to_i32_option(&arg3) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected i32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
                     return 1;
                 };
                 let arg3 = arg3 as _;
@@ -448,56 +420,28 @@ const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
                 let arg0 = args.get(0usize as i32);
                 let Some(arg0) = deno_core::_ops::to_i32_option(&arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected i32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
                     return 1;
                 };
                 let arg0 = arg0 as _;
                 let arg1 = args.get(1usize as i32);
                 let Some(arg1) = deno_core::_ops::to_i32_option(&arg1) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected i32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
                     return 1;
                 };
                 let arg1 = arg1 as _;
                 let arg2 = args.get(2usize as i32);
                 let Some(arg2) = deno_core::_ops::to_i32_option(&arg2) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected i32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
                     return 1;
                 };
                 let arg2 = arg2 as _;
                 let arg3 = args.get(3usize as i32);
                 let Some(arg3) = deno_core::_ops::to_i32_option(&arg3) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected i32".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected i32");
                     return 1;
                 };
                 let arg3 = arg3 as _;
@@ -605,14 +549,7 @@ const fn op_smi_option() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                "expected i32".as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, "expected i32");
                         return 1;
                     };
                     let arg0 = arg0 as _;

--- a/ops/op2/test_cases/sync/string_onebyte.out
+++ b/ops/op2/test_cases/sync/string_onebyte.out
@@ -127,10 +127,7 @@ const fn op_string_onebyte() -> ::deno_core::_ops::OpDecl {
                 let arg0 = match deno_core::_ops::to_cow_one_byte(&mut scope, &arg0) {
                     Ok(arg0) => arg0,
                     Err(arg0) => {
-                        let mut scope = unsafe {
-                            deno_core::v8::CallbackScope::new(info)
-                        };
-                        deno_core::_ops::throw_error1(&mut scope, arg0);
+                        deno_core::_ops::throw_error1(&info, arg0);
                         return 1;
                     }
                 };

--- a/ops/op2/test_cases/sync/string_onebyte.out
+++ b/ops/op2/test_cases/sync/string_onebyte.out
@@ -127,7 +127,7 @@ const fn op_string_onebyte() -> ::deno_core::_ops::OpDecl {
                 let arg0 = match deno_core::_ops::to_cow_one_byte(&mut scope, &arg0) {
                     Ok(arg0) => arg0,
                     Err(arg0) => {
-                        deno_core::_ops::throw_error1(&info, arg0);
+                        deno_core::_ops::throw_error_one_byte_info(&info, arg0);
                         return 1;
                     }
                 };

--- a/ops/op2/test_cases/sync/string_onebyte.out
+++ b/ops/op2/test_cases/sync/string_onebyte.out
@@ -130,14 +130,7 @@ const fn op_string_onebyte() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                arg0.as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error1(&mut scope, arg0);
                         return 1;
                     }
                 };

--- a/ops/op2/test_cases/sync/string_option_return.out
+++ b/ops/op2/test_cases/sync/string_option_return.out
@@ -51,10 +51,7 @@ pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    deno_core::_ops::throw_error2(
-                        &mut scope,
-                        deno_core::anyhow::Error::from(rv_err),
-                    );
+                    deno_core::_ops::throw_error2(&mut scope, rv_err);
                     return 1;
                 }
             };

--- a/ops/op2/test_cases/sync/string_option_return.out
+++ b/ops/op2/test_cases/sync/string_option_return.out
@@ -51,7 +51,7 @@ pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    deno_core::_ops::throw_error2(&mut scope, rv_err);
+                    deno_core::_ops::throw_error_anyhow(&mut scope, rv_err);
                     return 1;
                 }
             };

--- a/ops/op2/test_cases/sync/string_option_return.out
+++ b/ops/op2/test_cases/sync/string_option_return.out
@@ -51,13 +51,10 @@ pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    let msg = deno_core::v8::String::new(
-                            &mut scope,
-                            &format!("{}", deno_core::anyhow::Error::from(rv_err)),
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error2(
+                        &mut scope,
+                        deno_core::anyhow::Error::from(rv_err),
+                    );
                     return 1;
                 }
             };

--- a/ops/op2/test_cases/sync/string_return.out
+++ b/ops/op2/test_cases/sync/string_return.out
@@ -40,10 +40,7 @@ pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    deno_core::_ops::throw_error2(
-                        &mut scope,
-                        deno_core::anyhow::Error::from(rv_err),
-                    );
+                    deno_core::_ops::throw_error2(&mut scope, rv_err);
                     return 1;
                 }
             };
@@ -135,10 +132,7 @@ pub const fn op_string_return_ref() -> ::deno_core::_ops::OpDecl {
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    deno_core::_ops::throw_error2(
-                        &mut scope,
-                        deno_core::anyhow::Error::from(rv_err),
-                    );
+                    deno_core::_ops::throw_error2(&mut scope, rv_err);
                     return 1;
                 }
             };
@@ -230,10 +224,7 @@ pub const fn op_string_return_cow() -> ::deno_core::_ops::OpDecl {
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    deno_core::_ops::throw_error2(
-                        &mut scope,
-                        deno_core::anyhow::Error::from(rv_err),
-                    );
+                    deno_core::_ops::throw_error2(&mut scope, rv_err);
                     return 1;
                 }
             };

--- a/ops/op2/test_cases/sync/string_return.out
+++ b/ops/op2/test_cases/sync/string_return.out
@@ -40,7 +40,7 @@ pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    deno_core::_ops::throw_error2(&mut scope, rv_err);
+                    deno_core::_ops::throw_error_anyhow(&mut scope, rv_err);
                     return 1;
                 }
             };
@@ -132,7 +132,7 @@ pub const fn op_string_return_ref() -> ::deno_core::_ops::OpDecl {
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    deno_core::_ops::throw_error2(&mut scope, rv_err);
+                    deno_core::_ops::throw_error_anyhow(&mut scope, rv_err);
                     return 1;
                 }
             };
@@ -224,7 +224,7 @@ pub const fn op_string_return_cow() -> ::deno_core::_ops::OpDecl {
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    deno_core::_ops::throw_error2(&mut scope, rv_err);
+                    deno_core::_ops::throw_error_anyhow(&mut scope, rv_err);
                     return 1;
                 }
             };

--- a/ops/op2/test_cases/sync/string_return.out
+++ b/ops/op2/test_cases/sync/string_return.out
@@ -40,13 +40,10 @@ pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    let msg = deno_core::v8::String::new(
-                            &mut scope,
-                            &format!("{}", deno_core::anyhow::Error::from(rv_err)),
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error2(
+                        &mut scope,
+                        deno_core::anyhow::Error::from(rv_err),
+                    );
                     return 1;
                 }
             };
@@ -138,13 +135,10 @@ pub const fn op_string_return_ref() -> ::deno_core::_ops::OpDecl {
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    let msg = deno_core::v8::String::new(
-                            &mut scope,
-                            &format!("{}", deno_core::anyhow::Error::from(rv_err)),
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error2(
+                        &mut scope,
+                        deno_core::anyhow::Error::from(rv_err),
+                    );
                     return 1;
                 }
             };
@@ -236,13 +230,10 @@ pub const fn op_string_return_cow() -> ::deno_core::_ops::OpDecl {
             match deno_core::_ops::RustToV8Fallible::to_v8_fallible(result, &mut scope) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    let msg = deno_core::v8::String::new(
-                            &mut scope,
-                            &format!("{}", deno_core::anyhow::Error::from(rv_err)),
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error2(
+                        &mut scope,
+                        deno_core::anyhow::Error::from(rv_err),
+                    );
                     return 1;
                 }
             };

--- a/ops/op2/test_cases/sync/to_v8.out
+++ b/ops/op2/test_cases/sync/to_v8.out
@@ -46,7 +46,7 @@ pub const fn op_to_v8_return() -> ::deno_core::_ops::OpDecl {
             ) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    deno_core::_ops::throw_error2(&mut scope, rv_err);
+                    deno_core::_ops::throw_error_anyhow(&mut scope, rv_err);
                     return 1;
                 }
             };

--- a/ops/op2/test_cases/sync/to_v8.out
+++ b/ops/op2/test_cases/sync/to_v8.out
@@ -46,13 +46,10 @@ pub const fn op_to_v8_return() -> ::deno_core::_ops::OpDecl {
             ) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    let msg = deno_core::v8::String::new(
-                            &mut scope,
-                            &format!("{}", deno_core::anyhow::Error::from(rv_err)),
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error2(
+                        &mut scope,
+                        deno_core::anyhow::Error::from(rv_err),
+                    );
                     return 1;
                 }
             };

--- a/ops/op2/test_cases/sync/to_v8.out
+++ b/ops/op2/test_cases/sync/to_v8.out
@@ -46,10 +46,7 @@ pub const fn op_to_v8_return() -> ::deno_core::_ops::OpDecl {
             ) {
                 Ok(v) => rv.set(v),
                 Err(rv_err) => {
-                    deno_core::_ops::throw_error2(
-                        &mut scope,
-                        deno_core::anyhow::Error::from(rv_err),
-                    );
+                    deno_core::_ops::throw_error2(&mut scope, rv_err);
                     return 1;
                 }
             };

--- a/ops/op2/test_cases/sync/v8_global.out
+++ b/ops/op2/test_cases/sync/v8_global.out
@@ -44,7 +44,7 @@ pub const fn op_global() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::String,
                 >(arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected String");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected String");
                     return 1;
                 };
                 let arg0 = deno_core::v8::Global::new(&mut scope, arg0);

--- a/ops/op2/test_cases/sync/v8_global.out
+++ b/ops/op2/test_cases/sync/v8_global.out
@@ -45,14 +45,7 @@ pub const fn op_global() -> ::deno_core::_ops::OpDecl {
                     deno_core::v8::String,
                 >(arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected String".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected String");
                     return 1;
                 };
                 let arg0 = deno_core::v8::Global::new(&mut scope, arg0);

--- a/ops/op2/test_cases/sync/v8_global.out
+++ b/ops/op2/test_cases/sync/v8_global.out
@@ -44,8 +44,7 @@ pub const fn op_global() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::String,
                 >(arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected String");
+                    deno_core::_ops::throw_error1(&info, "expected String");
                     return 1;
                 };
                 let arg0 = deno_core::v8::Global::new(&mut scope, arg0);

--- a/ops/op2/test_cases/sync/v8_handlescope.out
+++ b/ops/op2/test_cases/sync/v8_handlescope.out
@@ -44,14 +44,7 @@ const fn op_handlescope() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::String,
                 >(arg1) else {
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected String".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected String");
                     return 1;
                 };
                 let arg1 = arg1;

--- a/ops/op2/test_cases/sync/v8_handlescope.out
+++ b/ops/op2/test_cases/sync/v8_handlescope.out
@@ -44,7 +44,7 @@ const fn op_handlescope() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::String,
                 >(arg1) else {
-                    deno_core::_ops::throw_error1(&mut scope, "expected String");
+                    deno_core::_ops::throw_error1(&info, "expected String");
                     return 1;
                 };
                 let arg1 = arg1;

--- a/ops/op2/test_cases/sync/v8_handlescope.out
+++ b/ops/op2/test_cases/sync/v8_handlescope.out
@@ -44,7 +44,7 @@ const fn op_handlescope() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::String,
                 >(arg1) else {
-                    deno_core::_ops::throw_error1(&info, "expected String");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected String");
                     return 1;
                 };
                 let arg1 = arg1;

--- a/ops/op2/test_cases/sync/v8_lifetime.out
+++ b/ops/op2/test_cases/sync/v8_lifetime.out
@@ -43,7 +43,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::String,
                 >(arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected String");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected String");
                     return 1;
                 };
                 let arg0 = arg0;

--- a/ops/op2/test_cases/sync/v8_lifetime.out
+++ b/ops/op2/test_cases/sync/v8_lifetime.out
@@ -43,8 +43,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::String,
                 >(arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected String");
+                    deno_core::_ops::throw_error1(&info, "expected String");
                     return 1;
                 };
                 let arg0 = arg0;

--- a/ops/op2/test_cases/sync/v8_lifetime.out
+++ b/ops/op2/test_cases/sync/v8_lifetime.out
@@ -44,14 +44,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                     deno_core::v8::String,
                 >(arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected String".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected String");
                     return 1;
                 };
                 let arg0 = arg0;

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -114,14 +114,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                "expected String".as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        crate::_ops::throw_error1(&mut scope, "expected String");
                         return unsafe { std::mem::zeroed() };
                     }
                 };
@@ -138,14 +131,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        let msg = deno_core::v8::String::new_from_one_byte(
-                                &mut scope,
-                                "expected String".as_bytes(),
-                                deno_core::v8::NewStringType::Normal,
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        crate::_ops::throw_error1(&mut scope, "expected String");
                         return unsafe { std::mem::zeroed() };
                     }
                 };

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -114,7 +114,10 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        deno_core::_ops::throw_error3(&mut scope, "expected String");
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "expected String",
+                        );
                         return unsafe { std::mem::zeroed() };
                     }
                 };
@@ -131,7 +134,10 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        deno_core::_ops::throw_error3(&mut scope, "expected String");
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "expected String",
+                        );
                         return unsafe { std::mem::zeroed() };
                     }
                 };
@@ -159,7 +165,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg0) = deno_core::_ops::v8_try_convert_option::<
                     deno_core::v8::String,
                 >(arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected String");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected String");
                     return 1;
                 };
                 let arg0 = match &arg0 {
@@ -170,7 +176,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg1) = deno_core::_ops::v8_try_convert_option::<
                     deno_core::v8::String,
                 >(arg1) else {
-                    deno_core::_ops::throw_error1(&info, "expected String");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected String");
                     return 1;
                 };
                 let arg1 = match &arg1 {

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -114,7 +114,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        deno_core::_ops::throw_error1(&mut scope, "expected String");
+                        deno_core::_ops::throw_error3(&mut scope, "expected String");
                         return unsafe { std::mem::zeroed() };
                     }
                 };
@@ -131,7 +131,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        deno_core::_ops::throw_error1(&mut scope, "expected String");
+                        deno_core::_ops::throw_error3(&mut scope, "expected String");
                         return unsafe { std::mem::zeroed() };
                     }
                 };
@@ -159,8 +159,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg0) = deno_core::_ops::v8_try_convert_option::<
                     deno_core::v8::String,
                 >(arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected String");
+                    deno_core::_ops::throw_error1(&info, "expected String");
                     return 1;
                 };
                 let arg0 = match &arg0 {
@@ -171,8 +170,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg1) = deno_core::_ops::v8_try_convert_option::<
                     deno_core::v8::String,
                 >(arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected String");
+                    deno_core::_ops::throw_error1(&info, "expected String");
                     return 1;
                 };
                 let arg1 = match &arg1 {

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -114,7 +114,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        crate::_ops::throw_error1(&mut scope, "expected String");
+                        deno_core::_ops::throw_error1(&mut scope, "expected String");
                         return unsafe { std::mem::zeroed() };
                     }
                 };
@@ -131,7 +131,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                                 &*fast_api_callback_options,
                             )
                         };
-                        crate::_ops::throw_error1(&mut scope, "expected String");
+                        deno_core::_ops::throw_error1(&mut scope, "expected String");
                         return unsafe { std::mem::zeroed() };
                     }
                 };

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -174,14 +174,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                     deno_core::v8::String,
                 >(arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected String".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected String");
                     return 1;
                 };
                 let arg0 = match &arg0 {
@@ -193,14 +186,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                     deno_core::v8::String,
                 >(arg1) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected String".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected String");
                     return 1;
                 };
                 let arg1 = match &arg1 {

--- a/ops/op2/test_cases/sync/v8_string.out
+++ b/ops/op2/test_cases/sync/v8_string.out
@@ -43,8 +43,7 @@ const fn op_v8_string() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::String,
                 >(arg0) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected String");
+                    deno_core::_ops::throw_error1(&info, "expected String");
                     return 1;
                 };
                 let arg0 = &arg0;
@@ -52,8 +51,7 @@ const fn op_v8_string() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::String,
                 >(arg1) else {
-                    let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    deno_core::_ops::throw_error1(&mut scope, "expected String");
+                    deno_core::_ops::throw_error1(&info, "expected String");
                     return 1;
                 };
                 let arg1 = arg1;

--- a/ops/op2/test_cases/sync/v8_string.out
+++ b/ops/op2/test_cases/sync/v8_string.out
@@ -44,14 +44,7 @@ const fn op_v8_string() -> ::deno_core::_ops::OpDecl {
                     deno_core::v8::String,
                 >(arg0) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected String".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected String");
                     return 1;
                 };
                 let arg0 = &arg0;
@@ -60,14 +53,7 @@ const fn op_v8_string() -> ::deno_core::_ops::OpDecl {
                     deno_core::v8::String,
                 >(arg1) else {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let msg = deno_core::v8::String::new_from_one_byte(
-                            &mut scope,
-                            "expected String".as_bytes(),
-                            deno_core::v8::NewStringType::Normal,
-                        )
-                        .unwrap();
-                    let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                    scope.throw_exception(exc);
+                    deno_core::_ops::throw_error1(&mut scope, "expected String");
                     return 1;
                 };
                 let arg1 = arg1;

--- a/ops/op2/test_cases/sync/v8_string.out
+++ b/ops/op2/test_cases/sync/v8_string.out
@@ -43,7 +43,7 @@ const fn op_v8_string() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg0) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::String,
                 >(arg0) else {
-                    deno_core::_ops::throw_error1(&info, "expected String");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected String");
                     return 1;
                 };
                 let arg0 = &arg0;
@@ -51,7 +51,7 @@ const fn op_v8_string() -> ::deno_core::_ops::OpDecl {
                 let Ok(mut arg1) = deno_core::_ops::v8_try_convert::<
                     deno_core::v8::String,
                 >(arg1) else {
-                    deno_core::_ops::throw_error1(&info, "expected String");
+                    deno_core::_ops::throw_error_one_byte_info(&info, "expected String");
                     return 1;
                 };
                 let arg1 = arg1;

--- a/ops/op2/test_cases/sync/webidl.out
+++ b/ops/op2/test_cases/sync/webidl.out
@@ -50,10 +50,7 @@ const fn op_webidl() -> ::deno_core::_ops::OpDecl {
                 ) {
                     Ok(t) => t,
                     Err(arg0_err) => {
-                        deno_core::_ops::throw_error2(
-                            &mut scope,
-                            deno_core::anyhow::Error::from(arg0_err),
-                        );
+                        deno_core::_ops::throw_error2(&mut scope, arg0_err);
                         return 1;
                     }
                 };
@@ -67,10 +64,7 @@ const fn op_webidl() -> ::deno_core::_ops::OpDecl {
                 ) {
                     Ok(t) => t,
                     Err(arg1_err) => {
-                        deno_core::_ops::throw_error2(
-                            &mut scope,
-                            deno_core::anyhow::Error::from(arg1_err),
-                        );
+                        deno_core::_ops::throw_error2(&mut scope, arg1_err);
                         return 1;
                     }
                 };

--- a/ops/op2/test_cases/sync/webidl.out
+++ b/ops/op2/test_cases/sync/webidl.out
@@ -50,7 +50,7 @@ const fn op_webidl() -> ::deno_core::_ops::OpDecl {
                 ) {
                     Ok(t) => t,
                     Err(arg0_err) => {
-                        deno_core::_ops::throw_error2(&mut scope, arg0_err);
+                        deno_core::_ops::throw_error_anyhow(&mut scope, arg0_err);
                         return 1;
                     }
                 };
@@ -64,7 +64,7 @@ const fn op_webidl() -> ::deno_core::_ops::OpDecl {
                 ) {
                     Ok(t) => t,
                     Err(arg1_err) => {
-                        deno_core::_ops::throw_error2(&mut scope, arg1_err);
+                        deno_core::_ops::throw_error_anyhow(&mut scope, arg1_err);
                         return 1;
                     }
                 };

--- a/ops/op2/test_cases/sync/webidl.out
+++ b/ops/op2/test_cases/sync/webidl.out
@@ -50,13 +50,10 @@ const fn op_webidl() -> ::deno_core::_ops::OpDecl {
                 ) {
                     Ok(t) => t,
                     Err(arg0_err) => {
-                        let msg = deno_core::v8::String::new(
-                                &mut scope,
-                                &format!("{}", deno_core::anyhow::Error::from(arg0_err)),
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error2(
+                            &mut scope,
+                            deno_core::anyhow::Error::from(arg0_err),
+                        );
                         return 1;
                     }
                 };
@@ -70,13 +67,10 @@ const fn op_webidl() -> ::deno_core::_ops::OpDecl {
                 ) {
                     Ok(t) => t,
                     Err(arg1_err) => {
-                        let msg = deno_core::v8::String::new(
-                                &mut scope,
-                                &format!("{}", deno_core::anyhow::Error::from(arg1_err)),
-                            )
-                            .unwrap();
-                        let exc = deno_core::v8::Exception::type_error(&mut scope, msg);
-                        scope.throw_exception(exc);
+                        deno_core::_ops::throw_error2(
+                            &mut scope,
+                            deno_core::anyhow::Error::from(arg1_err),
+                        );
                         return 1;
                     }
                 };

--- a/ops/webidl/test_cases/dict.out
+++ b/ops/webidl/test_cases/dict.out
@@ -15,11 +15,16 @@ impl<'a> ::deno_core::webidl::WebIdlConverter<'a> for Dict {
             = "e", __v8_static_f = "f"
         }
         thread_local! {
-            static __v8_a_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
-            static __v8_b_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
-            static __v8_c_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
-            static __v8_e_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
-            static __v8_f_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
+            static __v8_a_eternal : ::deno_core::v8::Eternal < ::deno_core::v8::String >
+            = ::deno_core::v8::Eternal::empty(); static __v8_b_eternal :
+            ::deno_core::v8::Eternal < ::deno_core::v8::String > =
+            ::deno_core::v8::Eternal::empty(); static __v8_c_eternal :
+            ::deno_core::v8::Eternal < ::deno_core::v8::String > =
+            ::deno_core::v8::Eternal::empty(); static __v8_e_eternal :
+            ::deno_core::v8::Eternal < ::deno_core::v8::String > =
+            ::deno_core::v8::Eternal::empty(); static __v8_f_eternal :
+            ::deno_core::v8::Eternal < ::deno_core::v8::String > =
+            ::deno_core::v8::Eternal::empty();
         }
         let __obj: Option<::deno_core::v8::Local<::deno_core::v8::Object>> = if __value
             .is_undefined() || __value.is_null()

--- a/ops/webidl/test_cases/dict.out
+++ b/ops/webidl/test_cases/dict.out
@@ -15,16 +15,11 @@ impl<'a> ::deno_core::webidl::WebIdlConverter<'a> for Dict {
             = "e", __v8_static_f = "f"
         }
         thread_local! {
-            static __v8_a_eternal : ::deno_core::v8::Eternal < ::deno_core::v8::String >
-            = ::deno_core::v8::Eternal::empty(); static __v8_b_eternal :
-            ::deno_core::v8::Eternal < ::deno_core::v8::String > =
-            ::deno_core::v8::Eternal::empty(); static __v8_c_eternal :
-            ::deno_core::v8::Eternal < ::deno_core::v8::String > =
-            ::deno_core::v8::Eternal::empty(); static __v8_e_eternal :
-            ::deno_core::v8::Eternal < ::deno_core::v8::String > =
-            ::deno_core::v8::Eternal::empty(); static __v8_f_eternal :
-            ::deno_core::v8::Eternal < ::deno_core::v8::String > =
-            ::deno_core::v8::Eternal::empty();
+            static __v8_a_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
+            static __v8_b_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
+            static __v8_c_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
+            static __v8_e_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
+            static __v8_f_eternal: ::deno_core::v8::Eternal<::deno_core::v8::String> = ::deno_core::v8::Eternal::empty();
         }
         let __obj: Option<::deno_core::v8::Local<::deno_core::v8::Object>> = if __value
             .is_undefined() || __value.is_null()


### PR DESCRIPTION
deno release build is about 700kb smaller with this patch
```
110239496 this patch
110942920 main
```