### PR TITLE
refactor: simplify async op error construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,7 @@ version = "0.2.0"
 dependencies = [
  "bytes",
  "deno_core",
+ "deno_error",
  "deno_ops",
  "pretty_assertions",
  "prettyplease",

--- a/core/00_infra.js
+++ b/core/00_infra.js
@@ -142,7 +142,7 @@
         // recreate the stacktrace and strip eventLoopTick() calls from stack trace
         ErrorCaptureStackTrace(res, eventLoopTick);
         throw res;
-      }
+      },
     );
     wrappedPromise[promiseIdSymbol] = promiseId;
     return wrappedPromise;

--- a/core/01_core.js
+++ b/core/01_core.js
@@ -161,10 +161,12 @@
   // responses of async ops.
   function eventLoopTick() {
     // First respond to all pending ops.
-    for (let i = 0; i < arguments.length - 3; i += 2) {
+    for (let i = 0; i < arguments.length - 3; i += 3) {
       const promiseId = arguments[i];
-      const res = arguments[i + 1];
-      __resolvePromise(promiseId, res);
+      const isOk = arguments[i + 1];
+      const res = arguments[i + 2];
+
+      __resolvePromise(promiseId, res, isOk);
     }
     // Drain nextTick queue if there's a tick scheduled.
     if (arguments[arguments.length - 1]) {

--- a/core/benches/ops/async.rs
+++ b/core/benches/ops/async.rs
@@ -97,11 +97,6 @@ pub async fn op_async_void_deferred() {}
 #[op2(async(deferred), nofast)]
 pub async fn op_async_void_deferred_nofast() {}
 
-#[op2(async)]
-pub async fn op_async_error() -> Result<(), JsErrorBox> {
-  Err(JsErrorBox::generic("foo"))
-}
-
 fn bench_op(
   b: &mut Bencher,
   count: usize,
@@ -241,16 +236,6 @@ fn bench_op_async_void_deferred_return(b: &mut Bencher) {
   );
 }
 
-fn bench_op_async_error(b: &mut Bencher) {
-  bench_op(
-    b,
-    BENCH_COUNT,
-    "op_async_error",
-    0,
-    "try { await op_async_error() } catch(e) {}",
-  );
-}
-
 macro_rules! bench_void {
   ($bench:ident, $op:ident) => {
     fn $bench(b: &mut Bencher) {
@@ -302,7 +287,6 @@ benchmark_group!(
   bench_op_async_void_deferred,
   bench_op_async_void_deferred_nofast,
   bench_op_async_void_deferred_return,
-  bench_op_async_error,
 );
 
 benchmark_main!(benches);

--- a/core/benches/ops/async.rs
+++ b/core/benches/ops/async.rs
@@ -18,6 +18,7 @@ deno_core::extension!(
     op_async_void_lazy_nofast,
     op_async_void_deferred,
     op_async_void_deferred_nofast,
+    op_async_error,
     op_async_void_deferred_return,
     op_async_yield,
     op_async_yield_lazy,
@@ -95,6 +96,11 @@ pub async fn op_async_void_deferred() {}
 
 #[op2(async(deferred), nofast)]
 pub async fn op_async_void_deferred_nofast() {}
+
+#[op2(async)]
+pub async fn op_async_error() -> Result<(), JsErrorBox> {
+  Err(JsErrorBox::generic("foo"))
+}
 
 fn bench_op(
   b: &mut Bencher,
@@ -235,6 +241,16 @@ fn bench_op_async_void_deferred_return(b: &mut Bencher) {
   );
 }
 
+fn bench_op_async_error(b: &mut Bencher) {
+  bench_op(
+    b,
+    BENCH_COUNT,
+    "op_async_error",
+    0,
+    "try { await op_async_error() } catch(e) {}",
+  );
+}
+
 macro_rules! bench_void {
   ($bench:ident, $op:ident) => {
     fn $bench(b: &mut Bencher) {
@@ -286,6 +302,7 @@ benchmark_group!(
   bench_op_async_void_deferred,
   bench_op_async_void_deferred_nofast,
   bench_op_async_void_deferred_return,
+  bench_op_async_error,
 );
 
 benchmark_main!(benches);

--- a/core/benches/ops/async.rs
+++ b/core/benches/ops/async.rs
@@ -18,7 +18,6 @@ deno_core::extension!(
     op_async_void_lazy_nofast,
     op_async_void_deferred,
     op_async_void_deferred_nofast,
-    op_async_error,
     op_async_void_deferred_return,
     op_async_yield,
     op_async_yield_lazy,

--- a/core/error.rs
+++ b/core/error.rs
@@ -1,8 +1,6 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 pub use super::modules::ModuleConcreteError;
-pub use super::runtime::op_driver::OpError;
-pub use super::runtime::op_driver::OpErrorWrapper;
 pub use crate::io::ResourceError;
 pub use crate::modules::ModuleLoaderError;
 use crate::runtime::v8_static_strings;

--- a/core/examples/hello_world.rs
+++ b/core/examples/hello_world.rs
@@ -7,7 +7,7 @@ use deno_core::*;
 /// An op for summing an array of numbers. The op-layer automatically
 /// deserializes inputs and serializes the returned Result & value.
 #[op2]
-fn op_sum(#[serde] nums: Vec<f64>) -> Result<f64, deno_core::error::OpError> {
+fn op_sum(#[serde] nums: Vec<f64>) -> Result<f64, deno_error::JsErrorBox> {
   // Sum inputs
   let sum = nums.iter().fold(0.0, |a, v| a + v);
   // return as a Result<f64, OpError>

--- a/core/examples/op2.rs
+++ b/core/examples/op2.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 use anyhow::Context;
-use deno_core::error::OpError;
 use deno_core::*;
 use std::rc::Rc;
 
@@ -9,7 +8,7 @@ use std::rc::Rc;
 fn op_use_state(
   state: &mut OpState,
   #[global] callback: v8::Global<v8::Function>,
-) -> Result<(), OpError> {
+) -> Result<(), deno_error::JsErrorBox> {
   state.put(callback);
   Ok(())
 }

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -514,8 +514,7 @@ async fn do_load_job<'s>(
           false,
           false,
         )
-        .unwrap_err()
-        .into(),
+        .unwrap_err(),
       );
     }
   }
@@ -621,8 +620,7 @@ fn op_import_sync<'s>(
           false,
           false,
         )
-        .unwrap_err()
-        .into(),
+        .unwrap_err(),
       );
     }
   }

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -1,7 +1,9 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-use crate::error::{exception_to_err_result, ResourceError};
-use crate::error::{format_file_name, CoreError};
+use crate::error::exception_to_err_result;
+use crate::error::format_file_name;
+use crate::error::CoreError;
+use crate::error::ResourceError;
 use crate::io::AdaptiveBufferStrategy;
 use crate::io::BufMutView;
 use crate::io::BufView;

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -2569,6 +2569,7 @@ impl JsRuntime {
         .complete(RuntimeActivityType::AsyncOp, promise_id as _);
       dispatched_ops |= true;
       args.push(v8::Integer::new(scope, promise_id).into());
+      args.push(v8::Boolean::new(scope, res.is_ok()).into());
       args.push(res.unwrap_or_else(std::convert::identity));
     }
 

--- a/core/runtime/op_driver/futures_unordered_driver.rs
+++ b/core/runtime/op_driver/futures_unordered_driver.rs
@@ -8,6 +8,7 @@ use super::OpInflightStats;
 use crate::OpId;
 use crate::PromiseId;
 use bit_set::BitSet;
+use deno_error::JsErrorClass;
 use deno_unsync::spawn;
 use deno_unsync::JoinHandle;
 use deno_unsync::UnsyncWaker;
@@ -124,7 +125,7 @@ impl<C: OpMappingContext> FuturesUnorderedDriver<C> {
 impl<C: OpMappingContext> OpDriver<C> for FuturesUnorderedDriver<C> {
   fn submit_op_fallible<
     R: 'static,
-    E: Into<OpError> + 'static,
+    E: JsErrorClass + 'static,
     const LAZY: bool,
     const DEFERRED: bool,
   >(

--- a/core/runtime/tests/error.rs
+++ b/core/runtime/tests/error.rs
@@ -1,7 +1,6 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 use crate::error::CoreError;
-use crate::error::OpError;
 use crate::op2;
 use crate::JsRuntime;
 use crate::RuntimeOptions;
@@ -12,8 +11,8 @@ use std::task::Poll;
 #[tokio::test]
 async fn test_error_builder() {
   #[op2(fast)]
-  fn op_err() -> Result<(), OpError> {
-    Err(JsErrorBox::new("DOMExceptionOperationError", "abc").into())
+  fn op_err() -> Result<(), JsErrorBox> {
+    Err(JsErrorBox::new("DOMExceptionOperationError", "abc"))
   }
 
   deno_core::extension!(test_ext, ops = [op_err]);

--- a/core/runtime/tests/mod.rs
+++ b/core/runtime/tests/mod.rs
@@ -1,11 +1,11 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-use crate::error::OpError;
 use crate::op2;
 use crate::CrossIsolateStore;
 use crate::JsRuntime;
 use crate::OpState;
 use crate::RuntimeOptions;
+use deno_error::JsErrorBox;
 use serde_v8::JsBuffer;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -37,7 +37,7 @@ async fn op_test(
   rc_op_state: Rc<RefCell<OpState>>,
   control: u8,
   #[buffer] buf: Option<JsBuffer>,
-) -> Result<u8, OpError> {
+) -> Result<u8, JsErrorBox> {
   let op_state_ = rc_op_state.borrow();
   let test_state = op_state_.borrow::<TestState>();
   test_state.dispatch_count.fetch_add(1, Ordering::Relaxed);

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -2,7 +2,6 @@
 
 #![allow(clippy::print_stdout, clippy::print_stderr, clippy::unused_async)]
 
-use crate::error::OpError;
 use crate::extensions::OpDecl;
 use crate::modules::StaticModuleLoader;
 use crate::runtime::tests::setup;
@@ -24,7 +23,7 @@ async fn test_async_opstate_borrow() {
   #[op2(async)]
   async fn op_async_borrow(
     op_state: Rc<RefCell<OpState>>,
-  ) -> Result<(), OpError> {
+  ) -> Result<(), JsErrorBox> {
     let n = {
       let op_state = op_state.borrow();
       let inner_state = op_state.borrow::<InnerState>();
@@ -63,7 +62,7 @@ async fn test_sync_op_serialize_object_with_numbers_as_keys() {
   #[op2]
   fn op_sync_serialize_object_with_numbers_as_keys(
     #[serde] value: serde_json::Value,
-  ) -> Result<(), OpError> {
+  ) -> Result<(), JsErrorBox> {
     assert_eq!(
       value.to_string(),
       r#"{"lines":{"100":{"unit":"m"},"200":{"unit":"cm"}}}"#
@@ -105,7 +104,7 @@ async fn test_async_op_serialize_object_with_numbers_as_keys() {
   #[op2(async)]
   async fn op_async_serialize_object_with_numbers_as_keys(
     #[serde] value: serde_json::Value,
-  ) -> Result<(), OpError> {
+  ) -> Result<(), JsErrorBox> {
     assert_eq!(
       value.to_string(),
       r#"{"lines":{"100":{"unit":"m"},"200":{"unit":"cm"}}}"#
@@ -148,7 +147,7 @@ fn test_op_return_serde_v8_error() {
   #[allow(clippy::unnecessary_wraps)]
   #[op2]
   #[serde]
-  fn op_err() -> Result<std::collections::BTreeMap<u64, u64>, OpError> {
+  fn op_err() -> Result<std::collections::BTreeMap<u64, u64>, JsErrorBox> {
     Ok([(1, 2), (3, 4)].into_iter().collect()) // Maps can't have non-string keys in serde_v8
   }
 
@@ -175,7 +174,7 @@ fn test_op_high_arity() {
     #[number] x2: i64,
     #[number] x3: i64,
     #[number] x4: i64,
-  ) -> Result<i64, OpError> {
+  ) -> Result<i64, JsErrorBox> {
     Ok(x1 + x2 + x3 + x4)
   }
 
@@ -196,7 +195,7 @@ fn test_op_disabled() {
   #[allow(clippy::unnecessary_wraps)]
   #[op2(fast)]
   #[number]
-  fn op_foo() -> Result<i64, OpError> {
+  fn op_foo() -> Result<i64, JsErrorBox> {
     Ok(42)
   }
 
@@ -220,14 +219,14 @@ fn test_op_disabled() {
 fn test_op_detached_buffer() {
   #[allow(clippy::unnecessary_wraps)]
   #[op2]
-  fn op_sum_take(#[buffer(detach)] b: JsBuffer) -> Result<u32, OpError> {
+  fn op_sum_take(#[buffer(detach)] b: JsBuffer) -> Result<u32, JsErrorBox> {
     Ok(b.as_ref().iter().clone().map(|x| *x as u32).sum())
   }
 
   #[allow(clippy::unnecessary_wraps)]
   #[op2]
   #[buffer]
-  fn op_boomerang(#[buffer(detach)] b: JsBuffer) -> Result<JsBuffer, OpError> {
+  fn op_boomerang(#[buffer(detach)] b: JsBuffer) -> Result<JsBuffer, JsErrorBox> {
     Ok(b)
   }
 
@@ -302,14 +301,14 @@ fn duplicate_op_names() {
     #[allow(clippy::unnecessary_wraps)]
     #[op2]
     #[string]
-    pub fn op_test() -> Result<String, OpError> {
+    pub fn op_test() -> Result<String, JsErrorBox> {
       Ok(String::from("Test"))
     }
   }
 
   #[op2]
   #[string]
-  pub fn op_test() -> Result<String, OpError> {
+  pub fn op_test() -> Result<String, JsErrorBox> {
     Ok(String::from("Test"))
   }
 
@@ -325,13 +324,13 @@ fn ops_in_js_have_proper_names() {
   #[allow(clippy::unnecessary_wraps)]
   #[op2]
   #[string]
-  fn op_test_sync() -> Result<String, OpError> {
+  fn op_test_sync() -> Result<String, JsErrorBox> {
     Ok(String::from("Test"))
   }
 
   #[op2(async)]
   #[string]
-  async fn op_test_async() -> Result<String, OpError> {
+  async fn op_test_async() -> Result<String, JsErrorBox> {
     Ok(String::from("Test"))
   }
 
@@ -540,9 +539,9 @@ pub async fn op_async() {
 
 #[op2(async)]
 #[allow(unreachable_code)]
-pub fn op_async_impl_future_error() -> Result<impl Future<Output = ()>, OpError>
+pub fn op_async_impl_future_error() -> Result<impl Future<Output = ()>, JsErrorBox>
 {
-  return Err(JsErrorBox::generic("dead").into());
+  return Err(JsErrorBox::generic("dead"));
   Ok(async {})
 }
 
@@ -553,16 +552,16 @@ pub async fn op_async_yield() {
 }
 
 #[op2(async)]
-pub async fn op_async_yield_error() -> Result<(), OpError> {
+pub async fn op_async_yield_error() -> Result<(), JsErrorBox> {
   tokio::task::yield_now().await;
   println!("op_async_yield_error!");
-  Err(JsErrorBox::generic("dead").into())
+  Err(JsErrorBox::generic("dead"))
 }
 
 #[op2(async)]
-pub async fn op_async_error() -> Result<(), OpError> {
+pub async fn op_async_error() -> Result<(), JsErrorBox> {
   println!("op_async_error!");
-  Err(JsErrorBox::generic("dead").into())
+  Err(JsErrorBox::generic("dead"))
 }
 
 #[op2(async(deferred), fast)]
@@ -581,8 +580,8 @@ pub fn op_sync() {
 }
 
 #[op2(fast)]
-pub fn op_sync_error() -> Result<(), OpError> {
-  Err(JsErrorBox::generic("Always fails").into())
+pub fn op_sync_error() -> Result<(), JsErrorBox> {
+  Err(JsErrorBox::generic("Always fails"))
 }
 
 #[op2(fast)]

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -226,7 +226,9 @@ fn test_op_detached_buffer() {
   #[allow(clippy::unnecessary_wraps)]
   #[op2]
   #[buffer]
-  fn op_boomerang(#[buffer(detach)] b: JsBuffer) -> Result<JsBuffer, JsErrorBox> {
+  fn op_boomerang(
+    #[buffer(detach)] b: JsBuffer,
+  ) -> Result<JsBuffer, JsErrorBox> {
     Ok(b)
   }
 
@@ -539,8 +541,8 @@ pub async fn op_async() {
 
 #[op2(async)]
 #[allow(unreachable_code)]
-pub fn op_async_impl_future_error() -> Result<impl Future<Output = ()>, JsErrorBox>
-{
+pub fn op_async_impl_future_error(
+) -> Result<impl Future<Output = ()>, JsErrorBox> {
   return Err(JsErrorBox::generic("dead"));
   Ok(async {})
 }

--- a/core/runtime/tests/snapshot.rs
+++ b/core/runtime/tests/snapshot.rs
@@ -2,11 +2,11 @@
 
 use self::runtime::create_snapshot;
 use self::runtime::CreateSnapshotOptions;
-use crate::error::OpError;
 use crate::modules::ModuleInfo;
 use crate::modules::RequestedModuleType;
 use crate::runtime::NO_OF_BUILTIN_MODULES;
 use crate::*;
+use deno_error::JsErrorBox;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -234,7 +234,7 @@ fn es_snapshot() {
   #[allow(clippy::unnecessary_wraps)]
   #[op2]
   #[string]
-  fn op_test() -> Result<String, OpError> {
+  fn op_test() -> Result<String, JsErrorBox> {
     Ok(String::from("test"))
   }
   let mut runtime = JsRuntimeForSnapshot::new(RuntimeOptions {

--- a/ops/compile_test_runner/Cargo.toml
+++ b/ops/compile_test_runner/Cargo.toml
@@ -23,3 +23,4 @@ serde.workspace = true
 syn.workspace = true
 testing_macros = "0.2.11"
 trybuild = "1.0"
+deno_error.workspace = true

--- a/ops/compile_test_runner/Cargo.toml
+++ b/ops/compile_test_runner/Cargo.toml
@@ -15,6 +15,7 @@ description = "Compile-test runner for deno_ops"
 [dev-dependencies]
 bytes.workspace = true
 deno_core.workspace = true
+deno_error.workspace = true
 deno_ops.workspace = true
 pretty_assertions.workspace = true
 prettyplease = "0.2.9"
@@ -23,4 +24,3 @@ serde.workspace = true
 syn.workspace = true
 testing_macros = "0.2.11"
 trybuild = "1.0"
-deno_error.workspace = true

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -352,7 +352,7 @@ pub(crate) fn generate_fast_result_early_exit(
         let mut scope = #create_scope;
         let exception = deno_core::error::to_v8_error(
           &mut scope,
-          &deno_core::error::OpErrorWrapper(err.into()),
+          &err,
         );
         scope.throw_exception(exception);
         // SAFETY: All fast return types have zero as a valid value

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -1178,7 +1178,7 @@ pub(crate) fn throw_exception(
     #maybe_opctx
     let exception = deno_core::error::to_v8_error(
       &mut #scope,
-      &deno_core::error::OpErrorWrapper(err.into()),
+      &err,
     );
     #scope.throw_exception(exception);
     return 1;

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -1967,19 +1967,19 @@ mod tests {
     (Numeric(__SMI__, None)) -> Result(Numeric(__SMI__, None))
   );
   test!(
-    fn op_option_numeric_result(state: &mut OpState) -> Result<Option<u32>, OpError>;
+    fn op_option_numeric_result(state: &mut OpState) -> Result<Option<u32>, JsErrorBox>;
     (Ref(Mut, OpState)) -> Result(OptionNumeric(u32, None))
   );
   test!(
-    #[smi] fn op_option_numeric_smi_result(#[smi] a: Option<u32>) -> Result<Option<u32>, OpError>;
+    #[smi] fn op_option_numeric_smi_result(#[smi] a: Option<u32>) -> Result<Option<u32>, JsErrorBox>;
     (OptionNumeric(__SMI__, None)) -> Result(OptionNumeric(__SMI__, None))
   );
   test!(
-    fn op_ffi_read_f64(state: &mut OpState, ptr: *mut c_void, #[bigint] offset: isize) -> Result<f64, OpError>;
+    fn op_ffi_read_f64(state: &mut OpState, ptr: *mut c_void, #[bigint] offset: isize) -> Result<f64, JsErrorBox>;
     (Ref(Mut, OpState), External(Ptr(Mut)), Numeric(isize, None)) -> Result(Numeric(f64, None))
   );
   test!(
-    #[number] fn op_64_bit_number(#[number] offset: isize) -> Result<u64, OpError>;
+    #[number] fn op_64_bit_number(#[number] offset: isize) -> Result<u64, JsErrorBox>;
     (Numeric(isize, Number)) -> Result(Numeric(u64, Number))
   );
   test!(
@@ -2080,7 +2080,7 @@ mod tests {
       #[smi] rid: ResourceId
     ) -> Result<
       ExtremelyLongTypeNameThatForcesEverythingToWrapAndAddsCommas,
-      OpError,
+      JsErrorBox,
     >;
     (RcRefCell(OpState), Numeric(__SMI__, None)) -> FutureResult(SerdeV8(ExtremelyLongTypeNameThatForcesEverythingToWrapAndAddsCommas))
   );

--- a/ops/op2/test_cases/async/async_arg_return_result.out
+++ b/ops/op2/test_cases/async/async_arg_return_result.out
@@ -71,10 +71,7 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let exception = deno_core::error::to_v8_error(
-                            &mut scope,
-                            &deno_core::error::OpErrorWrapper(err.into()),
-                        );
+                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
                         scope.throw_exception(exception);
                         return 1;
                     }

--- a/ops/op2/test_cases/async/async_opstate.out
+++ b/ops/op2/test_cases/async/async_opstate.out
@@ -67,10 +67,7 @@ pub const fn op_async_opstate() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let exception = deno_core::error::to_v8_error(
-                            &mut scope,
-                            &deno_core::error::OpErrorWrapper(err.into()),
-                        );
+                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
                         scope.throw_exception(exception);
                         return 1;
                     }

--- a/ops/op2/test_cases/async/async_result.out
+++ b/ops/op2/test_cases/async/async_result.out
@@ -63,10 +63,7 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let exception = deno_core::error::to_v8_error(
-                            &mut scope,
-                            &deno_core::error::OpErrorWrapper(err.into()),
-                        );
+                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
                         scope.throw_exception(exception);
                         return 1;
                     }

--- a/ops/op2/test_cases/async/async_result_impl.out
+++ b/ops/op2/test_cases/async/async_result_impl.out
@@ -57,10 +57,7 @@ pub const fn op_async_result_impl() -> ::deno_core::_ops::OpDecl {
                 Ok(result) => result,
                 Err(err) => {
                     let mut scope = unsafe { deno_core::v8::CallbackScope::new(info) };
-                    let exception = deno_core::error::to_v8_error(
-                        &mut scope,
-                        &deno_core::error::OpErrorWrapper(err.into()),
-                    );
+                    let exception = deno_core::error::to_v8_error(&mut scope, &err);
                     scope.throw_exception(exception);
                     return 1;
                 }
@@ -83,10 +80,7 @@ pub const fn op_async_result_impl() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let exception = deno_core::error::to_v8_error(
-                            &mut scope,
-                            &deno_core::error::OpErrorWrapper(err.into()),
-                        );
+                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
                         scope.throw_exception(exception);
                         return 1;
                     }
@@ -134,7 +128,7 @@ pub const fn op_async_result_impl() -> ::deno_core::_ops::OpDecl {
         #[allow(clippy::too_many_arguments)]
         pub fn call(
             x: i32,
-        ) -> Result<impl Future<Output = std::io::Result<i32>>, OpError> {
+        ) -> Result<impl Future<Output = std::io::Result<i32>>, JsErrorBox> {
             Ok(async move { Ok(x) })
         }
     }

--- a/ops/op2/test_cases/async/async_result_impl.rs
+++ b/ops/op2/test_cases/async/async_result_impl.rs
@@ -3,12 +3,12 @@
 #![deny(warnings)]
 deno_ops_compile_test_runner::prelude!();
 
-use deno_core::error::OpError;
+use deno_error::JsErrorBox;
 use std::future::Future;
 
 #[op2(async)]
 pub fn op_async_result_impl(
   x: i32,
-) -> Result<impl Future<Output = std::io::Result<i32>>, OpError> {
+) -> Result<impl Future<Output = std::io::Result<i32>>, JsErrorBox> {
   Ok(async move { Ok(x) })
 }

--- a/ops/op2/test_cases/async/async_result_smi.out
+++ b/ops/op2/test_cases/async/async_result_smi.out
@@ -87,10 +87,7 @@ pub const fn op_async() -> ::deno_core::_ops::OpDecl {
                         let mut scope = unsafe {
                             deno_core::v8::CallbackScope::new(info)
                         };
-                        let exception = deno_core::error::to_v8_error(
-                            &mut scope,
-                            &deno_core::error::OpErrorWrapper(err.into()),
-                        );
+                        let exception = deno_core::error::to_v8_error(&mut scope, &err);
                         scope.throw_exception(exception);
                         return 1;
                     }

--- a/ops/op2/test_cases/compiler_pass/async.rs
+++ b/ops/op2/test_cases/compiler_pass/async.rs
@@ -3,9 +3,9 @@
 #![deny(warnings)]
 deno_ops_compile_test_runner::prelude!();
 
-use deno_core::error::OpError;
 use deno_core::JsBuffer;
 use deno_core::OpState;
+use deno_error::JsErrorBox;
 use std::cell::RefCell;
 use std::future::Future;
 use std::rc::Rc;
@@ -26,14 +26,14 @@ pub async fn op_async3(x: i32) -> std::io::Result<i32> {
 }
 
 #[op2(async)]
-pub fn op_async4(x: i32) -> Result<impl Future<Output = i32>, OpError> {
+pub fn op_async4(x: i32) -> Result<impl Future<Output = i32>, JsErrorBox> {
   Ok(async move { x })
 }
 
 #[op2(async)]
 pub fn op_async5(
   x: i32,
-) -> Result<impl Future<Output = std::io::Result<i32>>, OpError> {
+) -> Result<impl Future<Output = std::io::Result<i32>>, JsErrorBox> {
   Ok(async move { Ok(x) })
 }
 

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -116,10 +116,7 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
                     let mut scope = unsafe {
                         deno_core::v8::CallbackScope::new(&*fast_api_callback_options)
                     };
-                    let exception = deno_core::error::to_v8_error(
-                        &mut scope,
-                        &deno_core::error::OpErrorWrapper(err.into()),
-                    );
+                    let exception = deno_core::error::to_v8_error(&mut scope, &err);
                     scope.throw_exception(exception);
                     return unsafe { std::mem::zeroed() };
                 }
@@ -152,10 +149,7 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
                         >::cast_unchecked(args.data())
                             .value() as *const deno_core::_ops::OpCtx)
                     };
-                    let exception = deno_core::error::to_v8_error(
-                        &mut scope,
-                        &deno_core::error::OpErrorWrapper(err.into()),
-                    );
+                    let exception = deno_core::error::to_v8_error(&mut scope, &err);
                     scope.throw_exception(exception);
                     return 1;
                 }
@@ -199,7 +193,7 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
     }
     impl op_bool {
         #[allow(clippy::too_many_arguments)]
-        pub fn call(arg: bool) -> Result<bool, OpError> {
+        pub fn call(arg: bool) -> Result<bool, JsErrorBox> {
             Ok(arg)
         }
     }

--- a/ops/op2/test_cases/sync/bool_result.rs
+++ b/ops/op2/test_cases/sync/bool_result.rs
@@ -3,9 +3,9 @@
 #![deny(warnings)]
 deno_ops_compile_test_runner::prelude!();
 
-use deno_core::error::OpError;
+use deno_error::JsErrorBox;
 
 #[op2(fast)]
-pub fn op_bool(arg: bool) -> Result<bool, OpError> {
+pub fn op_bool(arg: bool) -> Result<bool, JsErrorBox> {
   Ok(arg)
 }

--- a/ops/op2/test_cases/sync/result_external.out
+++ b/ops/op2/test_cases/sync/result_external.out
@@ -103,10 +103,7 @@ pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
                     let mut scope = unsafe {
                         deno_core::v8::CallbackScope::new(&*fast_api_callback_options)
                     };
-                    let exception = deno_core::error::to_v8_error(
-                        &mut scope,
-                        &deno_core::error::OpErrorWrapper(err.into()),
-                    );
+                    let exception = deno_core::error::to_v8_error(&mut scope, &err);
                     scope.throw_exception(exception);
                     return unsafe { std::mem::zeroed() };
                 }
@@ -137,10 +134,7 @@ pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
                         >::cast_unchecked(args.data())
                             .value() as *const deno_core::_ops::OpCtx)
                     };
-                    let exception = deno_core::error::to_v8_error(
-                        &mut scope,
-                        &deno_core::error::OpErrorWrapper(err.into()),
-                    );
+                    let exception = deno_core::error::to_v8_error(&mut scope, &err);
                     scope.throw_exception(exception);
                     return 1;
                 }
@@ -184,7 +178,7 @@ pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
     }
     impl op_external_with_result {
         #[allow(clippy::too_many_arguments)]
-        pub fn call() -> Result<*mut std::ffi::c_void, OpError> {
+        pub fn call() -> Result<*mut std::ffi::c_void, JsErrorBox> {
             Ok(0 as _)
         }
     }

--- a/ops/op2/test_cases/sync/result_external.rs
+++ b/ops/op2/test_cases/sync/result_external.rs
@@ -3,9 +3,9 @@
 #![deny(warnings)]
 deno_ops_compile_test_runner::prelude!();
 
-use deno_core::error::OpError;
+use deno_error::JsErrorBox;
 
 #[op2(fast)]
-pub fn op_external_with_result() -> Result<*mut std::ffi::c_void, OpError> {
+pub fn op_external_with_result() -> Result<*mut std::ffi::c_void, JsErrorBox> {
   Ok(0 as _)
 }

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -111,10 +111,7 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
                     let mut scope = unsafe {
                         deno_core::v8::CallbackScope::new(&*fast_api_callback_options)
                     };
-                    let exception = deno_core::error::to_v8_error(
-                        &mut scope,
-                        &deno_core::error::OpErrorWrapper(err.into()),
-                    );
+                    let exception = deno_core::error::to_v8_error(&mut scope, &err);
                     scope.throw_exception(exception);
                     return unsafe { std::mem::zeroed() };
                 }
@@ -143,10 +140,7 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
                         >::cast_unchecked(args.data())
                             .value() as *const deno_core::_ops::OpCtx)
                     };
-                    let exception = deno_core::error::to_v8_error(
-                        &mut scope,
-                        &deno_core::error::OpErrorWrapper(err.into()),
-                    );
+                    let exception = deno_core::error::to_v8_error(&mut scope, &err);
                     scope.throw_exception(exception);
                     return 1;
                 }
@@ -190,7 +184,7 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
     }
     impl op_u32_with_result {
         #[allow(clippy::too_many_arguments)]
-        pub fn call() -> Result<u32, OpError> {
+        pub fn call() -> Result<u32, JsErrorBox> {
             Ok(0)
         }
     }

--- a/ops/op2/test_cases/sync/result_primitive.rs
+++ b/ops/op2/test_cases/sync/result_primitive.rs
@@ -3,9 +3,9 @@
 #![deny(warnings)]
 deno_ops_compile_test_runner::prelude!();
 
-use deno_core::error::OpError;
+use deno_error::JsErrorBox;
 
 #[op2(fast)]
-pub fn op_u32_with_result() -> Result<u32, OpError> {
+pub fn op_u32_with_result() -> Result<u32, JsErrorBox> {
   Ok(0)
 }

--- a/ops/op2/test_cases/sync/result_scope.out
+++ b/ops/op2/test_cases/sync/result_scope.out
@@ -109,10 +109,7 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
                     let mut scope = unsafe {
                         deno_core::v8::CallbackScope::new(&*fast_api_callback_options)
                     };
-                    let exception = deno_core::error::to_v8_error(
-                        &mut scope,
-                        &deno_core::error::OpErrorWrapper(err.into()),
-                    );
+                    let exception = deno_core::error::to_v8_error(&mut scope, &err);
                     scope.throw_exception(exception);
                     return unsafe { std::mem::zeroed() };
                 }
@@ -144,10 +141,7 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
                         >::cast_unchecked(args.data())
                             .value() as *const deno_core::_ops::OpCtx)
                     };
-                    let exception = deno_core::error::to_v8_error(
-                        &mut scope,
-                        &deno_core::error::OpErrorWrapper(err.into()),
-                    );
+                    let exception = deno_core::error::to_v8_error(&mut scope, &err);
                     scope.throw_exception(exception);
                     return 1;
                 }
@@ -191,7 +185,7 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
     }
     impl op_void_with_result {
         #[allow(clippy::too_many_arguments)]
-        pub fn call(_scope: &mut v8::HandleScope) -> Result<(), OpError> {
+        pub fn call(_scope: &mut v8::HandleScope) -> Result<(), JsErrorBox> {
             Ok(())
         }
     }

--- a/ops/op2/test_cases/sync/result_scope.rs
+++ b/ops/op2/test_cases/sync/result_scope.rs
@@ -3,12 +3,12 @@
 #![deny(warnings)]
 deno_ops_compile_test_runner::prelude!();
 
-use deno_core::error::OpError;
 use deno_core::v8;
+use deno_error::JsErrorBox;
 
 #[op2(fast)]
 pub fn op_void_with_result(
   _scope: &mut v8::HandleScope,
-) -> Result<(), OpError> {
+) -> Result<(), JsErrorBox> {
   Ok(())
 }

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -103,10 +103,7 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
                     let mut scope = unsafe {
                         deno_core::v8::CallbackScope::new(&*fast_api_callback_options)
                     };
-                    let exception = deno_core::error::to_v8_error(
-                        &mut scope,
-                        &deno_core::error::OpErrorWrapper(err.into()),
-                    );
+                    let exception = deno_core::error::to_v8_error(&mut scope, &err);
                     scope.throw_exception(exception);
                     return unsafe { std::mem::zeroed() };
                 }
@@ -135,10 +132,7 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
                         >::cast_unchecked(args.data())
                             .value() as *const deno_core::_ops::OpCtx)
                     };
-                    let exception = deno_core::error::to_v8_error(
-                        &mut scope,
-                        &deno_core::error::OpErrorWrapper(err.into()),
-                    );
+                    let exception = deno_core::error::to_v8_error(&mut scope, &err);
                     scope.throw_exception(exception);
                     return 1;
                 }

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -3,7 +3,6 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use deno_core::error::OpError;
 use deno_core::op2;
 use deno_core::stats::RuntimeActivityDiff;
 use deno_core::stats::RuntimeActivitySnapshot;
@@ -98,7 +97,7 @@ impl TestObjectWrap {
   fn with_rename(&self) {}
 
   #[async_method]
-  async fn with_async_fn(&self, #[smi] ms: u32) -> Result<(), OpError> {
+  async fn with_async_fn(&self, #[smi] ms: u32) -> Result<(), JsErrorBox> {
     tokio::time::sleep(std::time::Duration::from_millis(ms as u64)).await;
     Ok(())
   }

--- a/testing/checkin/runner/ops_io.rs
+++ b/testing/checkin/runner/ops_io.rs
@@ -1,6 +1,5 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-use deno_core::error::OpError;
 use deno_core::op2;
 use deno_core::AsyncRefCell;
 use deno_core::BufView;
@@ -94,7 +93,7 @@ impl Resource for FileResource {
 pub async fn op_file_open(
   #[string] path: String,
   op_state: Rc<RefCell<OpState>>,
-) -> Result<ResourceId, OpError> {
+) -> Result<ResourceId, std::io::Error> {
   let tokio_file = tokio::fs::OpenOptions::new()
     .read(true)
     .write(false)
@@ -110,7 +109,7 @@ pub async fn op_file_open(
 
 #[op2]
 #[string]
-pub fn op_path_to_url(#[string] path: &str) -> Result<String, OpError> {
+pub fn op_path_to_url(#[string] path: &str) -> Result<String, std::io::Error> {
   let path = std::path::absolute(path)?;
   let url = url::Url::from_file_path(path).unwrap();
   Ok(url.to_string())


### PR DESCRIPTION
Removes usage of serde_v8 for constructing errors