### PR TITLE
fix(ext/net): node compatibility issue, expose fd using internal symbol in deno_core

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -644,6 +644,7 @@
   // Extra Deno.core.* exports
   const core = ObjectAssign(globalThis.Deno.core, {
     internalRidSymbol: Symbol("Deno.internal.rid"),
+    internalFdSymbol: Symbol("Deno.internal.fd"),
     resources,
     eventLoopTick,
     BadResource,


### PR DESCRIPTION

Please take a look at PR: https://github.com/denoland/deno/pull/27789
This change will help to expose fd to server when a socket connection is established.