### PR TITLE
Add `#[this] _: v8::Global<v8::Object>`

### DIFF
--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -757,10 +757,10 @@ fn map_v8_fastcall_arg_to_arg(
         let #arg_ident = #arg_ident.try_borrow_mut::<#state>();
       }
     }
-    Arg::VarArgs => {
-      quote! {
-        let #arg_ident = None;
-      }
+    Arg::VarArgs => quote!(let #arg_ident = None;),
+    Arg::This => {
+      *needs_fast_isolate = true;
+      quote!(let #arg_ident = deno_core::v8::Global::new(&mut #scope, this);)
     }
     Arg::String(Strings::RefStr) => {
       quote! {
@@ -886,6 +886,7 @@ fn map_arg_to_v8_fastcall_type(
     | Arg::Ref(RefType::Ref, Special::JsRuntimeState)
     | Arg::State(..)
     | Arg::VarArgs
+    | Arg::This
     | Arg::Special(Special::Isolate)
     | Arg::OptionState(..) => V8FastCallType::Virtual,
     // Other types + ref types are not handled

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -502,6 +502,12 @@ pub fn from_arg(
         let #arg_ident = Some(&#fn_args);
       })
     }
+    Arg::This => {
+      *needs_isolate = true;
+      gs_quote!(generator_state(scope, fn_args) => {
+        let #arg_ident = deno_core::v8::Global::new(&mut #scope, #fn_args.this());
+      })
+    }
     Arg::Buffer(buffer_type, mode, source) => {
       // Explicit temporary lifetime extension so we can take a reference
       let temp = format_ident!("{}_temp", arg_ident);

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -96,6 +96,9 @@ impl TestObjectWrap {
   #[rename("with_RENAME")]
   fn with_rename(&self) {}
 
+  #[fast]
+  fn with_this(&self, #[this] _: v8::Global<v8::Object>) {}
+
   #[async_method]
   async fn with_async_fn(&self, #[smi] ms: u32) -> Result<(), JsErrorBox> {
     tokio::time::sleep(std::time::Duration::from_millis(ms as u64)).await;
@@ -107,9 +110,6 @@ impl TestObjectWrap {
   fn with_slow_getter(&self) -> String {
     String::from("getter")
   }
-
-  #[fast]
-  fn with_this(&self, #[this] _: v8::Global<v8::Object>) {}
 }
 
 pub struct DOMPoint {

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -107,6 +107,9 @@ impl TestObjectWrap {
   fn with_slow_getter(&self) -> String {
     String::from("getter")
   }
+
+  #[fast]
+  fn with_this(&self, #[this] _: v8::Global<v8::Object>) {}
 }
 
 pub struct DOMPoint {

--- a/testing/ops.d.ts
+++ b/testing/ops.d.ts
@@ -41,6 +41,7 @@ export class TestObjectWrap {
   withVarargs(...args: any[]): number;
   with_RENAME(): void;
   withAsyncFn(ms: number): Promise<void>;
+  withThis(): void;
 }
 
 export class TestEnumWrap {}

--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -111,5 +111,7 @@ test(async function testDomPoint() {
 
   await promise;
 
+  wrap.withThis();
+
   new TestEnumWrap();
 });

--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -104,14 +104,13 @@ test(async function testDomPoint() {
   assertEquals(wrap.withVarargs(), 0);
   assertEquals(wrap.withVarargs(undefined), 1);
 
+  wrap.withThis();
   wrap.with_RENAME();
 
   const promise = wrap.withAsyncFn(10);
   assert(promise instanceof Promise);
 
   await promise;
-
-  wrap.withThis();
 
   new TestEnumWrap();
 });


### PR DESCRIPTION
Example usage:

```rust
#[op2]
impl UnsafePointerView {
  #[cppgc]
  fn get_context(&self, #[this] this: v8::Global<v8::Object>) -> GPUCanvasContext {
    GPUCanvasContext { view: this }
  }
}

struct GPUCanvasContext {
  view: v8::Global<v8::Object>,
}

#[op2]
impl GPUCanvasContext {
  fn canvas(&self) -> v8::Global<v8::Object> { self.view.clone() }
}
```

`#[this]` works on both slow and fast calls.