### PR TITLE
feat: optional code cache for extension sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,7 +1409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3058,9 +3058,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "130.0.8"
+version = "130.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be16314fd485983a2a2e001d90a959d6c7c3eb800a2f481b11104f76cd5608cd"
+checksum = "a511192602f7b435b0a241c1947aa743eb7717f20a9195f4b5e8ed1952e01db1"
 dependencies = [
  "bindgen",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ deno_ast = { version = "=0.44.0", features = ["transpiling"] }
 deno_core_icudata = "0.74.0"
 deno_error = { version = "0.5.5", features = ["serde_json", "serde", "url", "tokio"] }
 deno_unsync = "0.4.1"
-v8 = { version = "130.0.8", default-features = false }
+v8 = { version = "130.0.7", default-features = false }
 
 anyhow = "1"
 bencher = "0.1"

--- a/core/error.rs
+++ b/core/error.rs
@@ -81,6 +81,8 @@ pub enum CoreError {
   Module(ModuleConcreteError),
   #[error(transparent)]
   DataError(DataError),
+  #[error("Unable to get code cache from unbound module script for {0}")]
+  CreateCodeCache(String),
 }
 
 impl CoreError {
@@ -174,6 +176,7 @@ impl JsErrorClass for CoreError {
       | CoreError::MissingFromModuleMap(_)
       | CoreError::ExecutionTerminated
       | CoreError::PendingPromiseResolution
+      | CoreError::CreateCodeCache(_)
       | CoreError::EvaluateDynamicImportedModule => {
         Cow::Borrowed(GENERIC_ERROR)
       }
@@ -206,7 +209,8 @@ impl JsErrorClass for CoreError {
       | CoreError::FutureCanceled(_)
       | CoreError::ExecutionTerminated
       | CoreError::PendingPromiseResolution
-      | CoreError::EvaluateDynamicImportedModule => self.to_string().into(),
+      | CoreError::EvaluateDynamicImportedModule
+      | CoreError::CreateCodeCache(_) => self.to_string().into(),
     }
   }
 

--- a/core/inspector.rs
+++ b/core/inspector.rs
@@ -258,7 +258,7 @@ impl JsRuntimeInspector {
     let stack_trace = message.get_stack_trace(scope);
     let mut v8_inspector_ref = self.v8_inspector.borrow_mut();
     let v8_inspector = v8_inspector_ref.as_mut().unwrap();
-    let stack_trace = v8_inspector.create_stack_trace(stack_trace);
+    let stack_trace = v8_inspector.create_stack_trace(stack_trace.unwrap());
     v8_inspector.exception_thrown(
       context,
       if in_promise {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -107,6 +107,7 @@ pub use crate::module_specifier::resolve_url;
 pub use crate::module_specifier::ModuleResolutionError;
 pub use crate::module_specifier::ModuleSpecifier;
 pub use crate::modules::CustomModuleEvaluationKind;
+pub use crate::modules::ExtCodeCache;
 pub use crate::modules::FsModuleLoader;
 pub use crate::modules::ModuleCodeBytes;
 pub use crate::modules::ModuleCodeString;

--- a/core/modules/loaders.rs
+++ b/core/modules/loaders.rs
@@ -349,16 +349,9 @@ impl ModuleLoader for ExtModuleLoader {
     code_cache: &[u8],
   ) -> Pin<Box<dyn Future<Output = ()>>> {
     if let Some(ext_code_cache) = &self.ext_code_cache {
-      std::future::ready(ext_code_cache.code_cache_ready(
-        module_specifier,
-        hash,
-        code_cache,
-        true,
-      ))
-      .boxed_local()
-    } else {
-      std::future::ready(()).boxed_local()
+      ext_code_cache.code_cache_ready(module_specifier, hash, code_cache, true);
     }
+    std::future::ready(()).boxed_local()
   }
 }
 

--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -21,6 +21,7 @@ mod recursive_load;
 #[cfg(all(test, not(miri)))]
 mod tests;
 
+pub use loaders::ExtCodeCache;
 pub(crate) use loaders::ExtModuleLoader;
 pub use loaders::FsModuleLoader;
 pub(crate) use loaders::LazyEsmModuleLoader;

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -1946,7 +1946,7 @@ fn test_load_with_code_cache() {
 
 #[test]
 fn ext_module_loader_relative() {
-  let loader = ExtModuleLoader::new(vec![]);
+  let loader = ExtModuleLoader::new(vec![], None);
   let cases = [
     (
       ("../../foo.js", "ext:test/nested/mod/bar.js"),

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -3,6 +3,8 @@
 use super::exception_state::ExceptionState;
 #[cfg(test)]
 use super::op_driver::OpDriver;
+use crate::ModuleSourceCode;
+use crate::SourceCodeCacheInfo;
 use crate::_ops::OpMethodDecl;
 use crate::cppgc::FunctionTemplateData;
 use crate::error::exception_to_err_result;
@@ -338,6 +340,91 @@ impl JsRealm {
         return exception_to_err_result(tc_scope, exception, false, false);
       }
     };
+
+    match script.run(tc_scope) {
+      Some(value) => {
+        let value_handle = v8::Global::new(tc_scope, value);
+        Ok(value_handle)
+      }
+      None => {
+        assert!(tc_scope.has_caught());
+        let exception = tc_scope.exception().unwrap();
+        exception_to_err_result(tc_scope, exception, false, false)
+      }
+    }
+  }
+
+  pub fn execute_script_with_cache(
+    &self,
+    isolate: &mut v8::Isolate,
+    name: ModuleSpecifier,
+    source_code: impl IntoModuleCodeString,
+    get_cache: &dyn Fn(
+      &ModuleSpecifier,
+      &ModuleSourceCode,
+    ) -> SourceCodeCacheInfo,
+    cache_ready: &dyn Fn(ModuleSpecifier, u64, &[u8]),
+  ) -> Result<v8::Global<v8::Value>, CoreError> {
+    let scope = &mut self.0.handle_scope(isolate);
+
+    let specifier = name.clone();
+    let code = source_code.into_module_code();
+    let source = ModuleSourceCode::String(code);
+    let code_cache = get_cache(&name, &source);
+    let ModuleSourceCode::String(source) = source else {
+      unreachable!()
+    };
+    let name = name.into_module_name().v8_string(scope).unwrap();
+    let source = source.v8_string(scope).unwrap();
+    let origin = script_origin(scope, name, false, None);
+    let tc_scope = &mut v8::TryCatch::new(scope);
+
+    let (maybe_script, maybe_code_cache_hash) =
+      if let Some(data) = &code_cache.data {
+        let mut source = v8::script_compiler::Source::new_with_cached_data(
+          source,
+          Some(&origin),
+          v8::CachedData::new(data),
+        );
+        let script = v8::script_compiler::compile(
+          tc_scope,
+          &mut source,
+          v8::script_compiler::CompileOptions::ConsumeCodeCache,
+          v8::script_compiler::NoCacheReason::NoReason,
+        );
+        // Check if the provided code cache is rejected by V8.
+        let rejected = match source.get_cached_data() {
+          Some(cached_data) => cached_data.rejected(),
+          _ => true,
+        };
+        let maybe_code_cache_hash = if rejected {
+          Some(code_cache.hash) // recreate the cache
+        } else {
+          None
+        };
+        (Some(script), maybe_code_cache_hash)
+      } else {
+        (None, Some(code_cache.hash))
+      };
+
+    let script = maybe_script
+      .unwrap_or_else(|| v8::Script::compile(tc_scope, source, Some(&origin)));
+
+    let script = match script {
+      Some(script) => script,
+      None => {
+        let exception = tc_scope.exception().unwrap();
+        return exception_to_err_result(tc_scope, exception, false, false);
+      }
+    };
+
+    if let Some(code_cache_hash) = maybe_code_cache_hash {
+      let unbound_script = script.get_unbound_script(tc_scope);
+      let code_cache = unbound_script
+        .create_code_cache()
+        .ok_or_else(|| CoreError::CreateCodeCache(specifier.to_string()))?;
+      cache_ready(specifier, code_cache_hash, &code_cache);
+    }
 
     match script.run(tc_scope) {
       Some(value) => {

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -354,6 +354,8 @@ impl JsRealm {
     }
   }
 
+  // TODO(nathanwhit): reduce duplication between this and `execute_script`, and
+  // try to factor out the code cache logic to share with `op_eval_context`
   pub fn execute_script_with_cache(
     &self,
     isolate: &mut v8::Isolate,

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -1399,12 +1399,12 @@ impl JsRuntime {
       };
 
       let isolate = self.v8_isolate();
-      let mut scope = &mut realm.handle_scope(isolate);
+      let scope = &mut realm.handle_scope(isolate);
       module_map.mod_evaluate_sync(scope, mod_id)?;
       let mut cx = Context::from_waker(futures::task::noop_waker_ref());
       // poll once so code cache is populated. the `ExtCodeCache` trait is sync, so
       // the `CodeCacheReady` futures will always finish on the first poll.
-      let _ = module_map.poll_progress(&mut cx, &mut scope);
+      let _ = module_map.poll_progress(&mut cx, scope);
     }
 
     #[cfg(debug_assertions)]


### PR DESCRIPTION
Wires up the code cache through the `ExtModuleLoader` and extension initialization, so that embedders can use the V8 code cache on extension sources.