### PR TITLE
feat(BREAKING): move import meta override to `ModuleLoader` trait

### DIFF
--- a/core/modules/loaders.rs
+++ b/core/modules/loaders.rs
@@ -36,10 +36,6 @@ pub enum ModuleLoaderError {
   )]
   SpecifierMissingLazyLoadable(ModuleSpecifier),
   #[error(
-    "\"npm:\" specifiers are currently not supported in import.meta.resolve()"
-  )]
-  NpmUnsupportedMetaResolve,
-  #[error(
     "Attempted to load JSON module without specifying \"type\": \"json\" attribute in the import statement."
   )]
   JsonMissingAttribute,
@@ -109,6 +105,15 @@ pub trait ModuleLoader {
     referrer: &str,
     kind: ResolutionKind,
   ) -> Result<ModuleSpecifier, ModuleLoaderError>;
+
+  /// Override to customize the behavior of `import.meta.resolve` resolution.
+  fn import_meta_resolve(
+    &self,
+    specifier: &str,
+    referrer: &str,
+  ) -> Result<ModuleSpecifier, ModuleLoaderError> {
+    self.resolve(specifier, referrer, ResolutionKind::DynamicImport)
+  }
 
   /// Given ModuleSpecifier, load its source code.
   ///

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -65,8 +65,6 @@ type PrepareLoadFuture =
 
 type CodeCacheReadyFuture = dyn Future<Output = ()>;
 
-use super::ImportMetaResolveCallback;
-
 struct ModEvaluate {
   module_map: Rc<ModuleMap>,
   sender: Option<oneshot::Sender<Result<(), CoreError>>>,
@@ -125,7 +123,6 @@ pub(crate) struct ModuleMap {
   // Handling of futures for loading module sources
   // TODO(mmastrac): we should not be swapping this loader out
   pub(crate) loader: RefCell<Rc<dyn ModuleLoader>>,
-  pub(crate) import_meta_resolve_cb: ImportMetaResolveCallback,
 
   exception_state: Rc<ExceptionState>,
   dynamic_import_map: RefCell<HashMap<ModuleLoadId, DynImportState>>,
@@ -203,14 +200,12 @@ impl ModuleMap {
   pub(crate) fn new(
     loader: Rc<dyn ModuleLoader>,
     exception_state: Rc<ExceptionState>,
-    import_meta_resolve_cb: ImportMetaResolveCallback,
     will_snapshot: bool,
   ) -> Self {
     Self {
       will_snapshot,
       loader: loader.into(),
       exception_state,
-      import_meta_resolve_cb,
       dyn_module_evaluate_idle_counter: Default::default(),
       dynamic_import_map: Default::default(),
       preparing_dynamic_imports: Default::default(),

--- a/core/modules/mod.rs
+++ b/core/modules/mod.rs
@@ -178,27 +178,6 @@ impl From<&'static [u8]> for ModuleCodeBytes {
   }
 }
 
-/// Callback to customize value of `import.meta.resolve("./foo.ts")`.
-pub type ImportMetaResolveCallback = Box<
-  dyn Fn(
-    &dyn ModuleLoader,
-    String,
-    String,
-  ) -> Result<ModuleSpecifier, ModuleLoaderError>,
->;
-
-pub(crate) fn default_import_meta_resolve_cb(
-  loader: &dyn ModuleLoader,
-  specifier: String,
-  referrer: String,
-) -> Result<ModuleSpecifier, ModuleLoaderError> {
-  if specifier.starts_with("npm:") {
-    return Err(ModuleLoaderError::NpmUnsupportedMetaResolve);
-  }
-
-  loader.resolve(&specifier, &referrer, ResolutionKind::DynamicImport)
-}
-
 /// Callback to validate import attributes. If the validation fails and exception
 /// should be thrown using `scope.throw_exception()`.
 pub type ValidateImportAttributesCb =

--- a/core/runtime/bindings.rs
+++ b/core/runtime/bindings.rs
@@ -889,7 +889,7 @@ fn import_meta_resolve(
   let import_meta_resolve_result = {
     let loader = loader.borrow();
     let loader = loader.as_ref();
-    (module_map_rc.import_meta_resolve_cb)(loader, specifier_str, referrer)
+    loader.import_meta_resolve(&specifier_str, &referrer)
   };
 
   match import_meta_resolve_result {

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -41,7 +41,6 @@ use crate::modules::EvalContextCodeCacheReadyCb;
 use crate::modules::EvalContextGetCodeCacheCb;
 use crate::modules::ExtCodeCache;
 use crate::modules::ExtModuleLoader;
-use crate::modules::ImportMetaResolveCallback;
 use crate::modules::IntoModuleCodeString;
 use crate::modules::IntoModuleName;
 use crate::modules::ModuleId;
@@ -50,7 +49,6 @@ use crate::modules::ModuleMap;
 use crate::modules::ModuleName;
 use crate::modules::RequestedModuleType;
 use crate::modules::ValidateImportAttributesCb;
-use crate::modules::default_import_meta_resolve_cb;
 use crate::modules::script_origin;
 use crate::ops_metrics::OpMetricsFactoryFn;
 use crate::ops_metrics::dispatch_metrics_async;
@@ -514,12 +512,6 @@ pub struct RuntimeOptions {
   /// To signal validation failure, users should throw an V8 exception inside
   /// the callback.
   pub validate_import_attributes_cb: Option<ValidateImportAttributesCb>,
-
-  /// A callback that can be used to customize behavior of
-  /// `import.meta.resolve()` API. If no callback is provided, a default one
-  /// is used. The default callback returns value of
-  /// `RuntimeOptions::module_loader::resolve()` call.
-  pub import_meta_resolve_callback: Option<ImportMetaResolveCallback>,
 
   /// A callback that is called when the event loop has no more work to do,
   /// but there are active, non-blocking inspector session (eg. Chrome
@@ -1056,14 +1048,10 @@ impl JsRuntime {
     // ...now that JavaScript bindings to ops are available we can deserialize
     // modules stored in the snapshot (because they depend on the ops and external
     // references must match properly) and recreate a module map...
-    let import_meta_resolve_cb = options
-      .import_meta_resolve_callback
-      .unwrap_or_else(|| Box::new(default_import_meta_resolve_cb));
     let exception_state = context_state.exception_state.clone();
     let module_map = Rc::new(ModuleMap::new(
       loader,
       exception_state.clone(),
-      import_meta_resolve_cb,
       will_snapshot,
     ));
 


### PR DESCRIPTION
Makes things a lot easier in the CLI because I can control import meta resolution at the same place as regular resolution (note: enum is a private type in the cli code).

![image](https://github.com/user-attachments/assets/d3ebbaac-88f5-4272-9b75-973ebf671dd0)
