### PR TITLE
feat: upgrade V8 to 137

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,12 +22,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,7 +149,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide 0.8.5",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
  "windows-targets",
@@ -1486,18 +1480,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -3092,16 +3077,16 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "135.1.0"
+version = "137.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5861d62596971e448da865320a9ac547e2526fdf9eaf4fb40bf8a9f465bccecb"
+checksum = "f6aaebc183929f8a70b4320865ba92600add1a3f94cd2b1b898ad589e4e4925a"
 dependencies = [
  "bindgen",
  "bitflags",
  "fslock",
  "gzip-header",
  "home",
- "miniz_oxide 0.7.3",
+ "miniz_oxide",
  "paste",
  "which",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ deno_error = { version = "0.5.6", features = ["serde_json", "serde", "url", "tok
 deno_ops = { version = "0.221.0", path = "./ops" }
 deno_unsync = "0.4.2"
 serde_v8 = { version = "0.254.0", path = "./serde_v8" }
-v8 = { version = "135.1.0", default-features = false }
+v8 = { version = "137.0.0", default-features = false }
 
 anyhow = "1"
 bencher = "0.1"

--- a/core/cppgc.rs
+++ b/core/cppgc.rs
@@ -44,7 +44,7 @@ impl GarbageCollected for DummyT {
     unreachable!();
   }
 
-  fn get_name(&self) -> Option<&'static std::ffi::CStr> {
+  fn get_name(&self) -> &'static std::ffi::CStr {
     unreachable!();
   }
 }
@@ -110,11 +110,19 @@ impl v8::cppgc::GarbageCollected for PrototypeChainStore {
       visitor.trace(&erased.member);
     }
   }
+
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"PrototypeChainStore"
+  }
 }
 
 impl<T: GarbageCollected> v8::cppgc::GarbageCollected for CppGcObject<T> {
   fn trace(&self, visitor: &v8::cppgc::Visitor) {
     self.member.trace(visitor);
+  }
+
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    self.member.get_name()
   }
 }
 

--- a/core/extension_set.rs
+++ b/core/extension_set.rs
@@ -200,7 +200,7 @@ pub fn get_middlewares_and_external_refs(
 ) -> (
   Vec<GlobalTemplateMiddlewareFn>,
   Vec<GlobalObjectMiddlewareFn>,
-  Vec<v8::ExternalReference<'static>>,
+  Vec<v8::ExternalReference>,
 ) {
   // TODO(bartlomieju): these numbers were chosen arbitrarily. This is a very
   // niche features and it's unlikely a lot of extensions use it.

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -622,7 +622,7 @@ pub struct Extension {
   pub esm_entry_point: Option<&'static str>,
   pub ops: Cow<'static, [OpDecl]>,
   pub objects: Cow<'static, [OpMethodDecl]>,
-  pub external_references: Cow<'static, [v8::ExternalReference<'static>]>,
+  pub external_references: Cow<'static, [v8::ExternalReference]>,
   pub global_template_middleware: Option<GlobalTemplateMiddlewareFn>,
   pub global_object_middleware: Option<GlobalObjectMiddlewareFn>,
   pub op_state_fn: Option<Box<OpStateFn>>,
@@ -768,9 +768,7 @@ impl Extension {
     self.global_object_middleware
   }
 
-  pub fn get_external_references(
-    &mut self,
-  ) -> &[v8::ExternalReference<'static>] {
+  pub fn get_external_references(&mut self) -> &[v8::ExternalReference] {
     self.external_references.as_ref()
   }
 

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -1937,7 +1937,11 @@ mod tests {
     pub value: u32,
   }
 
-  impl GarbageCollected for TestResource {}
+  impl GarbageCollected for TestResource {
+    fn get_name(&self) -> &'static std::ffi::CStr {
+      c"TestResource"
+    }
+  }
 
   #[op2]
   #[cppgc]

--- a/core/runtime/snapshot.rs
+++ b/core/runtime/snapshot.rs
@@ -2,6 +2,7 @@
 
 use serde::Deserialize;
 use serde::Serialize;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
@@ -302,7 +303,6 @@ pub(crate) struct SnapshottedData<'snapshot> {
   pub ext_import_meta_proto: Option<u32>,
   pub module_map_data: ModuleMapSnapshotData,
   pub function_templates_data: FunctionTemplateSnapshotData,
-  pub externals_count: u32,
   pub extensions: Vec<&'snapshot str>,
   pub op_count: usize,
   pub source_count: usize,
@@ -377,13 +377,13 @@ pub(crate) fn store_snapshotted_data_for_snapshot<'snapshot>(
 
 /// Returns an isolate set up for snapshotting.
 pub(crate) fn create_snapshot_creator(
-  external_refs: &'static v8::ExternalReferences,
+  external_refs: Cow<'static, [v8::ExternalReference]>,
   maybe_startup_snapshot: Option<V8Snapshot>,
   params: v8::CreateParams,
 ) -> v8::OwnedIsolate {
   if let Some(snapshot) = maybe_startup_snapshot {
     v8::Isolate::snapshot_creator_from_existing_snapshot(
-      snapshot.0,
+      v8::StartupData::from(snapshot.0),
       Some(external_refs),
       Some(params),
     )

--- a/ops/op2/test_cases/async/async_cppgc.rs
+++ b/ops/op2/test_cases/async/async_cppgc.rs
@@ -6,7 +6,11 @@ use deno_core::GarbageCollected;
 
 struct Wrap;
 
-impl GarbageCollected for Wrap {}
+impl GarbageCollected for Wrap {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"Wrap"
+  }
+}
 
 #[op2(async)]
 #[cppgc]

--- a/ops/op2/test_cases/sync/cppgc_resource.rs
+++ b/ops/op2/test_cases/sync/cppgc_resource.rs
@@ -6,7 +6,11 @@ use deno_core::GarbageCollected;
 
 struct Wrap;
 
-impl GarbageCollected for Wrap {}
+impl GarbageCollected for Wrap {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"Wrap"
+  }
+}
 
 #[op2(fast)]
 fn op_cppgc_object(#[cppgc] _resource: &Wrap) {}

--- a/ops/op2/test_cases/sync/object_wrap.rs
+++ b/ops/op2/test_cases/sync/object_wrap.rs
@@ -10,7 +10,11 @@ pub struct Foo {
   x: Cell<u32>,
 }
 
-impl GarbageCollected for Foo {}
+impl GarbageCollected for Foo {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"Foo"
+  }
+}
 
 #[op2]
 impl Foo {

--- a/ops/op2/test_cases_fail/lifetimes.rs
+++ b/ops/op2/test_cases_fail/lifetimes.rs
@@ -5,7 +5,11 @@ use deno_core::GarbageCollected;
 
 struct Wrap;
 
-impl GarbageCollected for Wrap {}
+impl GarbageCollected for Wrap {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"Wrap"
+  }
+}
 
 #[op2(fast)]
 fn op_use_cppgc_object(#[cppgc] _wrap: &'static Wrap) {}

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -74,7 +74,11 @@ pub fn op_stats_delete(
 
 pub struct TestObjectWrap {}
 
-impl GarbageCollected for TestObjectWrap {}
+impl GarbageCollected for TestObjectWrap {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"TestObjectWrap"
+  }
+}
 
 #[op2]
 impl TestObjectWrap {
@@ -118,7 +122,11 @@ impl TestObjectWrap {
 
 pub struct DOMPoint {}
 
-impl GarbageCollected for DOMPoint {}
+impl GarbageCollected for DOMPoint {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"DOMPoint"
+  }
+}
 
 impl DOMPointReadOnly {
   fn from_point_inner(
@@ -152,7 +160,11 @@ pub struct DOMPointReadOnly {
   w: Cell<f64>,
 }
 
-impl GarbageCollected for DOMPointReadOnly {}
+impl GarbageCollected for DOMPointReadOnly {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"DOMPointReadOnly"
+  }
+}
 
 #[op2(base)]
 impl DOMPointReadOnly {
@@ -278,7 +290,11 @@ pub enum TestEnumWrap {
   A,
 }
 
-impl GarbageCollected for TestEnumWrap {}
+impl GarbageCollected for TestEnumWrap {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"TestEnumWrap"
+  }
+}
 
 #[op2]
 impl TestEnumWrap {
@@ -295,7 +311,11 @@ pub fn op_nop_generic<T: SomeType + 'static>(state: &mut OpState) {
 
 pub struct Foo;
 
-impl deno_core::GarbageCollected for Foo {}
+impl deno_core::GarbageCollected for Foo {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"Foo"
+  }
+}
 
 #[op2(fast)]
 pub fn op_scope_cppgc(_scope: &mut v8::HandleScope, #[cppgc] _foo: &Foo) {}

--- a/testing/checkin/runner/ops_async.rs
+++ b/testing/checkin/runner/ops_async.rs
@@ -67,7 +67,11 @@ pub struct TestResource {
   value: u32,
 }
 
-impl GarbageCollected for TestResource {}
+impl GarbageCollected for TestResource {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"TestResource"
+  }
+}
 
 #[op2(async)]
 #[cppgc]

--- a/testing/checkin/runner/ops_worker.rs
+++ b/testing/checkin/runner/ops_worker.rs
@@ -34,7 +34,11 @@ pub struct WorkerControl {
   shutdown_flag: Option<UnboundedSender<()>>,
 }
 
-impl GarbageCollected for WorkerControl {}
+impl GarbageCollected for WorkerControl {
+  fn get_name(&self) -> &'static std::ffi::CStr {
+    c"WorkerControl"
+  }
+}
 
 #[derive(Debug)]
 pub struct WorkerChannel {


### PR DESCRIPTION
in 13.6 the cppgc heap is automatically created, so we can remove our initialization for it.