### PR TITLE
feat: support options in error constructors

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -301,24 +301,24 @@
   // errors in the JS code (eg. "deno_net") so they are provided in "Deno.core"
   // but later reexported on "Deno.errors"
   class BadResource extends Error {
-    constructor(msg) {
-      super(msg);
+    constructor(msg, options) {
+      super(msg, options);
       this.name = "BadResource";
     }
   }
   const BadResourcePrototype = BadResource.prototype;
 
   class Interrupted extends Error {
-    constructor(msg) {
-      super(msg);
+    constructor(msg, options) {
+      super(msg, options);
       this.name = "Interrupted";
     }
   }
   const InterruptedPrototype = Interrupted.prototype;
 
   class NotCapable extends Error {
-    constructor(msg) {
-      super(msg);
+    constructor(msg, options) {
+      super(msg, options);
       this.name = "NotCapable";
     }
   }

--- a/testing/unit/error_test.ts
+++ b/testing/unit/error_test.ts
@@ -10,3 +10,18 @@ test(function testCustomError() {
     assert(e instanceof Deno.core.BadResource);
   }
 });
+
+test(function testJsErrorConstructors() {
+  const error = new Error("message");
+  const badResource = new Deno.core.BadResource("bad resource", { cause: error });
+  assertEquals(badResource.message, "bad resource");
+  assertEquals(badResource.cause, error);
+
+  const Interrupted = new Deno.core.Interrupted("interrupted", { cause: error });
+  assertEquals(Interrupted.message, "interrupted");
+  assertEquals(Interrupted.cause, error);
+
+  const notCapable = new Deno.core.NotCapable("not capable", { cause: error });
+  assertEquals(notCapable.message, "not capable");
+  assertEquals(notCapable.cause, error);
+})

--- a/testing/unit/error_test.ts
+++ b/testing/unit/error_test.ts
@@ -13,15 +13,19 @@ test(function testCustomError() {
 
 test(function testJsErrorConstructors() {
   const error = new Error("message");
-  const badResource = new Deno.core.BadResource("bad resource", { cause: error });
+  const badResource = new Deno.core.BadResource("bad resource", {
+    cause: error,
+  });
   assertEquals(badResource.message, "bad resource");
   assertEquals(badResource.cause, error);
 
-  const Interrupted = new Deno.core.Interrupted("interrupted", { cause: error });
+  const Interrupted = new Deno.core.Interrupted("interrupted", {
+    cause: error,
+  });
   assertEquals(Interrupted.message, "interrupted");
   assertEquals(Interrupted.cause, error);
 
   const notCapable = new Deno.core.NotCapable("not capable", { cause: error });
   assertEquals(notCapable.message, "not capable");
   assertEquals(notCapable.cause, error);
-})
+});


### PR DESCRIPTION
This PR adds support of the 2nd arguments (`options`) to JS error constructors (`BadResource`, `Interrupted`, and `NotCapable`). closes #1031

By this change, downstream implementations can use `cause` option of `Error` class.