### PR TITLE
Add `#[undefined]` ret type marker

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -160,6 +160,7 @@ pub use crate::runtime::SharedArrayBufferStore;
 pub use crate::runtime::V8_WRAPPER_OBJECT_INDEX;
 pub use crate::runtime::V8_WRAPPER_TYPE_INDEX;
 pub use crate::runtime::stats;
+
 pub use crate::source_map::SourceMapData;
 pub use crate::tasks::V8CrossThreadTaskSpawner;
 pub use crate::tasks::V8TaskSpawner;

--- a/core/runtime/ops_rust_to_v8.rs
+++ b/core/runtime/ops_rust_to_v8.rs
@@ -171,6 +171,9 @@ impl Marker for CppGcProtoMarker {}
 pub struct ToV8Marker;
 impl Marker for ToV8Marker {}
 
+pub struct Undefined;
+impl Marker for Undefined {}
+
 trait Marker {}
 
 /// Helper macro for [`RustToV8`] to reduce boilerplate.
@@ -450,6 +453,16 @@ impl<'a, T: crate::cppgc::GarbageCollected + PrototypeChain + 'static>
     v8::Local::<v8::Value>::from(deno_core::cppgc::make_cppgc_proto_object(
       scope, self.0,
     ))
+  }
+}
+
+//
+// Undefined
+//
+impl<'a> RustToV8<'a> for RustToV8Marker<Undefined, ()> {
+  #[inline(always)]
+  fn to_v8(self, scope: &mut v8::HandleScope<'a>) -> v8::Local<'a, v8::Value> {
+    v8::undefined(scope).into()
   }
 }
 

--- a/ops/op2/dispatch_fast.rs
+++ b/ops/op2/dispatch_fast.rs
@@ -971,7 +971,7 @@ fn map_retval_to_v8_fastcall_type(
     | Arg::SerdeV8(_)
     | Arg::ToV8(_)
     | Arg::WebIDL(_, _, _) => return Ok(None),
-    Arg::Void => V8FastCallType::Void,
+    Arg::VoidUndefined | Arg::Void => V8FastCallType::Void,
     Arg::Numeric(NumericArg::bool, _) => V8FastCallType::Bool,
     Arg::Numeric(NumericArg::u32, _)
     | Arg::Numeric(NumericArg::u16, _)

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -1112,11 +1112,12 @@ pub fn return_value_infallible(
         gs_quote!(generator_state(result) => (#marker(#result)))
       }
     }
-
     ArgMarker::ToV8 => {
       gs_quote!(generator_state(result) => (deno_core::_ops::RustToV8Marker::<deno_core::_ops::ToV8Marker, _>::from(#result)))
     }
-    ArgMarker::None => gs_quote!(generator_state(result) => (#result)),
+    ArgMarker::Undefined | ArgMarker::None => {
+      gs_quote!(generator_state(result) => (#result))
+    }
   };
   let res = match ret_type.slow_retval() {
     ArgSlowRetval::RetVal => {
@@ -1193,6 +1194,9 @@ pub fn return_value_v8_value(
     }
     ArgMarker::ToV8 => {
       quote!(deno_core::_ops::RustToV8Marker::<deno_core::_ops::ToV8Marker, _>::from(#result))
+    }
+    ArgMarker::Undefined => {
+      quote!(deno_core::v8::undefined(#scope).into())
     }
     ArgMarker::None => quote!(#result),
   };

--- a/testing/checkin/runner/ops.rs
+++ b/testing/checkin/runner/ops.rs
@@ -97,6 +97,12 @@ impl TestObjectWrap {
   fn with_scope_fast(&self, _scope: &mut v8::HandleScope) {}
 
   #[fast]
+  #[undefined]
+  fn undefined_result(&self) -> Result<(), JsErrorBox> {
+    Ok(())
+  }
+
+  #[fast]
   #[rename("with_RENAME")]
   fn with_rename(&self) {}
 

--- a/testing/ops.d.ts
+++ b/testing/ops.d.ts
@@ -45,6 +45,7 @@ export class TestObjectWrap {
   withAsyncFn(ms: number): Promise<void>;
   withThis(): void;
   withScopeFast(): void;
+  undefinedResult(): undefined;
 }
 
 export class TestEnumWrap {}

--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -134,6 +134,8 @@ test(async function testDomPoint() {
   wrap.withThis();
   wrap.with_RENAME();
 
+  assertEquals(wrap.undefinedResult(), undefined);
+
   const promise = wrap.withAsyncFn(10);
   assert(promise instanceof Promise);
 


### PR DESCRIPTION
Currently the only alternative is `UndefinedOption<T>` in webidl which isn't fast-compatible. This PR adds a fast API-compatible `#[undefined]` return type attribute.