### PR TITLE
feat: add `additional_properties` to `JsError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "deno_error"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fae9fe305307b5ef3ee4e8244c79cffcca421ab0ce8634dea0c6b1342f220f"
+checksum = "e983933fb4958fbe1e0a63c1e89a2af72b12c409e86404e547955564e6e217b8"
 dependencies = [
  "deno_error_macro",
  "libc",
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "deno_error_macro"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5abb2556e91848b66f562451fcbcdee2a3b7c88281828908dcf7cca355f5d997"
+checksum = "a1ad5ae3ef15db33e917d6ed54b53d0a98d068c4d1217eb35a4997423203c3ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ deno_ast = { version = "=0.45.1", features = ["transpiling"] }
 deno_core = { version = "0.347.0", path = "./core" }
 deno_core_icudata = "0.74.0"
 deno_core_testing = { path = "./testing" }
-deno_error = { version = "0.5.6", features = ["serde_json", "serde", "url", "tokio"] }
+deno_error = { version = "0.5.7", features = ["serde_json", "serde", "url", "tokio"] }
 deno_ops = { version = "0.223.0", path = "./ops" }
 deno_unsync = "0.4.2"
 serde_v8 = { version = "0.256.0", path = "./serde_v8" }

--- a/core/00_infra.js
+++ b/core/00_infra.js
@@ -99,12 +99,20 @@
     if (typeof error == "object") {
       ErrorCaptureStackTrace(error, buildCustomError);
       if (additionalProperties) {
+        const keys = [];
         for (const property of new SafeArrayIterator(additionalProperties)) {
           const key = property[0];
           if (!(key in error)) {
+            keys.push(key);
             error[key] = property[1];
           }
         }
+        Object.defineProperty(error, SymbolFor("errorAdditionalPropertyKeys"), {
+          value: keys,
+          writable: false,
+          enumerable: false,
+          configurable: false,
+        });
       }
     }
     return error;

--- a/core/error.rs
+++ b/core/error.rs
@@ -885,11 +885,14 @@ impl JsError {
         }
       };
 
-      let key_s = v8::String::new(scope, "errorAdditionalPropertyKeys").unwrap();
+      let key_s =
+        v8::String::new(scope, "errorAdditionalPropertyKeys").unwrap();
       let key = v8::Symbol::for_key(scope, key_s);
       let keys = exception.get(scope, key.into());
 
-      let additional_properties = if let Some(arr) = keys.and_then(|keys| keys.try_cast::<v8::Array>().ok()) {
+      let additional_properties = if let Some(arr) =
+        keys.and_then(|keys| keys.try_cast::<v8::Array>().ok())
+      {
         let mut out = Vec::with_capacity(arr.length() as usize);
 
         for i in 0..arr.length() {

--- a/core/error.rs
+++ b/core/error.rs
@@ -885,13 +885,15 @@ impl JsError {
         }
       };
 
-      let key_s =
+      let additional_properties_string =
         v8::String::new(scope, "errorAdditionalPropertyKeys").unwrap();
-      let key = v8::Symbol::for_key(scope, key_s);
-      let keys = exception.get(scope, key.into());
+      let additional_properties_key =
+        v8::Symbol::for_key(scope, additional_properties_string);
+      let additional_properties =
+        exception.get(scope, additional_properties_key.into());
 
       let additional_properties = if let Some(arr) =
-        keys.and_then(|keys| keys.try_cast::<v8::Array>().ok())
+        additional_properties.and_then(|keys| keys.try_cast::<v8::Array>().ok())
       {
         let mut out = Vec::with_capacity(arr.length() as usize);
 


### PR DESCRIPTION
currently js errors that are printed via console.log in cli display their additional properties, however the same does not apply for when displayed from rust. this allows for `fmt_errors.rs` in cli to change that.