### PR TITLE
Ref'ing read and writes on resource handles

### DIFF
--- a/core/io/resource.rs
+++ b/core/io/resource.rs
@@ -200,10 +200,6 @@ pub trait Resource: Any + 'static {
   fn size_hint(&self) -> (u64, Option<u64>) {
     (0, None)
   }
-
-  fn has_ref(&self) -> bool {
-    true
-  }
 }
 
 impl dyn Resource {

--- a/core/io/resource.rs
+++ b/core/io/resource.rs
@@ -200,6 +200,10 @@ pub trait Resource: Any + 'static {
   fn size_hint(&self) -> (u64, Option<u64>) {
     (0, None)
   }
+
+  fn has_ref(&self) -> bool {
+    true
+  }
 }
 
 impl dyn Resource {

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -242,6 +242,7 @@ pub struct OpState {
   pub feature_checker: Arc<FeatureChecker>,
   pub external_ops_tracker: ExternalOpsTracker,
   pub op_stack_trace_callback: Option<OpStackTraceCallback>,
+  /// Reference to the unrefered ops state in `ContextState`.
   pub(crate) unrefed_ops: UnrefedOps,
   /// Resources that are not referenced by the event loop. All async
   /// resource ops on these resources will not keep the event loop alive.
@@ -275,6 +276,7 @@ impl OpState {
     std::mem::take(&mut self.resource_table);
   }
 
+  // Silly but improves readability.
   pub fn uv_unref(&mut self, resource_id: ResourceId) {
     self.unrefed_resources.insert(resource_id);
   }

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -2,6 +2,7 @@
 
 use crate::FeatureChecker;
 use crate::OpDecl;
+use crate::ResourceId;
 use crate::error::JsStackFrame;
 use crate::gotham_state::GothamState;
 use crate::io::ResourceTable;
@@ -11,6 +12,7 @@ use crate::runtime::OpDriverImpl;
 use crate::runtime::UnrefedOps;
 use futures::task::AtomicWaker;
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::rc::Rc;
@@ -241,6 +243,7 @@ pub struct OpState {
   pub external_ops_tracker: ExternalOpsTracker,
   pub op_stack_trace_callback: Option<OpStackTraceCallback>,
   pub(crate) unrefed_ops: UnrefedOps,
+  pub unrefed_resources: HashSet<ResourceId>,
 }
 
 impl OpState {
@@ -258,6 +261,7 @@ impl OpState {
       },
       op_stack_trace_callback,
       unrefed_ops: Default::default(),
+      unrefed_resources: Default::default(),
     }
   }
 

--- a/core/ops.rs
+++ b/core/ops.rs
@@ -8,6 +8,7 @@ use crate::io::ResourceTable;
 use crate::ops_metrics::OpMetricsFn;
 use crate::runtime::JsRuntimeState;
 use crate::runtime::OpDriverImpl;
+use crate::runtime::UnrefedOps;
 use futures::task::AtomicWaker;
 use std::cell::RefCell;
 use std::ops::Deref;
@@ -239,6 +240,7 @@ pub struct OpState {
   pub feature_checker: Arc<FeatureChecker>,
   pub external_ops_tracker: ExternalOpsTracker,
   pub op_stack_trace_callback: Option<OpStackTraceCallback>,
+  pub(crate) unrefed_ops: UnrefedOps,
 }
 
 impl OpState {
@@ -255,6 +257,7 @@ impl OpState {
         counter: Arc::new(AtomicUsize::new(0)),
       },
       op_stack_trace_callback,
+      unrefed_ops: Default::default(),
     }
   }
 

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -288,7 +288,7 @@ fn get_resource(
     .get_any(rid)
     .map_err(JsErrorBox::from_err)?;
 
-  if !resource.has_ref() {
+  if op_state.unrefed_resources.contains(&rid) {
     op_state.unrefed_ops.borrow_mut().insert(promise_id);
   }
 

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -277,6 +277,8 @@ pub fn op_wasm_streaming_set_url(
   Ok(())
 }
 
+// Get a resource from the resource table and
+// handle unrefing the current task.
 fn get_resource(
   state: Rc<RefCell<OpState>>,
   rid: ResourceId,

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -814,6 +814,8 @@ impl JsRuntime {
       options.feature_checker.take(),
       options.maybe_op_stack_trace_callback,
     );
+    let unrefed_ops = op_state.unrefed_ops.clone();
+
     extension_set::setup_op_state(&mut op_state, &mut extensions);
 
     // Load the sources and source maps
@@ -978,6 +980,7 @@ impl JsRuntime {
       op_method_decls,
       methods_ctx_offset,
       op_state.borrow().external_ops_tracker.clone(),
+      unrefed_ops,
     ));
 
     // TODO(bartlomieju): factor out

--- a/core/runtime/mod.rs
+++ b/core/runtime/mod.rs
@@ -24,6 +24,7 @@ pub use jsrealm::ContextState;
 pub(crate) use jsrealm::JsRealm;
 pub use jsrealm::MODULE_MAP_SLOT_INDEX;
 pub(crate) use jsrealm::OpDriverImpl;
+pub(crate) use jsrealm::UnrefedOps;
 pub use jsruntime::CompiledWasmModuleStore;
 pub use jsruntime::CreateRealmOptions;
 pub use jsruntime::CrossIsolateStore;

--- a/ops/op2/config.rs
+++ b/ops/op2/config.rs
@@ -456,6 +456,14 @@ mod tests {
       },
     );
     test_parse(
+      "(async, promise_id)",
+      MacroConfig {
+        r#async: true,
+        promise_id: true,
+        ..Default::default()
+      },
+    );
+    test_parse(
       "(async(lazy))",
       MacroConfig {
         r#async: true,

--- a/ops/op2/dispatch_async.rs
+++ b/ops/op2/dispatch_async.rs
@@ -60,8 +60,8 @@ pub(crate) fn generate_dispatch_async(
     quote!()
   };
 
+  // Set input_index = 1 when we don't want promise ID as the first arg.
   let input_index = if config.promise_id { 0 } else { 1 };
-  // input_index = 1 as promise ID is the first arg
   let args =
     generate_dispatch_slow_call(generator_state, signature, input_index)?;
 

--- a/ops/op2/dispatch_async.rs
+++ b/ops/op2/dispatch_async.rs
@@ -60,8 +60,10 @@ pub(crate) fn generate_dispatch_async(
     quote!()
   };
 
+  let input_index = if config.promise_id { 0 } else { 1 };
   // input_index = 1 as promise ID is the first arg
-  let args = generate_dispatch_slow_call(generator_state, signature, 1)?;
+  let args =
+    generate_dispatch_slow_call(generator_state, signature, input_index)?;
 
   // Always need context and args
   generator_state.needs_opctx = true;

--- a/testing/checkin/runner/extensions.rs
+++ b/testing/checkin/runner/extensions.rs
@@ -36,6 +36,7 @@ deno_core::extension!(
     ops_async::op_async_get_cppgc_resource,
     ops_async::op_async_never_resolves,
     ops_async::op_async_fake,
+    ops_async::op_async_promise_id,
     ops_error::op_async_throw_error_eager,
     ops_error::op_async_throw_error_lazy,
     ops_error::op_async_throw_error_deferred,

--- a/testing/checkin/runner/ops_async.rs
+++ b/testing/checkin/runner/ops_async.rs
@@ -92,3 +92,8 @@ pub fn op_async_never_resolves() -> impl Future<Output = ()> {
 pub fn op_async_fake() -> Result<u32, JsErrorBox> {
   Ok(1)
 }
+
+#[op2(async, promise_id)]
+pub async fn op_async_promise_id(#[smi] promise_id: u32) -> u32 {
+  promise_id
+}

--- a/testing/checkin/runner/ops_io.rs
+++ b/testing/checkin/runner/ops_io.rs
@@ -73,12 +73,13 @@ pub fn op_pipe_create(op_state: &mut OpState) -> (ResourceId, ResourceId) {
 
 struct FileResource {
   handle: deno_core::ResourceHandle,
+  ref_: bool,
 }
 
 impl FileResource {
-  fn new(file: tokio::fs::File) -> Self {
+  fn new(file: tokio::fs::File, ref_: bool) -> Self {
     let handle = ResourceHandle::from_fd_like(&file);
-    Self { handle }
+    Self { handle, ref_ }
   }
 }
 
@@ -86,12 +87,29 @@ impl Resource for FileResource {
   fn backing_handle(self: Rc<Self>) -> Option<ResourceHandle> {
     Some(self.handle)
   }
+
+  fn has_ref(&self) -> bool {
+    self.ref_
+  }
+
+  fn read_byob(
+    self: std::rc::Rc<Self>,
+    buf: deno_core::BufMutView,
+  ) -> deno_core::AsyncResult<(usize, deno_core::BufMutView)> {
+    async {
+      // Do something to test unrefing.
+      tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+      Ok((0, buf))
+    }
+    .boxed_local()
+  }
 }
 
 #[op2(async)]
 #[serde]
 pub async fn op_file_open(
   #[string] path: String,
+  ref_: bool,
   op_state: Rc<RefCell<OpState>>,
 ) -> Result<ResourceId, std::io::Error> {
   let tokio_file = tokio::fs::OpenOptions::new()
@@ -103,7 +121,7 @@ pub async fn op_file_open(
   let rid = op_state
     .borrow_mut()
     .resource_table
-    .add(FileResource::new(tokio_file));
+    .add(FileResource::new(tokio_file, ref_));
   Ok(rid)
 }
 

--- a/testing/checkin/runner/ops_io.rs
+++ b/testing/checkin/runner/ops_io.rs
@@ -119,7 +119,7 @@ pub async fn op_file_open(
     .add(FileResource::new(tokio_file));
 
   if !ref_ {
-    op_state.borrow_mut().unrefed_resources.insert(rid);
+    op_state.borrow_mut().uv_unref(rid);
   }
 
   Ok(rid)

--- a/testing/checkin/runner/ops_io.rs
+++ b/testing/checkin/runner/ops_io.rs
@@ -118,7 +118,7 @@ pub async fn op_file_open(
     .resource_table
     .add(FileResource::new(tokio_file));
 
-  if ref_ {
+  if !ref_ {
     op_state.borrow_mut().unrefed_resources.insert(rid);
   }
 

--- a/testing/checkin/runtime/async.ts
+++ b/testing/checkin/runtime/async.ts
@@ -10,6 +10,7 @@ const {
   op_stats_delete,
   op_async_never_resolves,
   op_async_fake,
+  op_async_promise_id,
 } = Deno
   .core
   .ops;
@@ -41,6 +42,10 @@ let nextStats = 0;
 
 export function fakeAsync() {
   return op_async_fake();
+}
+
+export function asyncPromiseId(): number {
+  return op_async_promise_id();
 }
 
 export class Stats {

--- a/testing/unit/ops_async_test.ts
+++ b/testing/unit/ops_async_test.ts
@@ -1,6 +1,11 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
-import { assertStackTraceEquals, test } from "checkin:testing";
-import { asyncYield, barrierAwait, barrierCreate } from "checkin:async";
+import { assert, assertStackTraceEquals, test } from "checkin:testing";
+import {
+  asyncPromiseId,
+  asyncYield,
+  barrierAwait,
+  barrierCreate,
+} from "checkin:async";
 import { asyncThrow } from "checkin:error";
 
 // Test that stack traces from async ops are all sane
@@ -53,4 +58,11 @@ test(async function testAsyncBarrier() {
     promises.push(barrierAwait("barrier"));
   }
   await Promise.all(promises);
+});
+
+test(async function promiseId() {
+  const id = await asyncPromiseId();
+
+  assert(typeof id === "number");
+  assert(id > 0);
 });

--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -55,8 +55,25 @@ test(function opsSyncBadResource() {
 });
 
 test(async function testFileIsNotTerminal() {
-  const file = await op_file_open("./README.md");
+  const file = await op_file_open("./README.md", true);
   assert(!Deno.core.isTerminal(file));
+});
+
+test(async function testFileReadUnref() {
+  const file = await op_file_open("./README.md", true);
+
+  let called = false;
+  await Deno.core.read(file, new Uint8Array(100))
+    .then(() => {
+      called = true;
+    });
+  assert(called);
+
+  const file2 = await op_file_open("./README.md", false);
+  Deno.core.read(file2, new Uint8Array(100))
+    .then(() => {
+      throw new Error("should not be called");
+    });
 });
 
 test(async function testCppgcAsync() {


### PR DESCRIPTION
Adds a `unrefed_resources` hashset similar to `unrefed_ops` and `#[op2(async, promise_id)]` for `op_read`, `op_read_all`, `op_write`. 

This allows ref'ing and unrefing using resource handles instead of inflight promises, similar to `uv_ref` and `uv_unref` in libuv. Useful for implementing `HandleWrap` in Deno.