### PR TITLE
revert: Fix `create_stack_trace` from empty trace (#1064)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3058,9 +3058,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "130.0.7"
+version = "130.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a511192602f7b435b0a241c1947aa743eb7717f20a9195f4b5e8ed1952e01db1"
+checksum = "fd4499ccf83cf7c0e8dfeaa086044fbe9552b2d401aa142ea3d693276dac277d"
 dependencies = [
  "bindgen",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ deno_ast = { version = "=0.44.0", features = ["transpiling"] }
 deno_core_icudata = "0.74.0"
 deno_error = { version = "0.5.5", features = ["serde_json", "serde", "url", "tokio"] }
 deno_unsync = "0.4.1"
-v8 = { version = "130.0.7", default-features = false }
+v8 = { version = "130.0.6", default-features = false }
 
 anyhow = "1"
 bencher = "0.1"

--- a/core/inspector.rs
+++ b/core/inspector.rs
@@ -255,7 +255,7 @@ impl JsRuntimeInspector {
   ) {
     let context = scope.get_current_context();
     let message = v8::Exception::create_message(scope, exception);
-    let stack_trace = message.get_stack_trace(scope).unwrap();
+    let stack_trace = message.get_stack_trace(scope);
     let mut v8_inspector_ref = self.v8_inspector.borrow_mut();
     let v8_inspector = v8_inspector_ref.as_mut().unwrap();
     let stack_trace = v8_inspector.create_stack_trace(stack_trace.unwrap());

--- a/core/inspector.rs
+++ b/core/inspector.rs
@@ -255,7 +255,7 @@ impl JsRuntimeInspector {
   ) {
     let context = scope.get_current_context();
     let message = v8::Exception::create_message(scope, exception);
-    let stack_trace = message.get_stack_trace(scope);
+    let stack_trace = message.get_stack_trace(scope).unwrap();
     let mut v8_inspector_ref = self.v8_inspector.borrow_mut();
     let v8_inspector = v8_inspector_ref.as_mut().unwrap();
     let stack_trace = v8_inspector.create_stack_trace(stack_trace.unwrap());


### PR DESCRIPTION
This commit reverts
https://github.com/denoland/deno_core/commit/a29392c83459a33a2bf5602c5c6736cf24fb783a.

This is a temporary measure and that commit will be relanded,
but right now it's blocking other fixes in `deno_core`
due to using semver incompatible version of rusty_v8.