### PR TITLE
Allow String as `execute_script` name parameter

### DIFF
--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1507,7 +1507,8 @@ impl JsRuntime {
   /// the global scope by default, and it is possible to maintain local JS state and invoke
   /// this method multiple times.
   ///
-  /// `name` can be a filepath or any other string, but it is required to be 7-bit ASCII, eg.
+  /// `name` may be any type that implements the internal [`IntoModuleName`] trait.
+  /// It can be a filepath or any other string, but it is required to be 7-bit ASCII, eg.
   ///
   ///   - "/some/file/path.js"
   ///   - "<anon>"
@@ -1523,13 +1524,13 @@ impl JsRuntime {
   /// `Error` can usually be downcast to `JsError`.
   pub fn execute_script(
     &mut self,
-    name: &'static str,
+    name: impl IntoModuleName,
     source_code: impl IntoModuleCodeString,
   ) -> Result<v8::Global<v8::Value>, CoreError> {
     let isolate = &mut self.inner.v8_isolate;
     self.inner.main_realm.execute_script(
       isolate,
-      FastString::from_static(name),
+      name.into_module_name(),
       source_code.into_module_code(),
     )
   }


### PR DESCRIPTION
This PR allows the String usage for `execute_script`
```rust
let mut runtime = JsRuntime::new(RuntimeOptions::default());

let id = 1;
let script_name = format!("script-{}", id);
let script_content = format!("console.log('{}')", id);
let result = runtime.execute_script(script_name, script_content).unwrap();
```