### PR TITLE
Remove prototypes of object wrap methods

### DIFF
--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -101,6 +101,8 @@ test(async function testDomPoint() {
   assert(p1 instanceof DOMPoint);
   assert(p1 instanceof DOMPointReadOnly);
 
+  assertEquals("prototype" in DOMPoint.prototype.wrappingSmi, false);
+
   let caught;
   try {
     // @ts-expect-error bad arg test


### PR DESCRIPTION
Needed for Node compat.

Ref https://github.com/nodejs/node/commit/64348f5ea557d414b08d1b2602d794e48ac06bb2