### PR TITLE
cppgc: Support the new APIs from rusty_v8

### DIFF
--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -1937,7 +1937,7 @@ mod tests {
     pub value: u32,
   }
 
-  impl GarbageCollected for TestResource {
+  unsafe impl GarbageCollected for TestResource {
     fn get_name(&self) -> &'static std::ffi::CStr {
       c"TestResource"
     }

--- a/testing/checkin/runner/ops_async.rs
+++ b/testing/checkin/runner/ops_async.rs
@@ -67,7 +67,7 @@ pub struct TestResource {
   value: u32,
 }
 
-impl GarbageCollected for TestResource {
+unsafe impl GarbageCollected for TestResource {
   fn get_name(&self) -> &'static std::ffi::CStr {
     c"TestResource"
   }

--- a/testing/checkin/runner/ops_worker.rs
+++ b/testing/checkin/runner/ops_worker.rs
@@ -34,7 +34,7 @@ pub struct WorkerControl {
   shutdown_flag: Option<UnboundedSender<()>>,
 }
 
-impl GarbageCollected for WorkerControl {
+unsafe impl GarbageCollected for WorkerControl {
   fn get_name(&self) -> &'static std::ffi::CStr {
     c"WorkerControl"
   }


### PR DESCRIPTION
This implements the necessary changes to support the soundness fixes from https://github.com/denoland/rusty_v8/pull/1802.

I'm creating this as a draft for now because (a) it currently can't build until there is a release of the v8 crate with those changes, and (b) there are designs that probably need discussion.

@devsnek 