### PR TITLE
fix: obj wrap async method registration

### DIFF
--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -395,6 +395,11 @@ pub(crate) fn initialize_deno_core_ops_bindings<'s>(
     let accessor_store = create_accessor_store(method_ctxs);
 
     for method in method_ctxs.iter() {
+      // Skip async methods, we are going to register them later.
+      if method.decl.is_async {
+        continue;
+      }
+
       op_ctx_template_or_accessor(
         &accessor_store,
         set_up_async_stub_fn,
@@ -416,6 +421,20 @@ pub(crate) fn initialize_deno_core_ops_bindings<'s>(
     }
 
     index += decl.static_methods.len();
+
+    // Register async methods at the end since we need to create the template instance.
+    for method in method_ctxs.iter() {
+      if method.decl.is_async {
+        op_ctx_template_or_accessor(
+          &accessor_store,
+          set_up_async_stub_fn,
+          scope,
+          prototype,
+          tmpl,
+          method,
+        );
+      }
+    }
 
     let op_fn = tmpl.get_function(scope).unwrap();
     op_fn.set_name(key);

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -96,14 +96,14 @@ impl TestObjectWrap {
   #[rename("with_RENAME")]
   fn with_rename(&self) {}
 
-  #[fast]
-  fn with_this(&self, #[this] _: v8::Global<v8::Object>) {}
-
   #[async_method]
   async fn with_async_fn(&self, #[smi] ms: u32) -> Result<(), JsErrorBox> {
     tokio::time::sleep(std::time::Duration::from_millis(ms as u64)).await;
     Ok(())
   }
+
+  #[fast]
+  fn with_this(&self, #[this] _: v8::Global<v8::Object>) {}
 
   #[getter]
   #[string]


### PR DESCRIPTION
The template cannot be modified after a new instance via `tmpl.get_function()` is created. This patch defers async method registration to happen after other ops.