### PR TITLE
fix(inspector): Preserve floating point precision from inspector response

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -44,7 +44,7 @@ parking_lot.workspace = true
 percent-encoding.workspace = true
 pin-project.workspace = true
 serde.workspace = true
-serde_json = { workspace = true, features = ["preserve_order"] }
+serde_json = { workspace = true, features = ["float_roundtrip", "preserve_order"] }
 serde_v8.workspace = true
 smallvec.workspace = true
 sourcemap.workspace = true


### PR DESCRIPTION
Fixes https://github.com/denoland/deno/issues/29059

Messages from the inspector that hold a number value can result in the loss of floating point precision when deserialized.

When a user sends `0.9999999999999999` in the REPL, V8 returns a [RemoteObject](https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-RemoteObject) that contains the field `"value": 0.9999999999999999`. However, when it's deserialized into `serde_json::Value` here:

https://github.com/denoland/deno_core/blob/fc1ef37491950e82d2fb2e5e426a55723e730ce1/core/inspector.rs#L883-L884

`value` becomes `serde_json::Number(1.0)`, causing the REPL to print `1`. Enabling the `float_roundtrip` feature flag of serde json resolves this.

Before:
![Screenshot_20250608_182040](https://github.com/user-attachments/assets/e8a7dc8a-8b21-4677-87e8-370d5c0f3076)

After:
![Screenshot_20250608_202822-1](https://github.com/user-attachments/assets/141b7bda-f182-4631-964f-f984114b8766)