### PR TITLE
fix(compile): panic when calling op_is_terminal

### DIFF
--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -468,9 +468,11 @@ fn op_encode_binary_string(#[buffer] s: &[u8]) -> ByteString {
 fn op_is_terminal(
   state: &mut OpState,
   #[smi] rid: ResourceId,
-) -> Result<bool, ResourceError> {
-  let handle = state.resource_table.get_handle(rid)?;
-  Ok(handle.is_terminal())
+) -> bool {
+  match state.resource_table.get_handle(rid) {
+    Ok(handle) => handle.is_terminal(),
+    _ => false,
+  }
 }
 
 async fn do_load_job(

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -465,10 +465,7 @@ fn op_encode_binary_string(#[buffer] s: &[u8]) -> ByteString {
 }
 
 #[op2(fast)]
-fn op_is_terminal(
-  state: &mut OpState,
-  #[smi] rid: ResourceId,
-) -> bool {
+fn op_is_terminal(state: &mut OpState, #[smi] rid: ResourceId) -> bool {
   match state.resource_table.get_handle(rid) {
     Ok(handle) => handle.is_terminal(),
     _ => false,


### PR DESCRIPTION
This works towards fixing [#27730](https://github.com/denoland/deno/issues/27730) and [#21091](https://github.com/denoland/deno/issues/21091).

An error is not handled when calling `op_is_terminal`.
Ironically, this causes the application to panic when bootstrapping if there is no terminal in windows.

This PR does not fully fix the issue yet, as there is a similar problem in deno's code base, see this [pull request](https://github.com/denoland/deno/pull/28823).