### PR TITLE
fix: revert js_class_and_message_to_exception to just do TypeErrors

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -243,7 +243,11 @@ fn js_class_and_message_to_exception<'s>(
   message: &str,
 ) -> v8::Local<'s, v8::Value> {
   let message = v8::String::new(scope, message).unwrap();
-  /*match class {
+  /*
+  commented out since this was previously only handling type errors, but this
+  change is breaking CLI, so visiting on a later date
+
+  match class {
     TYPE_ERROR => v8::Exception::type_error(scope, message),
     RANGE_ERROR => v8::Exception::range_error(scope, message),
     REFERENCE_ERROR => v8::Exception::reference_error(scope, message),

--- a/core/error.rs
+++ b/core/error.rs
@@ -239,17 +239,18 @@ pub fn throw_js_error_class(
 
 fn js_class_and_message_to_exception<'s>(
   scope: &mut v8::HandleScope<'s>,
-  class: &str,
+  _class: &str,
   message: &str,
 ) -> v8::Local<'s, v8::Value> {
   let message = v8::String::new(scope, message).unwrap();
-  match class {
+  /*match class {
     TYPE_ERROR => v8::Exception::type_error(scope, message),
     RANGE_ERROR => v8::Exception::range_error(scope, message),
     REFERENCE_ERROR => v8::Exception::reference_error(scope, message),
     SYNTAX_ERROR => v8::Exception::syntax_error(scope, message),
     _ => v8::Exception::error(scope, message),
-  }
+  }*/
+  v8::Exception::type_error(scope, message)
 }
 
 pub fn to_v8_error<'a>(


### PR DESCRIPTION
This is the previous behaviour which was unexpected and we want to change this to actually throw the correct error, however this is breaking a few things in CLI so reverting this single change for now and will revisit at a later date