### PR TITLE
feat: extensions track esm initialization automatically

### DIFF
--- a/core/benches/ops/async.rs
+++ b/core/benches/ops/async.rs
@@ -112,7 +112,7 @@ fn bench_op(
     .build()
     .unwrap();
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![testing::init_ops_and_esm()],
+    extensions: vec![testing::init()],
     // We need to feature gate this here to prevent IDE errors
     #[cfg(feature = "unsafe_runtime_options")]
     unsafe_expose_natives_and_gc: true,

--- a/core/benches/ops/sync.rs
+++ b/core/benches/ops/sync.rs
@@ -169,7 +169,7 @@ fn bench_op(
   );
 
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![testing::init_ops_and_esm()],
+    extensions: vec![testing::init()],
     // We need to feature gate this here to prevent IDE errors
     #[cfg(feature = "unsafe_runtime_options")]
     unsafe_expose_natives_and_gc: true,

--- a/core/benches/snapshot/snapshot.rs
+++ b/core/benches/snapshot/snapshot.rs
@@ -44,11 +44,7 @@ macro_rules! fake_extensions {
 }
 
 fn make_extensions() -> Vec<Extension> {
-  fake_extensions!(init_ops_and_esm, a, b, c, d, e, f, g, h, i, j, k, l, m, n)
-}
-
-fn make_extensions_ops() -> Vec<Extension> {
-  fake_extensions!(init_ops, a, b, c, d, e, f, g, h, i, j, k, l, m, n)
+  fake_extensions!(init, a, b, c, d, e, f, g, h, i, j, k, l, m, n)
 }
 
 pub fn maybe_transpile_source(
@@ -162,7 +158,7 @@ fn bench_load_snapshot(c: &mut Criterion) {
       for _ in 0..iters {
         let now = Instant::now();
         let runtime = JsRuntime::new(RuntimeOptions {
-          extensions: make_extensions_ops(),
+          extensions: make_extensions(),
           startup_snapshot: Some(snapshot),
           ..Default::default()
         });

--- a/core/benches/snapshot/snapshot.rs
+++ b/core/benches/snapshot/snapshot.rs
@@ -38,13 +38,19 @@ macro_rules! fake_extensions {
         }
       )+
 
-      vec![$($name::$name::$which()),+]
+      vec![$($name::$name::init()),+]
     }
   );
 }
 
 fn make_extensions() -> Vec<Extension> {
-  fake_extensions!(init, a, b, c, d, e, f, g, h, i, j, k, l, m, n)
+  fake_extensions!(
+    a0, b0, c0, d0, e0, f0, g0, h0, i0, j0, k0, l0, m0, n0, o0, p0, q0, r0, s0,
+    t0, u0, v0, w0, x0, y0, z0, a1, b1, c1, d1, e1, f1, g1, h1, i1, j1, k1, l1,
+    m1, n1, o1, p1, q1, r1, s1, t1, u1, v1, w1, x1, y1, z1, a2, b2, c2, d2, e2,
+    f2, g2, h2, i2, j2, k2, l2, m2, n2, o2, p2, q2, r2, s2, t2, u2, v2, w2, x2,
+    y2, z2
+  )
 }
 
 pub fn maybe_transpile_source(

--- a/core/error.rs
+++ b/core/error.rs
@@ -85,6 +85,10 @@ pub enum CoreError {
   DataError(DataError),
   #[error("Unable to get code cache from unbound module script for {0}")]
   CreateCodeCache(String),
+  #[error(
+    "Extensions from snapshot loaded in wrong order: expected {0} but got {1}"
+  )]
+  ExtensionSnapshotMismatch(&'static str, &'static str),
 }
 
 impl CoreError {
@@ -179,7 +183,8 @@ impl JsErrorClass for CoreError {
       | CoreError::ExecutionTerminated
       | CoreError::PendingPromiseResolution
       | CoreError::CreateCodeCache(_)
-      | CoreError::EvaluateDynamicImportedModule => {
+      | CoreError::EvaluateDynamicImportedModule
+      | CoreError::ExtensionSnapshotMismatch(..) => {
         Cow::Borrowed(GENERIC_ERROR)
       }
     }
@@ -212,7 +217,8 @@ impl JsErrorClass for CoreError {
       | CoreError::ExecutionTerminated
       | CoreError::PendingPromiseResolution
       | CoreError::EvaluateDynamicImportedModule
-      | CoreError::CreateCodeCache(_) => self.to_string().into(),
+      | CoreError::CreateCodeCache(_)
+      | CoreError::ExtensionSnapshotMismatch(..) => self.to_string().into(),
     }
   }
 

--- a/core/examples/op2.rs
+++ b/core/examples/op2.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), anyhow::Error> {
 
   let mut js_runtime = JsRuntime::new(deno_core::RuntimeOptions {
     module_loader: Some(Rc::new(FsModuleLoader)),
-    extensions: vec![op2_sample::init_ops_and_esm()],
+    extensions: vec![op2_sample::init()],
     ..Default::default()
   });
 

--- a/core/examples/snapshot/build.rs
+++ b/core/examples/snapshot/build.rs
@@ -21,7 +21,7 @@ fn main() {
   let options = CreateSnapshotOptions {
     cargo_manifest_dir: env!("CARGO_MANIFEST_DIR"),
     startup_snapshot: None,
-    extensions: vec![runjs_extension::init_ops_and_esm()],
+    extensions: vec![runjs_extension::init()],
     with_runtime_cb: None,
     skip_op_registration: false,
     extension_transpiler: None,

--- a/core/examples/snapshot/src/main.rs
+++ b/core/examples/snapshot/src/main.rs
@@ -35,7 +35,7 @@ async fn run_js(file_path: &str) -> Result<(), anyhow::Error> {
   let mut js_runtime = JsRuntime::new(RuntimeOptions {
     module_loader: Some(Rc::new(FsModuleLoader)),
     startup_snapshot: Some(RUNTIME_SNAPSHOT),
-    extensions: vec![runjs_extension::init_ops()],
+    extensions: vec![runjs_extension::init()],
     ..Default::default()
   });
 

--- a/core/extension_set.rs
+++ b/core/extension_set.rs
@@ -20,6 +20,7 @@ use crate::runtime::ExtensionTranspiler;
 use crate::runtime::JsRuntimeState;
 use crate::runtime::OpDriverImpl;
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::iter::Chain;
 use std::rc::Rc;
 
@@ -296,16 +297,12 @@ fn load(
 pub fn into_sources_and_source_maps(
   transpiler: Option<&ExtensionTranspiler>,
   extensions: &[Extension],
+  extensions_in_snapshot: Option<&HashSet<&'static str>>,
   mut load_callback: impl FnMut(&ExtensionFileSource),
 ) -> Result<LoadedSources, CoreError> {
   let mut sources = LoadedSources::default();
 
   for extension in extensions {
-    if let Some(esm_entry_point) = extension.esm_entry_point {
-      sources
-        .esm_entry_points
-        .push(FastString::from_static(esm_entry_point));
-    }
     for file in &*extension.lazy_loaded_esm_files {
       let (code, maybe_source_map) =
         load(transpiler, file, &mut load_callback)?;
@@ -315,6 +312,18 @@ pub fn into_sources_and_source_maps(
         code,
         maybe_source_map,
       });
+    }
+
+    if let Some(extensions_in_snapshot) = extensions_in_snapshot {
+      if extensions_in_snapshot.contains(extension.name) {
+        continue;
+      }
+    }
+
+    if let Some(esm_entry_point) = extension.esm_entry_point {
+      sources
+        .esm_entry_points
+        .push(FastString::from_static(esm_entry_point));
     }
     for file in &*extension.js_files {
       let (code, maybe_source_map) =

--- a/core/extensions.rs
+++ b/core/extensions.rs
@@ -433,7 +433,7 @@ macro_rules! extension {
     /// ```rust,ignore
     /// use deno_core::{ JsRuntime, RuntimeOptions };
     ///
-    #[doc = concat!("let mut extensions = vec![", stringify!($name), "::init_ops_and_esm()];")]
+    #[doc = concat!("let mut extensions = vec![", stringify!($name), "::init()];")]
     /// let mut js_runtime = JsRuntime::new(RuntimeOptions {
     ///   extensions,
     ///   ..Default::default()
@@ -526,41 +526,17 @@ macro_rules! extension {
       }
 
       #[allow(dead_code)]
-      /// Initialize this extension for runtime or snapshot creation. Use this
-      /// function if the runtime or snapshot is not created from a (separate)
-      /// snapshot, or that snapshot does not contain this extension. Otherwise
-      /// use `init_ops()` instead.
+      /// Initialize this extension for runtime or snapshot creation.
       ///
       /// # Returns
       /// an Extension object that can be used during instantiation of a JsRuntime
-      pub fn init_ops_and_esm $( <  $( $param : $type + 'static ),+ > )? ( $( $( $options_id : $options_type ),* )? ) -> $crate::Extension
+      pub fn init $( <  $( $param : $type + 'static ),+ > )? ( $( $( $options_id : $options_type ),* )? ) -> $crate::Extension
       $( where $( $bound : $bound_type ),+ )?
       {
         let mut ext = Self::ext $( ::< $( $param ),+ > )?();
         Self::with_ops_fn $( ::< $( $param ),+ > )?(&mut ext);
         Self::with_state_and_middleware $( ::< $( $param ),+ > )?(&mut ext, $( $( $options_id , )* )? );
         Self::with_customizer(&mut ext);
-        ext
-      }
-
-      #[allow(dead_code)]
-      /// Initialize this extension for runtime or snapshot creation, excluding
-      /// its JavaScript sources and evaluation. This is used when the runtime
-      /// or snapshot is created from a (separate) snapshot which includes this
-      /// extension in order to avoid evaluating the JavaScript twice.
-      ///
-      /// # Returns
-      /// an Extension object that can be used during instantiation of a JsRuntime
-      pub fn init_ops $( <  $( $param : $type + 'static ),+ > )? ( $( $( $options_id : $options_type ),* )? ) -> $crate::Extension
-      $( where $( $bound : $bound_type ),+ )?
-      {
-        let mut ext = Self::ext $( ::< $( $param ),+ > )?();
-        Self::with_ops_fn $( ::< $( $param ),+ > )?(&mut ext);
-        Self::with_state_and_middleware $( ::< $( $param ),+ > )?(&mut ext, $( $( $options_id , )* )? );
-        Self::with_customizer(&mut ext);
-        ext.js_files = ::std::borrow::Cow::Borrowed(&[]);
-        ext.esm_files = ::std::borrow::Cow::Borrowed(&[]);
-        ext.esm_entry_point = ::std::option::Option::None;
         ext
       }
     }
@@ -737,7 +713,7 @@ impl Extension {
     }
   }
 
-  /// Middleware should be called before init_ops
+  /// Middleware should be called before init
   pub fn take_middleware(&mut self) -> Option<Box<OpMiddlewareFn>> {
     self.middleware_fn.take()
   }

--- a/core/modules/tests.rs
+++ b/core/modules/tests.rs
@@ -423,7 +423,7 @@ fn test_mods() {
   deno_core::extension!(test_ext, ops = [op_test]);
 
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     module_loader: Some(loader.clone()),
     ..Default::default()
   });
@@ -505,7 +505,7 @@ fn test_lazy_loaded_esm() {
   deno_core::extension!(test_ext, lazy_loaded_esm = [dir "modules/testdata", "lazy_loaded.js"]);
 
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops_and_esm()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
 

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -65,7 +65,6 @@ use futures::FutureExt;
 use futures::task::AtomicWaker;
 use smallvec::SmallVec;
 use std::any::Any;
-use std::collections::HashSet;
 use std::future::Future;
 use std::future::poll_fn;
 use v8::MessageErrorLevel;
@@ -144,7 +143,7 @@ impl<T> DerefMut for ManuallyDropRc<T> {
 /// control dropping more closely here using ManuallyDrop.
 pub(crate) struct InnerIsolateState {
   will_snapshot: bool,
-  extensions: HashSet<&'static str>,
+  extensions: Vec<&'static str>,
   op_count: usize,
   source_count: usize,
   addl_refs_count: usize,
@@ -836,7 +835,7 @@ impl JsRuntime {
     let mut sources = extension_set::into_sources_and_source_maps(
       options.extension_transpiler.as_deref(),
       &extensions,
-      sidecar_data.as_ref().map(|s| &s.snapshot_data.extensions),
+      sidecar_data.as_ref().map(|s| &*s.snapshot_data.extensions),
       |source| {
         mark_as_loaded_from_fs_during_snapshot(&mut files_loaded, &source.code)
       },

--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -698,7 +698,7 @@ mod tests {
   /// Run a test for a single op.
   fn run_test2(repeat: usize, op: &str, test: &str) -> Result<(), CoreError> {
     let mut runtime = JsRuntime::new(RuntimeOptions {
-      extensions: vec![testing::init_ops_and_esm()],
+      extensions: vec![testing::init()],
       ..Default::default()
     });
     let err_mapper =
@@ -749,7 +749,7 @@ mod tests {
     test: &str,
   ) -> Result<(), anyhow::Error> {
     let mut runtime = JsRuntime::new(RuntimeOptions {
-      extensions: vec![testing::init_ops_and_esm()],
+      extensions: vec![testing::init()],
       ..Default::default()
     });
     let err_mapper =

--- a/core/runtime/snapshot.rs
+++ b/core/runtime/snapshot.rs
@@ -3,6 +3,7 @@
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -303,7 +304,7 @@ pub(crate) struct SnapshottedData<'snapshot> {
   pub module_map_data: ModuleMapSnapshotData,
   pub function_templates_data: FunctionTemplateSnapshotData,
   pub externals_count: u32,
-  pub extension_count: usize,
+  pub extensions: HashSet<&'snapshot str>,
   pub op_count: usize,
   pub source_count: usize,
   pub addl_refs_count: usize,

--- a/core/runtime/snapshot.rs
+++ b/core/runtime/snapshot.rs
@@ -3,7 +3,6 @@
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -304,7 +303,7 @@ pub(crate) struct SnapshottedData<'snapshot> {
   pub module_map_data: ModuleMapSnapshotData,
   pub function_templates_data: FunctionTemplateSnapshotData,
   pub externals_count: u32,
-  pub extensions: HashSet<&'snapshot str>,
+  pub extensions: Vec<&'snapshot str>,
   pub op_count: usize,
   pub source_count: usize,
   pub addl_refs_count: usize,

--- a/core/runtime/tests/error.rs
+++ b/core/runtime/tests/error.rs
@@ -17,7 +17,7 @@ async fn test_error_builder() {
 
   deno_core::extension!(test_ext, ops = [op_err]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
   poll_fn(move |cx| {

--- a/core/runtime/tests/jsrealm.rs
+++ b/core/runtime/tests/jsrealm.rs
@@ -87,7 +87,7 @@ async fn js_realm_ref_unref_ops() {
 
   deno_core::extension!(test_ext, ops = [op_pending]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
 
@@ -139,7 +139,7 @@ fn es_snapshot() {
     );
 
     let runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
-      extensions: vec![module_snapshot::init_ops_and_esm()],
+      extensions: vec![module_snapshot::init()],
       module_loader: Some(Rc::new(StaticModuleLoader::default())),
       ..Default::default()
     });

--- a/core/runtime/tests/misc.rs
+++ b/core/runtime/tests/misc.rs
@@ -100,7 +100,7 @@ async fn test_wakers_for_async_ops() {
 
   deno_core::extension!(test_ext, ops = [op_async_sleep]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
 
@@ -670,7 +670,7 @@ async fn test_set_macrotask_callback_set_next_tick_callback() {
 
   deno_core::extension!(test_ext, ops = [op_async_sleep]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
 
@@ -727,7 +727,7 @@ fn test_has_tick_scheduled() {
 
   deno_core::extension!(test_ext, ops = [op_macrotask, op_next_tick]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
 
@@ -835,7 +835,7 @@ async fn test_promise_rejection_handler_generic(
   }
 
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
 
@@ -1000,7 +1000,7 @@ async fn test_dynamic_import_module_error_stack() {
     ),
   ]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     module_loader: Some(Rc::new(loader)),
     ..Default::default()
   });
@@ -1055,7 +1055,7 @@ async fn tla_in_esm_extensions_panics() {
   // Panics
   let _runtime = JsRuntime::new(RuntimeOptions {
     module_loader: Some(Rc::new(StaticModuleLoader::default())),
-    extensions: vec![test_ext::init_ops_and_esm()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
 }
@@ -1092,7 +1092,7 @@ async fn esm_extensions_throws() {
   // Panics
   let _runtime = JsRuntime::new(RuntimeOptions {
     module_loader: Some(Rc::new(StaticModuleLoader::default())),
-    extensions: vec![test_ext::init_ops_and_esm()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
 }
@@ -1214,7 +1214,7 @@ async fn terminate_execution_run_event_loop_js() {
   }
   deno_core::extension!(test_ext, ops = [op_async_sleep]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
 
@@ -1312,7 +1312,7 @@ async fn global_template_middleware() {
 
   deno_core::extension!(test_ext, global_template_middleware = gt_middleware);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
 

--- a/core/runtime/tests/mod.rs
+++ b/core/runtime/tests/mod.rs
@@ -80,7 +80,7 @@ fn setup(mode: Mode) -> (JsRuntime, Arc<AtomicUsize>) {
     }
   );
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops(mode, dispatch_count.clone())],
+    extensions: vec![test_ext::init(mode, dispatch_count.clone())],
     shared_array_buffer_store: Some(CrossIsolateStore::default()),
     ..Default::default()
   });

--- a/core/runtime/tests/ops.rs
+++ b/core/runtime/tests/ops.rs
@@ -43,7 +43,7 @@ async fn test_async_opstate_borrow() {
     state = |state| state.put(InnerState(42))
   );
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
 
@@ -75,7 +75,7 @@ async fn test_sync_op_serialize_object_with_numbers_as_keys() {
     ops = [op_sync_serialize_object_with_numbers_as_keys]
   );
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
 
@@ -117,7 +117,7 @@ async fn test_async_op_serialize_object_with_numbers_as_keys() {
     ops = [op_async_serialize_object_with_numbers_as_keys]
   );
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
 
@@ -153,7 +153,7 @@ fn test_op_return_serde_v8_error() {
 
   deno_core::extension!(test_ext, ops = [op_err]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
   assert!(
@@ -182,7 +182,7 @@ fn test_op_high_arity() {
 
   deno_core::extension!(test_ext, ops = [op_add_4]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
   let r = runtime
@@ -207,7 +207,7 @@ fn test_op_disabled() {
 
   deno_core::extension!(test_ext, ops_fn = ops);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
   // Disabled op should be replaced with a function that throws.
@@ -236,7 +236,7 @@ fn test_op_detached_buffer() {
 
   deno_core::extension!(test_ext, ops = [op_sum_take, op_boomerang]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
 
@@ -318,7 +318,7 @@ fn duplicate_op_names() {
 
   deno_core::extension!(test_ext, ops = [a::op_test, op_test]);
   JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
 }
@@ -340,7 +340,7 @@ fn ops_in_js_have_proper_names() {
 
   deno_core::extension!(test_ext, ops = [op_test_sync, op_test_async]);
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     ..Default::default()
   });
 
@@ -508,7 +508,7 @@ await op_void_async_deferred();
 
   let mut runtime = JsRuntime::new(RuntimeOptions {
     module_loader: Some(Rc::new(loader)),
-    extensions: vec![testing::init_ops()],
+    extensions: vec![testing::init()],
     ..Default::default()
   });
 
@@ -621,7 +621,7 @@ pub async fn test_op_metrics() {
 
   let out_clone = out.clone();
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     op_metrics_factory_fn: Some(Box::new(move |_, _, op| {
       let name = op.name;
       if !name.starts_with("op_async") && !name.starts_with("op_sync") {
@@ -702,7 +702,7 @@ pub async fn test_op_metrics_summary_tracker() {
     op.name.starts_with("op_async") || op.name.starts_with("op_sync")
   };
   let mut runtime = JsRuntime::new(RuntimeOptions {
-    extensions: vec![test_ext::init_ops()],
+    extensions: vec![test_ext::init()],
     op_metrics_factory_fn: Some(
       tracker.clone().op_metrics_factory_fn(op_enabled),
     ),

--- a/core/runtime/tests/snapshot.rs
+++ b/core/runtime/tests/snapshot.rs
@@ -333,7 +333,7 @@ pub(crate) fn es_snapshot_without_runtime_module_loader() {
     );
 
     let runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
-      extensions: vec![module_snapshot::init_ops_and_esm()],
+      extensions: vec![module_snapshot::init()],
       ..Default::default()
     });
 
@@ -428,7 +428,7 @@ pub fn snapshot_with_additional_extensions() {
 
   let snapshot = {
     let runtime = JsRuntimeForSnapshot::new(RuntimeOptions {
-      extensions: vec![before_snapshot::init_ops_and_esm()],
+      extensions: vec![before_snapshot::init()],
       ..Default::default()
     });
 
@@ -437,10 +437,7 @@ pub fn snapshot_with_additional_extensions() {
 
   let mut runtime = JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(snapshot),
-    extensions: vec![
-      before_snapshot::init_ops(),
-      after_snapshot::init_ops_and_esm(),
-    ],
+    extensions: vec![before_snapshot::init(), after_snapshot::init()],
     ..Default::default()
   });
 

--- a/testing/checkin/runner/mod.rs
+++ b/testing/checkin/runner/mod.rs
@@ -127,7 +127,7 @@ pub fn create_runtime_from_snapshot_with_options(
   additional_extensions: Vec<Extension>,
   options: RuntimeOptions,
 ) -> JsRuntime {
-  let mut extensions = vec![extensions::checkin_runtime::init_ops::<()>()];
+  let mut extensions = vec![extensions::checkin_runtime::init::<()>()];
   extensions.extend(additional_extensions);
   let module_loader =
     Rc::new(ts_module_loader::TypescriptModuleLoader::default());

--- a/testing/checkin/runner/snapshot.rs
+++ b/testing/checkin/runner/snapshot.rs
@@ -9,8 +9,7 @@ use super::extensions;
 use super::ts_module_loader::maybe_transpile_source;
 
 pub fn create_snapshot() -> Box<[u8]> {
-  let extensions_for_snapshot =
-    vec![extensions::checkin_runtime::init_ops_and_esm::<()>()];
+  let extensions_for_snapshot = vec![extensions::checkin_runtime::init::<()>()];
 
   let runtime_for_snapshot = JsRuntimeForSnapshot::new(RuntimeOptions {
     extensions: extensions_for_snapshot,

--- a/testing/checkin/runner/testing.rs
+++ b/testing/checkin/runner/testing.rs
@@ -49,8 +49,7 @@ pub fn op_test_register(
 /// Run a integration test within the `checkin` runtime. This executes a single file, imports and all,
 /// and compares its output with the `.out` file in the same directory.
 pub fn run_integration_test(test: &str) {
-  let (runtime, _) =
-    create_runtime(None, vec![checkin_testing::init_ops_and_esm()]);
+  let (runtime, _) = create_runtime(None, vec![checkin_testing::init()]);
   run_async(run_integration_test_task(runtime, test.to_owned()));
 }
 
@@ -102,8 +101,7 @@ async fn run_integration_test_task(
 /// Run a unit test within the `checkin` runtime. This loads a file which registers a number of tests,
 /// then each test is run individually and failures are printed.
 pub fn run_unit_test(test: &str) {
-  let (runtime, _) =
-    create_runtime(None, vec![checkin_testing::init_ops_and_esm()]);
+  let (runtime, _) = create_runtime(None, vec![checkin_testing::init()]);
   run_async(run_unit_test_task(runtime, test.to_owned()));
 }
 


### PR DESCRIPTION
track set of extensions in snapshot so that initialization cannot be misused. makes extension use simpler too.

```
load snapshot/plain     time:   [1.2286 ms 1.2341 ms 1.2396 ms]
                        change: [-0.8270% +0.1529% +1.3241%] (p = 0.81 > 0.05)
                        No change in performance detected.
Found 2 outliers among 50 measurements (4.00%)
  2 (4.00%) high severe
load snapshot/transpiled
                        time:   [1.2247 ms 1.2299 ms 1.2358 ms]
                        change: [-1.0111% -0.0696% +0.9278%] (p = 0.89 > 0.05)
                        No change in performance detected.
Found 4 outliers among 50 measurements (8.00%)
```