### PR TITLE
feat: lazy extension initialization

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -89,6 +89,14 @@ pub enum CoreError {
     "Extensions from snapshot loaded in wrong order: expected {0} but got {1}"
   )]
   ExtensionSnapshotMismatch(&'static str, &'static str),
+  #[error(
+    "Number of lazy-initialized extensions ({0}) does not match number of arguments ({1})"
+  )]
+  ExtensionLazyInitCountMismatch(usize, usize),
+  #[error(
+    "Lazy-initialized extensions loaded in wrong order: expected {0} but got {1}"
+  )]
+  ExtensionLazyInitOrderMismatch(&'static str, &'static str),
 }
 
 impl CoreError {
@@ -184,7 +192,9 @@ impl JsErrorClass for CoreError {
       | CoreError::PendingPromiseResolution
       | CoreError::CreateCodeCache(_)
       | CoreError::EvaluateDynamicImportedModule
-      | CoreError::ExtensionSnapshotMismatch(..) => {
+      | CoreError::ExtensionSnapshotMismatch(..)
+      | CoreError::ExtensionLazyInitCountMismatch(..)
+      | CoreError::ExtensionLazyInitOrderMismatch(..) => {
         Cow::Borrowed(GENERIC_ERROR)
       }
     }
@@ -218,7 +228,11 @@ impl JsErrorClass for CoreError {
       | CoreError::PendingPromiseResolution
       | CoreError::EvaluateDynamicImportedModule
       | CoreError::CreateCodeCache(_)
-      | CoreError::ExtensionSnapshotMismatch(..) => self.to_string().into(),
+      | CoreError::ExtensionSnapshotMismatch(..)
+      | CoreError::ExtensionLazyInitCountMismatch(..)
+      | CoreError::ExtensionLazyInitOrderMismatch(..) => {
+        self.to_string().into()
+      }
     }
   }
 

--- a/core/extension_set.rs
+++ b/core/extension_set.rs
@@ -24,10 +24,18 @@ use std::iter::Chain;
 use std::rc::Rc;
 
 /// Contribute to the `OpState` from each extension.
-pub fn setup_op_state(op_state: &mut OpState, extensions: &mut [Extension]) {
+pub fn setup_op_state(
+  op_state: &mut OpState,
+  extensions: &mut [Extension],
+) -> Vec<&'static str> {
+  let mut lazy_extensions = Vec::with_capacity(extensions.len());
   for ext in extensions {
+    if ext.needs_lazy_init {
+      lazy_extensions.push(ext.name);
+    }
     ext.take_state(op_state);
   }
+  lazy_extensions
 }
 
 // TODO(bartlomieju): `deno_core_ext` ops should be returned as a separate

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -72,6 +72,7 @@ pub use crate::convert::ToV8;
 pub use crate::cppgc::GarbageCollected;
 pub use crate::extensions::AccessorType;
 pub use crate::extensions::Extension;
+pub use crate::extensions::ExtensionArguments;
 pub use crate::extensions::ExtensionFileSource;
 pub use crate::extensions::ExtensionFileSourceCode;
 pub use crate::extensions::Op;


### PR DESCRIPTION
Allows something like this:

```rust
let extensions = vec![
  my_cool_ext::lazy_init(),
];

let js_runtime = JsRuntime::new(Options { extensions, .. });

js_runtime.lazy_init_extensions(vec![
  my_cool_ext::args(a, b),
]);
```