### PR TITLE
fix: `#[undefined]` attribute

### DIFF
--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -1115,7 +1115,10 @@ pub fn return_value_infallible(
     ArgMarker::ToV8 => {
       gs_quote!(generator_state(result) => (deno_core::_ops::RustToV8Marker::<deno_core::_ops::ToV8Marker, _>::from(#result)))
     }
-    ArgMarker::Undefined | ArgMarker::None => {
+    ArgMarker::Undefined => {
+      gs_quote!(generator_state(scope) => (deno_core::v8::undefined(&mut #scope)))
+    }
+    ArgMarker::None => {
       gs_quote!(generator_state(result) => (#result))
     }
   };

--- a/ops/op2/signature.rs
+++ b/ops/op2/signature.rs
@@ -465,9 +465,8 @@ impl Arg {
             | NumericArg::usize,
             NumericFlag::Number,
           ) => ArgSlowRetval::RetVal,
-          Arg::VoidUndefined | Arg::Void | Arg::Numeric(..) => {
-            ArgSlowRetval::RetVal
-          }
+          Arg::VoidUndefined => ArgSlowRetval::V8LocalNoScope,
+          Arg::Void | Arg::Numeric(..) => ArgSlowRetval::RetVal,
           Arg::External(_) => ArgSlowRetval::V8Local,
           // Fast return value path for empty strings
           Arg::String(_) => ArgSlowRetval::RetValFallible,

--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -134,7 +134,7 @@ test(async function testDomPoint() {
   wrap.withThis();
   wrap.with_RENAME();
 
-  assertEquals(wrap.undefinedResult(), undefined);
+  assert(wrap.undefinedResult() === undefined);
 
   const promise = wrap.withAsyncFn(10);
   assert(promise instanceof Promise);


### PR DESCRIPTION
Apparently `assertEquals` is not strict enough, replaced with a normal `assert`