### PR TITLE
perf: reduce generated op code for metrics"

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -187,6 +187,7 @@ pub mod _ops {
   pub use super::ops_metrics::dispatch_metrics_async;
   pub use super::ops_metrics::dispatch_metrics_fast;
   pub use super::ops_metrics::dispatch_metrics_slow;
+  pub use super::ops_metrics::with_metrics;
   pub use super::ops_metrics::OpMetricsEvent;
   pub use super::runtime::ops::*;
   pub use super::runtime::ops_rust_to_v8::*;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -188,6 +188,7 @@ pub mod _ops {
   pub use super::ops_metrics::dispatch_metrics_fast;
   pub use super::ops_metrics::dispatch_metrics_slow;
   pub use super::ops_metrics::with_metrics;
+  pub use super::ops_metrics::with_metrics_fast;
   pub use super::ops_metrics::OpMetricsEvent;
   pub use super::runtime::ops::*;
   pub use super::runtime::ops_rust_to_v8::*;

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -144,7 +144,7 @@ pub(crate) fn generate_dispatch_slow(
   };
 
   Ok(
-    gs_quote!(generator_state(opctx, info, slow_function, slow_function_metrics) => {
+    gs_quote!(generator_state(info, slow_function, slow_function_metrics) => {
       fn slow_function_impl<'s>(#info: &'s deno_core::v8::FunctionCallbackInfo) -> usize {
         #[cfg(debug_assertions)]
         let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(&<Self as deno_core::_ops::Op>::DECL);
@@ -171,20 +171,8 @@ pub(crate) fn generate_dispatch_slow(
 
       extern "C" fn #slow_function_metrics<'s>(#info: *const deno_core::v8::FunctionCallbackInfo) {
         let info: &'s _ = unsafe { &*#info };
-        let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(info);
+        deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
 
-        let #opctx: &'s _ = unsafe {
-          &*(deno_core::v8::Local::<deno_core::v8::External>::cast_unchecked(args.data()).value()
-              as *const deno_core::_ops::OpCtx)
-        };
-
-        deno_core::_ops::dispatch_metrics_slow(#opctx, deno_core::_ops::OpMetricsEvent::Dispatched);
-        let res = Self::slow_function_impl(info);
-        if res == 0 {
-          deno_core::_ops::dispatch_metrics_slow(#opctx, deno_core::_ops::OpMetricsEvent::Completed);
-        } else {
-          deno_core::_ops::dispatch_metrics_slow(#opctx, deno_core::_ops::OpMetricsEvent::Error);
-        }
       }
     }),
   )

--- a/ops/op2/test_cases/async/async_deferred.out
+++ b/ops/op2/test_cases/async/async_deferred.out
@@ -73,25 +73,10 @@ pub const fn op_async_deferred() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, promise_id, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, promise_id, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/async/async_lazy.out
+++ b/ops/op2/test_cases/async/async_lazy.out
@@ -73,25 +73,10 @@ pub const fn op_async_lazy() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, promise_id, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, promise_id, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -91,25 +91,10 @@ const fn op_add() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> u32 {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0, arg1),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -165,31 +165,7 @@ const fn op_add() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_add {

--- a/ops/op2/test_cases/sync/add_options.out
+++ b/ops/op2/test_cases/sync/add_options.out
@@ -72,31 +72,7 @@ pub const fn op_test_add_option() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_test_add_option {

--- a/ops/op2/test_cases/sync/bigint.out
+++ b/ops/op2/test_cases/sync/bigint.out
@@ -56,25 +56,10 @@ pub const fn op_bigint() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> u64 {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/bigint.out
+++ b/ops/op2/test_cases/sync/bigint.out
@@ -108,31 +108,7 @@ pub const fn op_bigint() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_bigint {

--- a/ops/op2/test_cases/sync/bool.out
+++ b/ops/op2/test_cases/sync/bool.out
@@ -61,25 +61,10 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> bool {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/bool.out
+++ b/ops/op2/test_cases/sync/bool.out
@@ -123,31 +123,7 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_bool {

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -164,31 +164,7 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_bool {

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -65,25 +65,10 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> bool {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -73,25 +73,10 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(
@@ -292,25 +277,10 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -207,31 +207,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_buffers {
@@ -450,31 +426,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_buffers_32 {
@@ -572,31 +524,7 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_buffers_option {

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -70,25 +70,10 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0, arg1, arg2),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(
@@ -252,25 +237,10 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0, arg1),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -173,31 +173,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_buffers {
@@ -364,31 +340,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_buffers_32 {

--- a/ops/op2/test_cases/sync/buffers_out.out
+++ b/ops/op2/test_cases/sync/buffers_out.out
@@ -69,31 +69,7 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_buffers {
@@ -183,31 +159,7 @@ const fn op_buffers_option() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_buffers_option {
@@ -292,31 +244,7 @@ const fn op_arraybuffers() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_arraybuffers {

--- a/ops/op2/test_cases/sync/cfg.out
+++ b/ops/op2/test_cases/sync/cfg.out
@@ -58,25 +58,10 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(
@@ -181,25 +166,10 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/cfg.out
+++ b/ops/op2/test_cases/sync/cfg.out
@@ -109,31 +109,7 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_maybe_windows {
@@ -256,31 +232,7 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_maybe_windows {

--- a/ops/op2/test_cases/sync/clippy_allow.out
+++ b/ops/op2/test_cases/sync/clippy_allow.out
@@ -109,31 +109,7 @@ pub const fn op_extra_annotation() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_extra_annotation {
@@ -254,31 +230,7 @@ pub const fn op_clippy_internal() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_clippy_internal {

--- a/ops/op2/test_cases/sync/clippy_allow.out
+++ b/ops/op2/test_cases/sync/clippy_allow.out
@@ -58,25 +58,10 @@ pub const fn op_extra_annotation() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(
@@ -179,25 +164,10 @@ pub const fn op_clippy_internal() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -65,25 +65,10 @@ const fn op_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(
@@ -234,25 +219,10 @@ const fn op_option_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(
@@ -481,25 +451,10 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(
@@ -723,25 +678,10 @@ const fn op_use_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -157,31 +157,7 @@ const fn op_cppgc_object() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_cppgc_object {
@@ -358,31 +334,7 @@ const fn op_option_cppgc_object() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_option_cppgc_object {
@@ -450,31 +402,7 @@ const fn op_make_cppgc_object() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_make_cppgc_object {
@@ -645,31 +573,7 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_use_cppgc_object {
@@ -740,31 +644,7 @@ const fn op_make_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_make_cppgc_object_option {
@@ -935,31 +815,7 @@ const fn op_use_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_use_cppgc_object_option {

--- a/ops/op2/test_cases/sync/doc_comment.out
+++ b/ops/op2/test_cases/sync/doc_comment.out
@@ -57,25 +57,10 @@ pub const fn op_has_doc_comment() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/doc_comment.out
+++ b/ops/op2/test_cases/sync/doc_comment.out
@@ -108,31 +108,7 @@ pub const fn op_has_doc_comment() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_has_doc_comment {

--- a/ops/op2/test_cases/sync/fast_alternative.out
+++ b/ops/op2/test_cases/sync/fast_alternative.out
@@ -66,31 +66,7 @@ const fn op_slow() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_slow {
@@ -269,31 +245,7 @@ const fn op_fast() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_fast {
@@ -373,31 +325,7 @@ const fn op_slow_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl<T: Trait> op_slow_generic<T> {
@@ -576,31 +504,7 @@ const fn op_fast_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl<T: Trait> op_fast_generic<T> {

--- a/ops/op2/test_cases/sync/fast_alternative.out
+++ b/ops/op2/test_cases/sync/fast_alternative.out
@@ -171,25 +171,10 @@ const fn op_fast() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> u32 {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0, arg1),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(
@@ -430,25 +415,10 @@ const fn op_fast_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> u32 {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0, arg1),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/from_v8.out
+++ b/ops/op2/test_cases/sync/from_v8.out
@@ -61,31 +61,7 @@ pub const fn op_from_v8_arg() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_from_v8_arg {

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -56,25 +56,10 @@ pub const fn op_generics<T: Trait>() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(
@@ -175,25 +160,10 @@ pub const fn op_generics_static<T: Trait + 'static>() -> ::deno_core::_ops::OpDe
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(
@@ -294,25 +264,10 @@ pub const fn op_generics_static_where<T: Trait + 'static>() -> ::deno_core::_ops
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -107,31 +107,7 @@ pub const fn op_generics<T: Trait>() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl<T: Trait> op_generics<T> {
@@ -250,31 +226,7 @@ pub const fn op_generics_static<T: Trait + 'static>() -> ::deno_core::_ops::OpDe
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl<T: Trait + 'static> op_generics_static<T> {
@@ -393,31 +345,7 @@ pub const fn op_generics_static_where<T: Trait + 'static>() -> ::deno_core::_ops
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl<T: Trait + 'static> op_generics_static_where<T> {

--- a/ops/op2/test_cases/sync/nofast.out
+++ b/ops/op2/test_cases/sync/nofast.out
@@ -64,31 +64,7 @@ const fn op_nofast() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_nofast {

--- a/ops/op2/test_cases/sync/object_wrap.out
+++ b/ops/op2/test_cases/sync/object_wrap.out
@@ -98,31 +98,7 @@ impl Foo {
                 info: *const deno_core::v8::FunctionCallbackInfo,
             ) {
                 let info: &'s _ = unsafe { &*info };
-                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                    info,
-                );
-                let opctx: &'s _ = unsafe {
-                    &*(deno_core::v8::Local::<
-                        deno_core::v8::External,
-                    >::cast_unchecked(args.data())
-                        .value() as *const deno_core::_ops::OpCtx)
-                };
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Dispatched,
-                );
-                let res = Self::slow_function_impl(info);
-                if res == 0 {
-                    deno_core::_ops::dispatch_metrics_slow(
-                        opctx,
-                        deno_core::_ops::OpMetricsEvent::Completed,
-                    );
-                } else {
-                    deno_core::_ops::dispatch_metrics_slow(
-                        opctx,
-                        deno_core::_ops::OpMetricsEvent::Error,
-                    );
-                }
+                deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
             }
         }
         impl constructor {
@@ -199,31 +175,7 @@ impl Foo {
                 info: *const deno_core::v8::FunctionCallbackInfo,
             ) {
                 let info: &'s _ = unsafe { &*info };
-                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                    info,
-                );
-                let opctx: &'s _ = unsafe {
-                    &*(deno_core::v8::Local::<
-                        deno_core::v8::External,
-                    >::cast_unchecked(args.data())
-                        .value() as *const deno_core::_ops::OpCtx)
-                };
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Dispatched,
-                );
-                let res = Self::slow_function_impl(info);
-                if res == 0 {
-                    deno_core::_ops::dispatch_metrics_slow(
-                        opctx,
-                        deno_core::_ops::OpMetricsEvent::Completed,
-                    );
-                } else {
-                    deno_core::_ops::dispatch_metrics_slow(
-                        opctx,
-                        deno_core::_ops::OpMetricsEvent::Error,
-                    );
-                }
+                deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
             }
         }
         trait Callable {
@@ -308,31 +260,7 @@ impl Foo {
                 info: *const deno_core::v8::FunctionCallbackInfo,
             ) {
                 let info: &'s _ = unsafe { &*info };
-                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                    info,
-                );
-                let opctx: &'s _ = unsafe {
-                    &*(deno_core::v8::Local::<
-                        deno_core::v8::External,
-                    >::cast_unchecked(args.data())
-                        .value() as *const deno_core::_ops::OpCtx)
-                };
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Dispatched,
-                );
-                let res = Self::slow_function_impl(info);
-                if res == 0 {
-                    deno_core::_ops::dispatch_metrics_slow(
-                        opctx,
-                        deno_core::_ops::OpMetricsEvent::Completed,
-                    );
-                } else {
-                    deno_core::_ops::dispatch_metrics_slow(
-                        opctx,
-                        deno_core::_ops::OpMetricsEvent::Error,
-                    );
-                }
+                deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
             }
         }
         trait Callable {
@@ -437,31 +365,7 @@ impl Foo {
                 info: *const deno_core::v8::FunctionCallbackInfo,
             ) {
                 let info: &'s _ = unsafe { &*info };
-                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                    info,
-                );
-                let opctx: &'s _ = unsafe {
-                    &*(deno_core::v8::Local::<
-                        deno_core::v8::External,
-                    >::cast_unchecked(args.data())
-                        .value() as *const deno_core::_ops::OpCtx)
-                };
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Dispatched,
-                );
-                let res = Self::slow_function_impl(info);
-                if res == 0 {
-                    deno_core::_ops::dispatch_metrics_slow(
-                        opctx,
-                        deno_core::_ops::OpMetricsEvent::Completed,
-                    );
-                } else {
-                    deno_core::_ops::dispatch_metrics_slow(
-                        opctx,
-                        deno_core::_ops::OpMetricsEvent::Error,
-                    );
-                }
+                deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
             }
         }
         trait Callable {
@@ -621,31 +525,7 @@ impl Foo {
                 info: *const deno_core::v8::FunctionCallbackInfo,
             ) {
                 let info: &'s _ = unsafe { &*info };
-                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                    info,
-                );
-                let opctx: &'s _ = unsafe {
-                    &*(deno_core::v8::Local::<
-                        deno_core::v8::External,
-                    >::cast_unchecked(args.data())
-                        .value() as *const deno_core::_ops::OpCtx)
-                };
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Dispatched,
-                );
-                let res = Self::slow_function_impl(info);
-                if res == 0 {
-                    deno_core::_ops::dispatch_metrics_slow(
-                        opctx,
-                        deno_core::_ops::OpMetricsEvent::Completed,
-                    );
-                } else {
-                    deno_core::_ops::dispatch_metrics_slow(
-                        opctx,
-                        deno_core::_ops::OpMetricsEvent::Error,
-                    );
-                }
+                deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
             }
         }
         trait Callable {
@@ -724,31 +604,7 @@ impl Foo {
                 info: *const deno_core::v8::FunctionCallbackInfo,
             ) {
                 let info: &'s _ = unsafe { &*info };
-                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                    info,
-                );
-                let opctx: &'s _ = unsafe {
-                    &*(deno_core::v8::Local::<
-                        deno_core::v8::External,
-                    >::cast_unchecked(args.data())
-                        .value() as *const deno_core::_ops::OpCtx)
-                };
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Dispatched,
-                );
-                let res = Self::slow_function_impl(info);
-                if res == 0 {
-                    deno_core::_ops::dispatch_metrics_slow(
-                        opctx,
-                        deno_core::_ops::OpMetricsEvent::Completed,
-                    );
-                } else {
-                    deno_core::_ops::dispatch_metrics_slow(
-                        opctx,
-                        deno_core::_ops::OpMetricsEvent::Error,
-                    );
-                }
+                deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
             }
         }
         trait Callable {
@@ -824,31 +680,7 @@ impl Foo {
                 info: *const deno_core::v8::FunctionCallbackInfo,
             ) {
                 let info: &'s _ = unsafe { &*info };
-                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                    info,
-                );
-                let opctx: &'s _ = unsafe {
-                    &*(deno_core::v8::Local::<
-                        deno_core::v8::External,
-                    >::cast_unchecked(args.data())
-                        .value() as *const deno_core::_ops::OpCtx)
-                };
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Dispatched,
-                );
-                let res = Self::slow_function_impl(info);
-                if res == 0 {
-                    deno_core::_ops::dispatch_metrics_slow(
-                        opctx,
-                        deno_core::_ops::OpMetricsEvent::Completed,
-                    );
-                } else {
-                    deno_core::_ops::dispatch_metrics_slow(
-                        opctx,
-                        deno_core::_ops::OpMetricsEvent::Error,
-                    );
-                }
+                deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
             }
         }
         trait Callable {
@@ -913,31 +745,7 @@ impl Foo {
                 info: *const deno_core::v8::FunctionCallbackInfo,
             ) {
                 let info: &'s _ = unsafe { &*info };
-                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                    info,
-                );
-                let opctx: &'s _ = unsafe {
-                    &*(deno_core::v8::Local::<
-                        deno_core::v8::External,
-                    >::cast_unchecked(args.data())
-                        .value() as *const deno_core::_ops::OpCtx)
-                };
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Dispatched,
-                );
-                let res = Self::slow_function_impl(info);
-                if res == 0 {
-                    deno_core::_ops::dispatch_metrics_slow(
-                        opctx,
-                        deno_core::_ops::OpMetricsEvent::Completed,
-                    );
-                } else {
-                    deno_core::_ops::dispatch_metrics_slow(
-                        opctx,
-                        deno_core::_ops::OpMetricsEvent::Error,
-                    );
-                }
+                deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
             }
         }
         impl __static_doThing {
@@ -1010,31 +818,7 @@ impl Foo {
                 info: *const deno_core::v8::FunctionCallbackInfo,
             ) {
                 let info: &'s _ = unsafe { &*info };
-                let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                    info,
-                );
-                let opctx: &'s _ = unsafe {
-                    &*(deno_core::v8::Local::<
-                        deno_core::v8::External,
-                    >::cast_unchecked(args.data())
-                        .value() as *const deno_core::_ops::OpCtx)
-                };
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Dispatched,
-                );
-                let res = Self::slow_function_impl(info);
-                if res == 0 {
-                    deno_core::_ops::dispatch_metrics_slow(
-                        opctx,
-                        deno_core::_ops::OpMetricsEvent::Completed,
-                    );
-                } else {
-                    deno_core::_ops::dispatch_metrics_slow(
-                        opctx,
-                        deno_core::_ops::OpMetricsEvent::Error,
-                    );
-                }
+                deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
             }
         }
         trait Callable {

--- a/ops/op2/test_cases/sync/object_wrap.out
+++ b/ops/op2/test_cases/sync/object_wrap.out
@@ -435,25 +435,10 @@ impl Foo {
                     's,
                 >,
             ) -> () {
-                let fast_api_callback_options: &'s mut _ = unsafe {
-                    &mut *fast_api_callback_options
-                };
-                let opctx: &'s _ = unsafe {
-                    &*(deno_core::v8::Local::<
-                        deno_core::v8::External,
-                    >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                        .value() as *const deno_core::_ops::OpCtx)
-                };
-                deno_core::_ops::dispatch_metrics_fast(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Dispatched,
-                );
-                let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-                deno_core::_ops::dispatch_metrics_fast(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-                res
+                deno_core::_ops::with_metrics_fast(
+                    fast_api_callback_options,
+                    || Self::v8_fn_ptr_fast(this, fast_api_callback_options),
+                )
             }
             #[allow(clippy::too_many_arguments)]
             extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/op_state_attr.out
+++ b/ops/op2/test_cases/sync/op_state_attr.out
@@ -56,25 +56,10 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/op_state_attr.out
+++ b/ops/op2/test_cases/sync/op_state_attr.out
@@ -141,31 +141,7 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_state_rc {

--- a/ops/op2/test_cases/sync/op_state_rc.out
+++ b/ops/op2/test_cases/sync/op_state_rc.out
@@ -135,31 +135,7 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_state_rc {

--- a/ops/op2/test_cases/sync/op_state_rc.out
+++ b/ops/op2/test_cases/sync/op_state_rc.out
@@ -56,25 +56,10 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -135,31 +135,7 @@ const fn op_state_ref() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_state_ref {
@@ -306,31 +282,7 @@ const fn op_state_mut() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_state_mut {
@@ -414,31 +366,7 @@ const fn op_state_and_v8() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_state_and_v8 {
@@ -623,31 +551,7 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_state_and_v8_local {

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -56,25 +56,10 @@ const fn op_state_ref() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(
@@ -203,25 +188,10 @@ const fn op_state_mut() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(
@@ -443,25 +413,10 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg1, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg1, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/result_external.out
+++ b/ops/op2/test_cases/sync/result_external.out
@@ -56,25 +56,10 @@ pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> *mut ::std::ffi::c_void {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/result_external.out
+++ b/ops/op2/test_cases/sync/result_external.out
@@ -149,31 +149,7 @@ pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_external_with_result {

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -155,31 +155,7 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_u32_with_result {

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -64,25 +64,10 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> u32 {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/result_scope.out
+++ b/ops/op2/test_cases/sync/result_scope.out
@@ -56,25 +56,10 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/result_scope.out
+++ b/ops/op2/test_cases/sync/result_scope.out
@@ -156,31 +156,7 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_void_with_result {

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -147,31 +147,7 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_void_with_result {

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -56,25 +56,10 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/serde_v8.out
+++ b/ops/op2/test_cases/sync/serde_v8.out
@@ -73,31 +73,7 @@ pub const fn op_serde_v8() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_serde_v8 {

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -113,25 +113,10 @@ const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> i32 {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(
@@ -336,25 +321,10 @@ const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> i32 {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -209,31 +209,7 @@ const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_smi_unsigned_return {
@@ -456,31 +432,7 @@ const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_smi_signed_return {
@@ -560,31 +512,7 @@ const fn op_smi_option() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_smi_option {

--- a/ops/op2/test_cases/sync/stack_trace.out
+++ b/ops/op2/test_cases/sync/stack_trace.out
@@ -56,25 +56,10 @@ const fn op_stack_trace() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/stack_trace.out
+++ b/ops/op2/test_cases/sync/stack_trace.out
@@ -160,31 +160,7 @@ const fn op_stack_trace() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_stack_trace {

--- a/ops/op2/test_cases/sync/stack_trace_scope.out
+++ b/ops/op2/test_cases/sync/stack_trace_scope.out
@@ -177,31 +177,7 @@ const fn op_stack_trace() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_stack_trace {

--- a/ops/op2/test_cases/sync/stack_trace_scope.out
+++ b/ops/op2/test_cases/sync/stack_trace_scope.out
@@ -65,25 +65,10 @@ const fn op_stack_trace() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/string_cow.out
+++ b/ops/op2/test_cases/sync/string_cow.out
@@ -160,31 +160,7 @@ const fn op_string_cow() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_string_cow {

--- a/ops/op2/test_cases/sync/string_cow.out
+++ b/ops/op2/test_cases/sync/string_cow.out
@@ -69,25 +69,10 @@ const fn op_string_cow() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> u32 {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/string_onebyte.out
+++ b/ops/op2/test_cases/sync/string_onebyte.out
@@ -144,31 +144,7 @@ const fn op_string_onebyte() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_string_onebyte {

--- a/ops/op2/test_cases/sync/string_onebyte.out
+++ b/ops/op2/test_cases/sync/string_onebyte.out
@@ -69,25 +69,10 @@ const fn op_string_onebyte() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> u32 {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/string_option_return.out
+++ b/ops/op2/test_cases/sync/string_option_return.out
@@ -65,31 +65,7 @@ pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_string_return {

--- a/ops/op2/test_cases/sync/string_owned.out
+++ b/ops/op2/test_cases/sync/string_owned.out
@@ -69,25 +69,10 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> u32 {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/string_owned.out
+++ b/ops/op2/test_cases/sync/string_owned.out
@@ -138,31 +138,7 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_string_owned {

--- a/ops/op2/test_cases/sync/string_ref.out
+++ b/ops/op2/test_cases/sync/string_ref.out
@@ -160,31 +160,7 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_string_owned {

--- a/ops/op2/test_cases/sync/string_ref.out
+++ b/ops/op2/test_cases/sync/string_ref.out
@@ -69,25 +69,10 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> u32 {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/string_return.out
+++ b/ops/op2/test_cases/sync/string_return.out
@@ -54,31 +54,7 @@ pub const fn op_string_return() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_string_return {
@@ -146,31 +122,7 @@ pub const fn op_string_return_ref() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_string_return_ref {
@@ -238,31 +190,7 @@ pub const fn op_string_return_cow() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_string_return_cow {

--- a/ops/op2/test_cases/sync/to_v8.out
+++ b/ops/op2/test_cases/sync/to_v8.out
@@ -60,31 +60,7 @@ pub const fn op_to_v8_return() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_to_v8_return {

--- a/ops/op2/test_cases/sync/v8_global.out
+++ b/ops/op2/test_cases/sync/v8_global.out
@@ -61,31 +61,7 @@ pub const fn op_global() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_global {

--- a/ops/op2/test_cases/sync/v8_handlescope.out
+++ b/ops/op2/test_cases/sync/v8_handlescope.out
@@ -62,31 +62,7 @@ const fn op_handlescope() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_handlescope {

--- a/ops/op2/test_cases/sync/v8_lifetime.out
+++ b/ops/op2/test_cases/sync/v8_lifetime.out
@@ -60,31 +60,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_v8_lifetime {

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -196,31 +196,7 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_v8_lifetime {

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -68,25 +68,10 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                 's,
             >,
         ) -> () {
-            let fast_api_callback_options: &'s mut _ = unsafe {
-                &mut *fast_api_callback_options
-            };
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(unsafe { fast_api_callback_options.data })
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::v8_fn_ptr_fast(this, arg0, arg1, fast_api_callback_options);
-            deno_core::_ops::dispatch_metrics_fast(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Completed,
-            );
-            res
+            deno_core::_ops::with_metrics_fast(
+                fast_api_callback_options,
+                || Self::v8_fn_ptr_fast(this, arg0, arg1, fast_api_callback_options),
+            )
         }
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(

--- a/ops/op2/test_cases/sync/v8_string.out
+++ b/ops/op2/test_cases/sync/v8_string.out
@@ -68,31 +68,7 @@ const fn op_v8_string() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_v8_string {

--- a/ops/op2/test_cases/sync/webidl.out
+++ b/ops/op2/test_cases/sync/webidl.out
@@ -85,31 +85,7 @@ const fn op_webidl() -> ::deno_core::_ops::OpDecl {
             info: *const deno_core::v8::FunctionCallbackInfo,
         ) {
             let info: &'s _ = unsafe { &*info };
-            let args = deno_core::v8::FunctionCallbackArguments::from_function_callback_info(
-                info,
-            );
-            let opctx: &'s _ = unsafe {
-                &*(deno_core::v8::Local::<
-                    deno_core::v8::External,
-                >::cast_unchecked(args.data())
-                    .value() as *const deno_core::_ops::OpCtx)
-            };
-            deno_core::_ops::dispatch_metrics_slow(
-                opctx,
-                deno_core::_ops::OpMetricsEvent::Dispatched,
-            );
-            let res = Self::slow_function_impl(info);
-            if res == 0 {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Completed,
-                );
-            } else {
-                deno_core::_ops::dispatch_metrics_slow(
-                    opctx,
-                    deno_core::_ops::OpMetricsEvent::Error,
-                );
-            }
+            deno_core::_ops::with_metrics(info, || Self::slow_function_impl(info));
         }
     }
     impl op_webidl {


### PR DESCRIPTION
- **wip**
- **with_metrics_fast**
