### PR TITLE
feat: add import.meta proto for ext modules

### DIFF
--- a/core/01_core.js
+++ b/core/01_core.js
@@ -52,6 +52,7 @@
     op_get_extras_binding_object,
     op_get_promise_details,
     op_get_proxy_details,
+    op_get_ext_import_meta_proto,
     op_has_tick_scheduled,
     op_lazy_load_esm,
     op_memory_usage,
@@ -478,6 +479,11 @@
       op_print(`${consoleStringify(...args)}\n`, false);
     };
   }
+
+  // Default impl of contextual logging
+  op_get_ext_import_meta_proto().log = function internalLog(level, ...args) {
+    console.error(`[${level.toUpperCase()}]`, ...args);
+  };
 
   const consoleStringify = (...args) => args.map(consoleStringifyArg).join(" ");
 

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -133,7 +133,8 @@ builtin_ops! {
   ops_builtin_v8::op_leak_tracing_enable,
   ops_builtin_v8::op_leak_tracing_submit,
   ops_builtin_v8::op_leak_tracing_get_all,
-  ops_builtin_v8::op_leak_tracing_get
+  ops_builtin_v8::op_leak_tracing_get,
+  ops_builtin_v8::op_get_ext_import_meta_proto
 }
 
 #[op2(fast)]

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -937,6 +937,18 @@ pub fn op_memory_usage(scope: &mut v8::HandleScope) -> MemoryUsage {
 }
 
 #[op2]
+pub fn op_get_ext_import_meta_proto<'s>(
+  scope: &mut v8::HandleScope<'s>,
+) -> v8::Local<'s, v8::Value> {
+  let context_state_rc = JsRealm::state_from_scope(scope);
+  if let Some(proto) = context_state_rc.ext_import_meta_proto.borrow().clone() {
+    v8::Local::new(scope, proto).into()
+  } else {
+    v8::null(scope).into()
+  }
+}
+
+#[op2]
 pub fn op_set_wasm_streaming_callback(
   scope: &mut v8::HandleScope,
   #[global] cb: v8::Global<v8::Function>,

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -787,6 +787,13 @@ pub extern "C" fn host_initialize_import_meta_object_callback(
   meta.set(scope, resolve_key.into(), val.into());
 
   maybe_add_import_meta_filename_dirname(scope, meta, &name);
+
+  if name.starts_with("ext:") {
+    if let Some(proto) = state.ext_import_meta_proto.borrow().clone() {
+      let prototype = v8::Local::new(scope, proto);
+      meta.set_prototype(scope, prototype.into());
+    }
+  }
 }
 
 fn maybe_add_import_meta_filename_dirname(

--- a/core/runtime/jsrealm.rs
+++ b/core/runtime/jsrealm.rs
@@ -77,6 +77,7 @@ pub struct ContextState {
   pub(crate) exception_state: Rc<ExceptionState>,
   pub(crate) has_next_tick_scheduled: Cell<bool>,
   pub(crate) external_ops_tracker: ExternalOpsTracker,
+  pub(crate) ext_import_meta_proto: RefCell<Option<v8::Global<v8::Object>>>,
 }
 
 impl ContextState {
@@ -104,6 +105,7 @@ impl ContextState {
       timers: Default::default(),
       unrefed_ops: Default::default(),
       external_ops_tracker,
+      ext_import_meta_proto: Default::default(),
     }
   }
 }

--- a/core/runtime/snapshot.rs
+++ b/core/runtime/snapshot.rs
@@ -299,6 +299,7 @@ pub fn get_js_files(
 #[derive(Serialize, Deserialize)]
 pub(crate) struct SnapshottedData<'snapshot> {
   pub js_handled_promise_rejection_cb: Option<u32>,
+  pub ext_import_meta_proto: Option<u32>,
   pub module_map_data: ModuleMapSnapshotData,
   pub function_templates_data: FunctionTemplateSnapshotData,
   pub externals_count: u32,


### PR DESCRIPTION
this can be used to extend the api surface for ext modules without the overhead of assigning new data to each one. in particular, to add contextual logging (https://github.com/denoland/deno/pull/28562)