### PR TITLE
feat: Upgrade V8 to 13.4

### DIFF
--- a/.github/workflows/ci-job.yml
+++ b/.github/workflows/ci-job.yml
@@ -50,6 +50,12 @@ jobs:
       - name: Install Rust
         uses: dsherret/rust-toolchain-file@v1
 
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
+      - name: Install nextest
+        run: cargo binstall cargo-nextest --secure
+
       - name: Install Deno
         uses: denoland/setup-deno@v1
 

--- a/.github/workflows/ci-test-ops/action.yml
+++ b/.github/workflows/ci-test-ops/action.yml
@@ -5,4 +5,4 @@ runs:
     - name: Cargo test (ops)
       shell: bash
       run: |-
-        cargo test --workspace --release -p deno_ops_compile_test_runner
+        cargo nextest run --workspace --release -p deno_ops_compile_test_runner

--- a/.github/workflows/ci-test-valgrind/action.yml
+++ b/.github/workflows/ci-test-valgrind/action.yml
@@ -15,4 +15,4 @@ runs:
           valgrind --error-exitcode=1 --leak-check=no
           --suppressions=/home/runner/work/deno_core/deno_core/.github/workflows/ci-test-valgrind/suppressions.txt
           --gen-suppressions=all" \
-          cargo test -p deno_core -p deno_core_testing -p serde_v8 --release
+          cargo nextest run -p deno_core -p deno_core_testing -p serde_v8 --release

--- a/.github/workflows/ci-test/action.yml
+++ b/.github/workflows/ci-test/action.yml
@@ -5,7 +5,7 @@ runs:
     - name: Cargo test
       shell: bash
       run: |-
-        cargo test --workspace --release --all-features --tests --examples --exclude deno_ops_compile_test_runner
+        cargo nextest run --workspace --release --all-features --tests --examples --exclude deno_ops_compile_test_runner
         cargo test --doc
 
     - name: Run examples

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,7 +1409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -3059,6 +3059,8 @@ dependencies = [
 [[package]]
 name = "v8"
 version = "134.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a7bf4d0c2b03c45fcac29740cd38b695c4b07ebec9bef7ea60801e2b285204"
 dependencies = [
  "bindgen",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3058,9 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "130.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a511192602f7b435b0a241c1947aa743eb7717f20a9195f4b5e8ed1952e01db1"
+version = "134.3.0"
 dependencies = [
  "bindgen",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ deno_ast = { version = "=0.44.0", features = ["transpiling"] }
 deno_core_icudata = "0.74.0"
 deno_error = { version = "0.5.5", features = ["serde_json", "serde", "url", "tokio"] }
 deno_unsync = "0.4.1"
-v8 = { version = "130.0.7", default-features = false }
+v8 = { version = "134.3.0", default-features = false }
 
 anyhow = "1"
 bencher = "0.1"

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -171,7 +171,7 @@ extern "C" fn noop() {}
 
 const NOOP_FN: CFunction = CFunction::new(
   noop as _,
-  &CFunctionInfo::new(Type::Void.scalar(), &[], Int64Representation::Number),
+  &CFunctionInfo::new(Type::Void.as_info(), &[], Int64Representation::Number),
 );
 
 // Declaration for object wrappers.

--- a/core/inspector.rs
+++ b/core/inspector.rs
@@ -258,7 +258,7 @@ impl JsRuntimeInspector {
     let stack_trace = message.get_stack_trace(scope);
     let mut v8_inspector_ref = self.v8_inspector.borrow_mut();
     let v8_inspector = v8_inspector_ref.as_mut().unwrap();
-    let stack_trace = v8_inspector.create_stack_trace(stack_trace.unwrap());
+    let stack_trace = v8_inspector.create_stack_trace(stack_trace);
     v8_inspector.exception_thrown(
       context,
       if in_promise {

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -13,7 +13,6 @@ use std::borrow::Cow;
 use std::ffi::c_void;
 use std::mem::MaybeUninit;
 use std::ptr::NonNull;
-use v8::WriteOptions;
 
 /// The default string buffer size on the stack that prevents mallocs in some
 /// string functions. Keep in mind that Windows only offers 1MB stacks by default,
@@ -314,11 +313,11 @@ pub fn to_cow_one_byte(
   // Create an uninitialized buffer of `capacity` bytes.
   let mut buffer = Vec::<u8>::with_capacity(capacity);
   // Write the buffer to a slice made from this uninitialized data
-  string.write_one_byte_uninit(
+  string.write_one_byte_uninit_v2(
     scope,
-    buffer.spare_capacity_mut(),
     0,
-    WriteOptions::NO_NULL_TERMINATION,
+    buffer.spare_capacity_mut(),
+    v8::WriteFlags::empty(),
   );
 
   // SAFETY: We initialized bytes from `0..capacity` in

--- a/ops/op2/test_cases/async/async_deferred.out
+++ b/ops/op2/test_cases/async/async_deferred.out
@@ -22,15 +22,14 @@ pub const fn op_async_deferred() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
+                            CType::V8Value.as_info(),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
-                            CType::CallbackOptions.scalar(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -42,15 +41,14 @@ pub const fn op_async_deferred() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
+                            CType::V8Value.as_info(),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
-                            CType::CallbackOptions.scalar(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),

--- a/ops/op2/test_cases/async/async_lazy.out
+++ b/ops/op2/test_cases/async/async_lazy.out
@@ -22,15 +22,14 @@ pub const fn op_async_lazy() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
+                            CType::V8Value.as_info(),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
-                            CType::CallbackOptions.scalar(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -42,15 +41,14 @@ pub const fn op_async_lazy() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
+                            CType::V8Value.as_info(),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
-                            CType::CallbackOptions.scalar(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),

--- a/ops/op2/test_cases/sync/add.out
+++ b/ops/op2/test_cases/sync/add.out
@@ -24,19 +24,16 @@ const fn op_add() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Uint32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
                         &[
-                            CType::V8Value.scalar(),
+                            CType::V8Value.as_info(),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Uint32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Uint32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                         ],
@@ -52,22 +49,19 @@ const fn op_add() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Uint32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
                         &[
-                            CType::V8Value.scalar(),
+                            CType::V8Value.as_info(),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Uint32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Uint32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
-                            CType::CallbackOptions.scalar(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),

--- a/ops/op2/test_cases/sync/bigint.out
+++ b/ops/op2/test_cases/sync/bigint.out
@@ -22,8 +22,8 @@ pub const fn op_bigint() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Uint64.scalar(),
-                        &[CType::V8Value.scalar()],
+                        CType::Uint64.as_info(),
+                        &[CType::V8Value.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -34,8 +34,8 @@ pub const fn op_bigint() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Uint64.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Uint64.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )

--- a/ops/op2/test_cases/sync/bool.out
+++ b/ops/op2/test_cases/sync/bool.out
@@ -22,8 +22,8 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Bool.scalar(),
-                        &[CType::V8Value.scalar(), CType::Bool.scalar()],
+                        CType::Bool.as_info(),
+                        &[CType::V8Value.as_info(), CType::Bool.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -34,11 +34,11 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Bool.scalar(),
+                        CType::Bool.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::Bool.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::Bool.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),

--- a/ops/op2/test_cases/sync/bool_result.out
+++ b/ops/op2/test_cases/sync/bool_result.out
@@ -22,11 +22,11 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Bool.scalar(),
+                        CType::Bool.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::Bool.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::Bool.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -38,11 +38,11 @@ pub const fn op_bool() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Bool.scalar(),
+                        CType::Bool.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::Bool.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::Bool.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),

--- a/ops/op2/test_cases/sync/buffers.out
+++ b/ops/op2/test_cases/sync/buffers.out
@@ -22,13 +22,14 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::Uint8.typed_array(),
-                            CType::Uint8.typed_array(),
-                            CType::Uint8.typed_array(),
-                            CType::Uint8.typed_array(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -40,14 +41,14 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::Uint8.typed_array(),
-                            CType::Uint8.typed_array(),
-                            CType::Uint8.typed_array(),
-                            CType::Uint8.typed_array(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -65,10 +66,10 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-            arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-            arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-            arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+            arg0: deno_core::v8::Local<deno_core::v8::Value>,
+            arg1: deno_core::v8::Local<deno_core::v8::Value>,
+            arg2: deno_core::v8::Local<deno_core::v8::Value>,
+            arg3: deno_core::v8::Local<deno_core::v8::Value>,
             fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
                 's,
             >,
@@ -86,7 +87,14 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-            let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
+            let res = Self::v8_fn_ptr_fast(
+                this,
+                arg0,
+                arg1,
+                arg2,
+                arg3,
+                fast_api_callback_options,
+            );
             deno_core::_ops::dispatch_metrics_fast(
                 opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
@@ -96,35 +104,125 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-            arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-            arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-            arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+            arg0: deno_core::v8::Local<deno_core::v8::Value>,
+            arg1: deno_core::v8::Local<deno_core::v8::Value>,
+            arg2: deno_core::v8::Local<deno_core::v8::Value>,
+            arg3: deno_core::v8::Local<deno_core::v8::Value>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
             let result = {
-                let arg0 = unsafe { &*arg0 }
-                    .get_storage_if_aligned()
-                    .expect("Invalid buffer");
+                let Ok(arg0) = arg0.try_cast::<deno_core::v8::ArrayBufferView>() else {
+                    {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(
+                                &*fast_api_callback_options,
+                            )
+                        };
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "expected ArrayBufferView",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
+                };
+                let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
+                let arg0 = unsafe {
+                    let (input_ptr, input_len) = arg0
+                        .get_contents_raw_parts(&mut buffer);
+                    let slice = ::std::slice::from_raw_parts_mut(input_ptr, input_len);
+                    let (before, slice, after) = slice.align_to_mut();
+                    debug_assert!(before.is_empty());
+                    debug_assert!(after.is_empty());
+                    slice
+                };
                 let arg0 = arg0;
-                let arg1 = unsafe { &*arg1 }
-                    .get_storage_if_aligned()
-                    .expect("Invalid buffer");
+                let Ok(arg1) = arg1.try_cast::<deno_core::v8::ArrayBufferView>() else {
+                    {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(
+                                &*fast_api_callback_options,
+                            )
+                        };
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "expected ArrayBufferView",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
+                };
+                let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
+                let arg1 = unsafe {
+                    let (input_ptr, input_len) = arg1
+                        .get_contents_raw_parts(&mut buffer);
+                    let slice = ::std::slice::from_raw_parts_mut(input_ptr, input_len);
+                    let (before, slice, after) = slice.align_to_mut();
+                    debug_assert!(before.is_empty());
+                    debug_assert!(after.is_empty());
+                    slice
+                };
                 let arg1 = arg1;
-                let arg2 = unsafe { &*arg2 }
-                    .get_storage_if_aligned()
-                    .expect("Invalid buffer");
+                let Ok(arg2) = arg2.try_cast::<deno_core::v8::ArrayBufferView>() else {
+                    {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(
+                                &*fast_api_callback_options,
+                            )
+                        };
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "expected ArrayBufferView",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
+                };
+                let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
+                let arg2 = unsafe {
+                    let (input_ptr, input_len) = arg2
+                        .get_contents_raw_parts(&mut buffer);
+                    let slice = ::std::slice::from_raw_parts_mut(input_ptr, input_len);
+                    let (before, slice, after) = slice.align_to_mut();
+                    debug_assert!(before.is_empty());
+                    debug_assert!(after.is_empty());
+                    slice
+                };
                 let arg2 = if arg2.len() == 0 {
                     ::std::ptr::null_mut()
                 } else {
                     arg2.as_mut_ptr() as _
                 };
-                let arg3 = unsafe { &*arg3 }
-                    .get_storage_if_aligned()
-                    .expect("Invalid buffer");
+                let Ok(arg3) = arg3.try_cast::<deno_core::v8::ArrayBufferView>() else {
+                    {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(
+                                &*fast_api_callback_options,
+                            )
+                        };
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "expected ArrayBufferView",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
+                };
+                let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
+                let arg3 = unsafe {
+                    let (input_ptr, input_len) = arg3
+                        .get_contents_raw_parts(&mut buffer);
+                    let slice = ::std::slice::from_raw_parts_mut(input_ptr, input_len);
+                    let (before, slice, after) = slice.align_to_mut();
+                    debug_assert!(before.is_empty());
+                    debug_assert!(after.is_empty());
+                    slice
+                };
                 let arg3 = if arg3.len() == 0 {
                     ::std::ptr::null_mut()
                 } else {
@@ -265,13 +363,14 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::Uint32.typed_array(),
-                            CType::Uint32.typed_array(),
-                            CType::Uint32.typed_array(),
-                            CType::Uint32.typed_array(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -283,14 +382,14 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::Uint32.typed_array(),
-                            CType::Uint32.typed_array(),
-                            CType::Uint32.typed_array(),
-                            CType::Uint32.typed_array(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -308,10 +407,10 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-            arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-            arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-            arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+            arg0: deno_core::v8::Local<deno_core::v8::Value>,
+            arg1: deno_core::v8::Local<deno_core::v8::Value>,
+            arg2: deno_core::v8::Local<deno_core::v8::Value>,
+            arg3: deno_core::v8::Local<deno_core::v8::Value>,
             fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
                 's,
             >,
@@ -329,7 +428,14 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-            let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2, arg3);
+            let res = Self::v8_fn_ptr_fast(
+                this,
+                arg0,
+                arg1,
+                arg2,
+                arg3,
+                fast_api_callback_options,
+            );
             deno_core::_ops::dispatch_metrics_fast(
                 opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
@@ -339,35 +445,125 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-            arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-            arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-            arg3: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+            arg0: deno_core::v8::Local<deno_core::v8::Value>,
+            arg1: deno_core::v8::Local<deno_core::v8::Value>,
+            arg2: deno_core::v8::Local<deno_core::v8::Value>,
+            arg3: deno_core::v8::Local<deno_core::v8::Value>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
             let result = {
-                let arg0 = unsafe { &*arg0 }
-                    .get_storage_if_aligned()
-                    .expect("Invalid buffer");
+                let Ok(arg0) = arg0.try_cast::<deno_core::v8::ArrayBufferView>() else {
+                    {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(
+                                &*fast_api_callback_options,
+                            )
+                        };
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "expected ArrayBufferView",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
+                };
+                let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
+                let arg0 = unsafe {
+                    let (input_ptr, input_len) = arg0
+                        .get_contents_raw_parts(&mut buffer);
+                    let slice = ::std::slice::from_raw_parts_mut(input_ptr, input_len);
+                    let (before, slice, after) = slice.align_to_mut();
+                    debug_assert!(before.is_empty());
+                    debug_assert!(after.is_empty());
+                    slice
+                };
                 let arg0 = arg0;
-                let arg1 = unsafe { &*arg1 }
-                    .get_storage_if_aligned()
-                    .expect("Invalid buffer");
+                let Ok(arg1) = arg1.try_cast::<deno_core::v8::ArrayBufferView>() else {
+                    {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(
+                                &*fast_api_callback_options,
+                            )
+                        };
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "expected ArrayBufferView",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
+                };
+                let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
+                let arg1 = unsafe {
+                    let (input_ptr, input_len) = arg1
+                        .get_contents_raw_parts(&mut buffer);
+                    let slice = ::std::slice::from_raw_parts_mut(input_ptr, input_len);
+                    let (before, slice, after) = slice.align_to_mut();
+                    debug_assert!(before.is_empty());
+                    debug_assert!(after.is_empty());
+                    slice
+                };
                 let arg1 = arg1;
-                let arg2 = unsafe { &*arg2 }
-                    .get_storage_if_aligned()
-                    .expect("Invalid buffer");
+                let Ok(arg2) = arg2.try_cast::<deno_core::v8::ArrayBufferView>() else {
+                    {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(
+                                &*fast_api_callback_options,
+                            )
+                        };
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "expected ArrayBufferView",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
+                };
+                let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
+                let arg2 = unsafe {
+                    let (input_ptr, input_len) = arg2
+                        .get_contents_raw_parts(&mut buffer);
+                    let slice = ::std::slice::from_raw_parts_mut(input_ptr, input_len);
+                    let (before, slice, after) = slice.align_to_mut();
+                    debug_assert!(before.is_empty());
+                    debug_assert!(after.is_empty());
+                    slice
+                };
                 let arg2 = if arg2.len() == 0 {
                     ::std::ptr::null_mut()
                 } else {
                     arg2.as_mut_ptr() as _
                 };
-                let arg3 = unsafe { &*arg3 }
-                    .get_storage_if_aligned()
-                    .expect("Invalid buffer");
+                let Ok(arg3) = arg3.try_cast::<deno_core::v8::ArrayBufferView>() else {
+                    {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(
+                                &*fast_api_callback_options,
+                            )
+                        };
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "expected ArrayBufferView",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
+                };
+                let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
+                let arg3 = unsafe {
+                    let (input_ptr, input_len) = arg3
+                        .get_contents_raw_parts(&mut buffer);
+                    let slice = ::std::slice::from_raw_parts_mut(input_ptr, input_len);
+                    let (before, slice, after) = slice.align_to_mut();
+                    debug_assert!(before.is_empty());
+                    debug_assert!(after.is_empty());
+                    slice
+                };
                 let arg3 = if arg3.len() == 0 {
                     ::std::ptr::null_mut()
                 } else {

--- a/ops/op2/test_cases/sync/buffers_copy.out
+++ b/ops/op2/test_cases/sync/buffers_copy.out
@@ -22,12 +22,13 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::Uint8.typed_array(),
-                            CType::Uint8.typed_array(),
-                            CType::Uint8.typed_array(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -39,13 +40,13 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::Uint8.typed_array(),
-                            CType::Uint8.typed_array(),
-                            CType::Uint8.typed_array(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -63,9 +64,9 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-            arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-            arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+            arg0: deno_core::v8::Local<deno_core::v8::Value>,
+            arg1: deno_core::v8::Local<deno_core::v8::Value>,
+            arg2: deno_core::v8::Local<deno_core::v8::Value>,
             fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
                 's,
             >,
@@ -83,7 +84,13 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
                 opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-            let res = Self::v8_fn_ptr_fast(this, arg0, arg1, arg2);
+            let res = Self::v8_fn_ptr_fast(
+                this,
+                arg0,
+                arg1,
+                arg2,
+                fast_api_callback_options,
+            );
             deno_core::_ops::dispatch_metrics_fast(
                 opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
@@ -93,26 +100,95 @@ const fn op_buffers() -> ::deno_core::_ops::OpDecl {
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-            arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
-            arg2: *mut deno_core::v8::fast_api::FastApiTypedArray<u8>,
+            arg0: deno_core::v8::Local<deno_core::v8::Value>,
+            arg1: deno_core::v8::Local<deno_core::v8::Value>,
+            arg2: deno_core::v8::Local<deno_core::v8::Value>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
             let result = {
-                let arg0 = unsafe { &*arg0 }
-                    .get_storage_if_aligned()
-                    .expect("Invalid buffer");
+                let Ok(arg0) = arg0.try_cast::<deno_core::v8::ArrayBufferView>() else {
+                    {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(
+                                &*fast_api_callback_options,
+                            )
+                        };
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "expected ArrayBufferView",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
+                };
+                let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
+                let arg0 = unsafe {
+                    let (input_ptr, input_len) = arg0
+                        .get_contents_raw_parts(&mut buffer);
+                    let slice = ::std::slice::from_raw_parts_mut(input_ptr, input_len);
+                    let (before, slice, after) = slice.align_to_mut();
+                    debug_assert!(before.is_empty());
+                    debug_assert!(after.is_empty());
+                    slice
+                };
                 let arg0 = arg0.to_vec();
-                let arg1 = unsafe { &*arg1 }
-                    .get_storage_if_aligned()
-                    .expect("Invalid buffer");
+                let Ok(arg1) = arg1.try_cast::<deno_core::v8::ArrayBufferView>() else {
+                    {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(
+                                &*fast_api_callback_options,
+                            )
+                        };
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "expected ArrayBufferView",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
+                };
+                let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
+                let arg1 = unsafe {
+                    let (input_ptr, input_len) = arg1
+                        .get_contents_raw_parts(&mut buffer);
+                    let slice = ::std::slice::from_raw_parts_mut(input_ptr, input_len);
+                    let (before, slice, after) = slice.align_to_mut();
+                    debug_assert!(before.is_empty());
+                    debug_assert!(after.is_empty());
+                    slice
+                };
                 let arg1 = arg1.to_vec().into_boxed_slice();
-                let arg2 = unsafe { &*arg2 }
-                    .get_storage_if_aligned()
-                    .expect("Invalid buffer");
+                let Ok(arg2) = arg2.try_cast::<deno_core::v8::ArrayBufferView>() else {
+                    {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(
+                                &*fast_api_callback_options,
+                            )
+                        };
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "expected ArrayBufferView",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
+                };
+                let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
+                let arg2 = unsafe {
+                    let (input_ptr, input_len) = arg2
+                        .get_contents_raw_parts(&mut buffer);
+                    let slice = ::std::slice::from_raw_parts_mut(input_ptr, input_len);
+                    let (before, slice, after) = slice.align_to_mut();
+                    debug_assert!(before.is_empty());
+                    debug_assert!(after.is_empty());
+                    slice
+                };
                 let arg2 = arg2.to_vec().into();
                 Self::call(arg0, arg1, arg2)
             };
@@ -231,11 +307,12 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::Uint32.typed_array(),
-                            CType::Uint32.typed_array(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -247,12 +324,12 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::Uint32.typed_array(),
-                            CType::Uint32.typed_array(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -270,8 +347,8 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast_metrics<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-            arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+            arg0: deno_core::v8::Local<deno_core::v8::Value>,
+            arg1: deno_core::v8::Local<deno_core::v8::Value>,
             fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
                 's,
             >,
@@ -289,7 +366,7 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
                 opctx,
                 deno_core::_ops::OpMetricsEvent::Dispatched,
             );
-            let res = Self::v8_fn_ptr_fast(this, arg0, arg1);
+            let res = Self::v8_fn_ptr_fast(this, arg0, arg1, fast_api_callback_options);
             deno_core::_ops::dispatch_metrics_fast(
                 opctx,
                 deno_core::_ops::OpMetricsEvent::Completed,
@@ -299,21 +376,69 @@ const fn op_buffers_32() -> ::deno_core::_ops::OpDecl {
         #[allow(clippy::too_many_arguments)]
         extern "C" fn v8_fn_ptr_fast<'s>(
             this: deno_core::v8::Local<deno_core::v8::Object>,
-            arg0: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
-            arg1: *mut deno_core::v8::fast_api::FastApiTypedArray<u32>,
+            arg0: deno_core::v8::Local<deno_core::v8::Value>,
+            arg1: deno_core::v8::Local<deno_core::v8::Value>,
+            fast_api_callback_options: *mut deno_core::v8::fast_api::FastApiCallbackOptions<
+                's,
+            >,
         ) -> () {
             #[cfg(debug_assertions)]
             let _reentrancy_check_guard = deno_core::_ops::reentrancy_check(
                 &<Self as deno_core::_ops::Op>::DECL,
             );
+            let fast_api_callback_options: &'s mut _ = unsafe {
+                &mut *fast_api_callback_options
+            };
             let result = {
-                let arg0 = unsafe { &*arg0 }
-                    .get_storage_if_aligned()
-                    .expect("Invalid buffer");
+                let Ok(arg0) = arg0.try_cast::<deno_core::v8::ArrayBufferView>() else {
+                    {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(
+                                &*fast_api_callback_options,
+                            )
+                        };
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "expected ArrayBufferView",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
+                };
+                let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
+                let arg0 = unsafe {
+                    let (input_ptr, input_len) = arg0
+                        .get_contents_raw_parts(&mut buffer);
+                    let slice = ::std::slice::from_raw_parts_mut(input_ptr, input_len);
+                    let (before, slice, after) = slice.align_to_mut();
+                    debug_assert!(before.is_empty());
+                    debug_assert!(after.is_empty());
+                    slice
+                };
                 let arg0 = arg0.to_vec();
-                let arg1 = unsafe { &*arg1 }
-                    .get_storage_if_aligned()
-                    .expect("Invalid buffer");
+                let Ok(arg1) = arg1.try_cast::<deno_core::v8::ArrayBufferView>() else {
+                    {
+                        let mut scope = unsafe {
+                            deno_core::v8::CallbackScope::new(
+                                &*fast_api_callback_options,
+                            )
+                        };
+                        deno_core::_ops::throw_error_one_byte(
+                            &mut scope,
+                            "expected ArrayBufferView",
+                        );
+                        return unsafe { std::mem::zeroed() };
+                    }
+                };
+                let mut buffer = [0; ::deno_core::v8::TYPED_ARRAY_MAX_SIZE_IN_HEAP];
+                let arg1 = unsafe {
+                    let (input_ptr, input_len) = arg1
+                        .get_contents_raw_parts(&mut buffer);
+                    let slice = ::std::slice::from_raw_parts_mut(input_ptr, input_len);
+                    let (before, slice, after) = slice.align_to_mut();
+                    debug_assert!(before.is_empty());
+                    debug_assert!(after.is_empty());
+                    slice
+                };
                 let arg1 = arg1.to_vec().into_boxed_slice();
                 Self::call(arg0, arg1)
             };

--- a/ops/op2/test_cases/sync/cfg.out
+++ b/ops/op2/test_cases/sync/cfg.out
@@ -24,8 +24,8 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -36,8 +36,8 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -171,8 +171,8 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -183,8 +183,8 @@ pub const fn op_maybe_windows() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )

--- a/ops/op2/test_cases/sync/clippy_allow.out
+++ b/ops/op2/test_cases/sync/clippy_allow.out
@@ -24,8 +24,8 @@ pub const fn op_extra_annotation() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -36,8 +36,8 @@ pub const fn op_extra_annotation() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -169,8 +169,8 @@ pub const fn op_clippy_internal() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -181,8 +181,8 @@ pub const fn op_clippy_internal() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )

--- a/ops/op2/test_cases/sync/cppgc_resource.out
+++ b/ops/op2/test_cases/sync/cppgc_resource.out
@@ -22,11 +22,11 @@ const fn op_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::V8Value.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -38,11 +38,11 @@ const fn op_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::V8Value.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -215,11 +215,11 @@ const fn op_option_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::V8Value.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -231,11 +231,11 @@ const fn op_option_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::V8Value.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -510,11 +510,11 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::V8Value.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -526,11 +526,11 @@ const fn op_use_cppgc_object() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::V8Value.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -800,11 +800,11 @@ const fn op_use_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::V8Value.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -816,11 +816,11 @@ const fn op_use_cppgc_object_option() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::V8Value.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),

--- a/ops/op2/test_cases/sync/doc_comment.out
+++ b/ops/op2/test_cases/sync/doc_comment.out
@@ -23,8 +23,8 @@ pub const fn op_has_doc_comment() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -35,8 +35,8 @@ pub const fn op_has_doc_comment() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )

--- a/ops/op2/test_cases/sync/fast_alternative.out
+++ b/ops/op2/test_cases/sync/fast_alternative.out
@@ -128,19 +128,16 @@ const fn op_fast() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Uint32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
                         &[
-                            CType::V8Value.scalar(),
+                            CType::V8Value.as_info(),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Uint32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Uint32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                         ],
@@ -156,22 +153,19 @@ const fn op_fast() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Uint32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
                         &[
-                            CType::V8Value.scalar(),
+                            CType::V8Value.as_info(),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Uint32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Uint32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
-                            CType::CallbackOptions.scalar(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -435,19 +429,16 @@ const fn op_fast_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Uint32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
                         &[
-                            CType::V8Value.scalar(),
+                            CType::V8Value.as_info(),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Uint32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Uint32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                         ],
@@ -463,22 +454,19 @@ const fn op_fast_generic<T: Trait>() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Uint32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
                         &[
-                            CType::V8Value.scalar(),
+                            CType::V8Value.as_info(),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Uint32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Uint32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
-                            CType::CallbackOptions.scalar(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),

--- a/ops/op2/test_cases/sync/generics.out
+++ b/ops/op2/test_cases/sync/generics.out
@@ -22,8 +22,8 @@ pub const fn op_generics<T: Trait>() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -34,8 +34,8 @@ pub const fn op_generics<T: Trait>() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -165,8 +165,8 @@ pub const fn op_generics_static<T: Trait + 'static>() -> ::deno_core::_ops::OpDe
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -177,8 +177,8 @@ pub const fn op_generics_static<T: Trait + 'static>() -> ::deno_core::_ops::OpDe
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -308,8 +308,8 @@ pub const fn op_generics_static_where<T: Trait + 'static>() -> ::deno_core::_ops
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -320,8 +320,8 @@ pub const fn op_generics_static_where<T: Trait + 'static>() -> ::deno_core::_ops
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )

--- a/ops/op2/test_cases/sync/object_wrap.out
+++ b/ops/op2/test_cases/sync/object_wrap.out
@@ -497,8 +497,11 @@ impl Foo {
                     deno_core::v8::fast_api::CFunction::new(
                         Self::v8_fn_ptr_fast as _,
                         &deno_core::v8::fast_api::CFunctionInfo::new(
-                            CType::Void.scalar(),
-                            &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                            CType::Void.as_info(),
+                            &[
+                                CType::V8Value.as_info(),
+                                CType::CallbackOptions.as_info(),
+                            ],
                             deno_core::v8::fast_api::Int64Representation::BigInt,
                         ),
                     )
@@ -509,8 +512,11 @@ impl Foo {
                     deno_core::v8::fast_api::CFunction::new(
                         Self::v8_fn_ptr_fast_metrics as _,
                         &deno_core::v8::fast_api::CFunctionInfo::new(
-                            CType::Void.scalar(),
-                            &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                            CType::Void.as_info(),
+                            &[
+                                CType::V8Value.as_info(),
+                                CType::CallbackOptions.as_info(),
+                            ],
                             deno_core::v8::fast_api::Int64Representation::BigInt,
                         ),
                     )

--- a/ops/op2/test_cases/sync/op_state_attr.out
+++ b/ops/op2/test_cases/sync/op_state_attr.out
@@ -22,8 +22,8 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -34,8 +34,8 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )

--- a/ops/op2/test_cases/sync/op_state_rc.out
+++ b/ops/op2/test_cases/sync/op_state_rc.out
@@ -22,8 +22,8 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -34,8 +34,8 @@ const fn op_state_rc() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )

--- a/ops/op2/test_cases/sync/op_state_ref.out
+++ b/ops/op2/test_cases/sync/op_state_ref.out
@@ -22,8 +22,8 @@ const fn op_state_ref() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -34,8 +34,8 @@ const fn op_state_ref() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -193,8 +193,8 @@ const fn op_state_mut() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -205,8 +205,8 @@ const fn op_state_mut() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -472,11 +472,11 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::V8Value.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -488,11 +488,11 @@ const fn op_state_and_v8_local() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::V8Value.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),

--- a/ops/op2/test_cases/sync/result_external.out
+++ b/ops/op2/test_cases/sync/result_external.out
@@ -22,8 +22,8 @@ pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Pointer.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Pointer.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -34,8 +34,8 @@ pub const fn op_external_with_result() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Pointer.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Pointer.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )

--- a/ops/op2/test_cases/sync/result_primitive.out
+++ b/ops/op2/test_cases/sync/result_primitive.out
@@ -24,10 +24,9 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Uint32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -40,10 +39,9 @@ pub const fn op_u32_with_result() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Uint32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )

--- a/ops/op2/test_cases/sync/result_scope.out
+++ b/ops/op2/test_cases/sync/result_scope.out
@@ -22,8 +22,8 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -34,8 +34,8 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )

--- a/ops/op2/test_cases/sync/result_void.out
+++ b/ops/op2/test_cases/sync/result_void.out
@@ -22,8 +22,8 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -34,8 +34,8 @@ pub const fn op_void_with_result() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )

--- a/ops/op2/test_cases/sync/smi.out
+++ b/ops/op2/test_cases/sync/smi.out
@@ -24,29 +24,24 @@ const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Int32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
                         &[
-                            CType::V8Value.scalar(),
+                            CType::V8Value.as_info(),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                         ],
@@ -62,32 +57,27 @@ const fn op_smi_unsigned_return() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Int32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
                         &[
-                            CType::V8Value.scalar(),
+                            CType::V8Value.as_info(),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
-                            CType::CallbackOptions.scalar(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -271,29 +261,24 @@ const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Int32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
                         &[
-                            CType::V8Value.scalar(),
+                            CType::V8Value.as_info(),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                         ],
@@ -309,32 +294,27 @@ const fn op_smi_signed_return() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Int32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
                         &[
-                            CType::V8Value.scalar(),
+                            CType::V8Value.as_info(),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
                             v8::fast_api::CTypeInfo::new(
                                 CType::Int32,
-                                v8::fast_api::SequenceType::Scalar,
                                 v8::fast_api::Flags::Clamp,
                             ),
-                            CType::CallbackOptions.scalar(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),

--- a/ops/op2/test_cases/sync/stack_trace.out
+++ b/ops/op2/test_cases/sync/stack_trace.out
@@ -22,8 +22,8 @@ const fn op_stack_trace() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -34,8 +34,8 @@ const fn op_stack_trace() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
-                        &[CType::V8Value.scalar(), CType::CallbackOptions.scalar()],
+                        CType::Void.as_info(),
+                        &[CType::V8Value.as_info(), CType::CallbackOptions.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )

--- a/ops/op2/test_cases/sync/stack_trace_scope.out
+++ b/ops/op2/test_cases/sync/stack_trace_scope.out
@@ -22,11 +22,11 @@ const fn op_stack_trace() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::SeqOneByteString.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::SeqOneByteString.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -38,11 +38,11 @@ const fn op_stack_trace() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::SeqOneByteString.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::SeqOneByteString.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),

--- a/ops/op2/test_cases/sync/string_cow.out
+++ b/ops/op2/test_cases/sync/string_cow.out
@@ -24,10 +24,9 @@ const fn op_string_cow() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Uint32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
-                        &[CType::V8Value.scalar(), CType::SeqOneByteString.scalar()],
+                        &[CType::V8Value.as_info(), CType::SeqOneByteString.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -40,13 +39,12 @@ const fn op_string_cow() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Uint32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::SeqOneByteString.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::SeqOneByteString.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),

--- a/ops/op2/test_cases/sync/string_onebyte.out
+++ b/ops/op2/test_cases/sync/string_onebyte.out
@@ -24,10 +24,9 @@ const fn op_string_onebyte() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Uint32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
-                        &[CType::V8Value.scalar(), CType::SeqOneByteString.scalar()],
+                        &[CType::V8Value.as_info(), CType::SeqOneByteString.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -40,13 +39,12 @@ const fn op_string_onebyte() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Uint32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::SeqOneByteString.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::SeqOneByteString.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),

--- a/ops/op2/test_cases/sync/string_owned.out
+++ b/ops/op2/test_cases/sync/string_owned.out
@@ -24,10 +24,9 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Uint32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
-                        &[CType::V8Value.scalar(), CType::SeqOneByteString.scalar()],
+                        &[CType::V8Value.as_info(), CType::SeqOneByteString.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -40,13 +39,12 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Uint32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::SeqOneByteString.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::SeqOneByteString.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),

--- a/ops/op2/test_cases/sync/string_ref.out
+++ b/ops/op2/test_cases/sync/string_ref.out
@@ -24,10 +24,9 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Uint32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
-                        &[CType::V8Value.scalar(), CType::SeqOneByteString.scalar()],
+                        &[CType::V8Value.as_info(), CType::SeqOneByteString.as_info()],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
                 )
@@ -40,13 +39,12 @@ const fn op_string_owned() -> ::deno_core::_ops::OpDecl {
                     &deno_core::v8::fast_api::CFunctionInfo::new(
                         v8::fast_api::CTypeInfo::new(
                             CType::Uint32,
-                            v8::fast_api::SequenceType::Scalar,
                             v8::fast_api::Flags::Clamp,
                         ),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::SeqOneByteString.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::SeqOneByteString.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),

--- a/ops/op2/test_cases/sync/v8_ref_option.out
+++ b/ops/op2/test_cases/sync/v8_ref_option.out
@@ -22,12 +22,12 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::V8Value.scalar(),
-                            CType::V8Value.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),
@@ -39,12 +39,12 @@ pub const fn op_v8_lifetime() -> ::deno_core::_ops::OpDecl {
                 deno_core::v8::fast_api::CFunction::new(
                     Self::v8_fn_ptr_fast_metrics as _,
                     &deno_core::v8::fast_api::CFunctionInfo::new(
-                        CType::Void.scalar(),
+                        CType::Void.as_info(),
                         &[
-                            CType::V8Value.scalar(),
-                            CType::V8Value.scalar(),
-                            CType::V8Value.scalar(),
-                            CType::CallbackOptions.scalar(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::V8Value.as_info(),
+                            CType::CallbackOptions.as_info(),
                         ],
                         deno_core::v8::fast_api::Int64Representation::BigInt,
                     ),

--- a/serde_v8/de.rs
+++ b/serde_v8/de.rs
@@ -739,6 +739,7 @@ pub fn to_utf8(
   to_utf8_fast(s, scope).unwrap_or_else(|| to_utf8_slow(s, scope))
 }
 
+#[allow(deprecated)]
 fn to_utf8_fast(
   s: v8::Local<v8::String>,
   scope: &mut v8::HandleScope,
@@ -775,17 +776,15 @@ fn to_utf8_slow(
   let capacity = s.utf8_length(scope);
   let mut buf = Vec::with_capacity(capacity);
 
-  let bytes_len = s.write_utf8_uninit(
+  s.write_utf8_uninit_v2(
     scope,
     buf.spare_capacity_mut(),
-    None,
-    v8::WriteOptions::NO_NULL_TERMINATION
-      | v8::WriteOptions::REPLACE_INVALID_UTF8,
+    v8::WriteFlags::kReplaceInvalidUtf8,
   );
 
   // SAFETY: write_utf8_uninit guarantees `bytes_len` bytes are initialized & valid utf8
   unsafe {
-    buf.set_len(bytes_len);
+    buf.set_len(capacity);
     String::from_utf8_unchecked(buf)
   }
 }

--- a/serde_v8/magic/bytestring.rs
+++ b/serde_v8/magic/bytestring.rs
@@ -79,13 +79,7 @@ impl FromV8 for ByteString {
     // before immediately writing into that buffer and sanity check with an assert
     unsafe {
       buffer.set_len(len);
-      let written = v8str.write_one_byte(
-        scope,
-        &mut buffer,
-        0,
-        v8::WriteOptions::NO_NULL_TERMINATION,
-      );
-      assert!(written == len);
+      v8str.write_one_byte_v2(scope, 0, &mut buffer, v8::WriteFlags::empty());
     }
     Ok(Self(buffer))
   }

--- a/serde_v8/magic/u16string.rs
+++ b/serde_v8/magic/u16string.rs
@@ -96,13 +96,7 @@ impl FromV8 for U16String {
     // before immediately writing into that buffer and sanity check with an assert
     unsafe {
       buffer.set_len(len);
-      let written = v8str.write(
-        scope,
-        &mut buffer,
-        0,
-        v8::WriteOptions::NO_NULL_TERMINATION,
-      );
-      assert!(written == len);
+      v8str.write_v2(scope, 0, &mut buffer, v8::WriteFlags::empty());
     }
     Ok(buffer.into())
   }

--- a/testing/checkin/runner/mod.rs
+++ b/testing/checkin/runner/mod.rs
@@ -101,10 +101,7 @@ pub fn create_runtime(
 
   static SNAPSHOT: OnceLock<Box<[u8]>> = OnceLock::new();
 
-  let snapshot = SNAPSHOT.get_or_init(|| {
-    let snapshot = snapshot::create_snapshot();
-    snapshot.into()
-  });
+  let snapshot = SNAPSHOT.get_or_init(snapshot::create_snapshot);
 
   let mut runtime =
     create_runtime_from_snapshot(snapshot, false, additional_extensions);


### PR DESCRIPTION
- use nextest to run tests in separate processes due to one-snapshot-per-process (until isolate group support)
- update some string functions
- update fast call for removed types