### PR TITLE
fix: op_current_user_call_site didn't handling eval correctly

### DIFF
--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -1096,23 +1096,31 @@ pub fn op_current_user_call_site(
     if !frame.is_user_javascript() {
       continue;
     }
-    let file_name = frame
-      .get_script_name(scope)
-      .unwrap()
-      .to_rust_string_lossy(scope);
-    // TODO: this condition should be configurable. It's a CLI assumption.
-    if (file_name.starts_with("ext:") || file_name.starts_with("node:"))
-      && i != frame_count - 1
-    {
-      continue;
-    }
     let line_number = frame.get_line_number() as u32;
     let column_number = frame.get_column() as u32;
-    let application = js_runtime_state
-      .source_mapper
-      .borrow_mut()
-      .apply_source_map(&file_name, line_number, column_number);
-
+    let (file_name, application) = match frame.get_script_name(scope) {
+      Some(name) => {
+        let file_name = name.to_rust_string_lossy(scope);
+        // TODO: this condition should be configurable. It's a CLI assumption.
+        if (file_name.starts_with("ext:") || file_name.starts_with("node:") || file_name.starts_with("checkin:"))
+            && i != frame_count - 1
+        {
+          continue;
+        }
+        let application = js_runtime_state
+            .source_mapper
+            .borrow_mut()
+            .apply_source_map(&file_name, line_number, column_number);
+        (file_name, application)
+      },
+      None => {
+        if frame.is_eval() {
+          ("[eval]".to_string(), SourceMapApplication::Unchanged)
+        } else {
+          ("[unknown]".to_string(), SourceMapApplication::Unchanged)
+        }
+      },
+    };
     match application {
       SourceMapApplication::Unchanged => {
         write_line_and_col_to_ret_buf(ret_buf, line_number, column_number);

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -1102,24 +1102,26 @@ pub fn op_current_user_call_site(
       Some(name) => {
         let file_name = name.to_rust_string_lossy(scope);
         // TODO: this condition should be configurable. It's a CLI assumption.
-        if (file_name.starts_with("ext:") || file_name.starts_with("node:") || file_name.starts_with("checkin:"))
-            && i != frame_count - 1
+        if (file_name.starts_with("ext:")
+          || file_name.starts_with("node:")
+          || file_name.starts_with("checkin:"))
+          && i != frame_count - 1
         {
           continue;
         }
         let application = js_runtime_state
-            .source_mapper
-            .borrow_mut()
-            .apply_source_map(&file_name, line_number, column_number);
+          .source_mapper
+          .borrow_mut()
+          .apply_source_map(&file_name, line_number, column_number);
         (file_name, application)
-      },
+      }
       None => {
         if frame.is_eval() {
           ("[eval]".to_string(), SourceMapApplication::Unchanged)
         } else {
           ("[unknown]".to_string(), SourceMapApplication::Unchanged)
         }
-      },
+      }
     };
     match application {
       SourceMapApplication::Unchanged => {

--- a/testing/checkin/runner/extensions.rs
+++ b/testing/checkin/runner/extensions.rs
@@ -68,6 +68,7 @@ deno_core::extension!(
     "checkin:timers" = "timers.ts",
     "checkin:worker" = "worker.ts",
     "checkin:throw" = "throw.ts",
+    "checkin:callsite" = "callsite.ts",
   ],
   state = |state| {
     state.put(TestData::default());

--- a/testing/checkin/runtime/__init.js
+++ b/testing/checkin/runtime/__init.js
@@ -6,10 +6,12 @@ import * as timers from "checkin:timers";
 import * as worker from "checkin:worker";
 import * as throw_ from "checkin:throw";
 import * as object from "checkin:object";
+import * as callsite from "checkin:callsite";
 async;
 error;
 throw_;
 object;
+callsite;
 
 globalThis.console = console.console;
 globalThis.setTimeout = timers.setTimeout;

--- a/testing/checkin/runtime/callsite.ts
+++ b/testing/checkin/runtime/callsite.ts
@@ -1,0 +1,11 @@
+import { op_current_user_call_site } from 'ext:core/ops'
+
+const callSiteRetBuf = new Uint32Array(2);
+const callSiteRetBufU8 = new Uint8Array(callSiteRetBuf.buffer);
+
+export function getCallSite() {
+    const fileName = op_current_user_call_site(callSiteRetBufU8);
+    const lineNumber = callSiteRetBuf[0];
+    const columnNumber = callSiteRetBuf[1];
+    return { fileName, lineNumber, columnNumber };
+}

--- a/testing/checkin/runtime/callsite.ts
+++ b/testing/checkin/runtime/callsite.ts
@@ -1,11 +1,12 @@
-import { op_current_user_call_site } from 'ext:core/ops'
+// Copyright 2018-2025 the Deno authors. MIT license.
+import { op_current_user_call_site } from "ext:core/ops";
 
 const callSiteRetBuf = new Uint32Array(2);
 const callSiteRetBufU8 = new Uint8Array(callSiteRetBuf.buffer);
 
 export function getCallSite() {
-    const fileName = op_current_user_call_site(callSiteRetBufU8);
-    const lineNumber = callSiteRetBuf[0];
-    const columnNumber = callSiteRetBuf[1];
-    return { fileName, lineNumber, columnNumber };
+  const fileName = op_current_user_call_site(callSiteRetBufU8);
+  const lineNumber = callSiteRetBuf[0];
+  const columnNumber = callSiteRetBuf[1];
+  return { fileName, lineNumber, columnNumber };
 }

--- a/testing/lib.rs
+++ b/testing/lib.rs
@@ -49,6 +49,7 @@ unit_test!(
   tc39_test,
   timer_test,
   type_test,
+  callsite_test,
 );
 
 // Test the load and run of an entire file within the `checkin` infrastructure.

--- a/testing/ops.d.ts
+++ b/testing/ops.d.ts
@@ -21,6 +21,8 @@ export function op_worker_send(...any: any[]): any;
 export function op_worker_spawn(...any: any[]): any;
 export function op_worker_terminate(...any: any[]): any;
 
+export function op_current_user_call_site(...any: any[]): any;
+
 export class DOMPointReadOnly {}
 
 export class DOMPoint {

--- a/testing/tsconfig.json
+++ b/testing/tsconfig.json
@@ -12,7 +12,8 @@
       "checkin:throw": ["checkin/runtime/throw.ts"],
       "checkin:timers": ["checkin/runtime/timers.ts"],
       "checkin:worker": ["checkin/runtime/worker.ts"],
-      "checkin:object": ["checkin/runtime/object.ts"]
+      "checkin:object": ["checkin/runtime/object.ts"],
+      "checkin:callsite": ["checkin/runtime/callsite.ts"]
     },
     "lib": ["ESNext", "DOM", "ES2023.Array"],
     "module": "ESNext",

--- a/testing/unit/callsite_test.ts
+++ b/testing/unit/callsite_test.ts
@@ -5,8 +5,8 @@ import { getCallSite } from "checkin:callsite";
 test(function testCallSiteOps() {
   const callSite = getCallSite();
   assertEquals(callSite.fileName, "test:///unit/callsite_test.ts");
-  assertEquals(callSite.lineNumber, 5);
-  assertEquals(callSite.columnNumber, 22);
+  assertEquals(callSite.lineNumber, 6);
+  assertEquals(callSite.columnNumber, 20);
 });
 
 test(function testCallSiteOpEval() {

--- a/testing/unit/callsite_test.ts
+++ b/testing/unit/callsite_test.ts
@@ -1,0 +1,16 @@
+import { test, assertEquals } from "checkin:testing";
+import { getCallSite } from "checkin:callsite"
+
+test(async function testCallSiteOps() {
+    const callSite = getCallSite()
+    assertEquals(callSite.fileName, "test:///unit/callsite_test.ts")
+    assertEquals(callSite.lineNumber, 5)
+    assertEquals(callSite.columnNumber, 22)
+})
+
+test(async function testCallSiteOpEval() {
+    const callSite = eval("getCallSite()")
+    assertEquals(callSite.fileName, "[eval]")
+    assertEquals(callSite.lineNumber, 1)
+    assertEquals(callSite.columnNumber, 1)
+})

--- a/testing/unit/callsite_test.ts
+++ b/testing/unit/callsite_test.ts
@@ -1,16 +1,17 @@
-import { test, assertEquals } from "checkin:testing";
-import { getCallSite } from "checkin:callsite"
+// Copyright 2018-2025 the Deno authors. MIT license.
+import { assertEquals, test } from "checkin:testing";
+import { getCallSite } from "checkin:callsite";
 
-test(async function testCallSiteOps() {
-    const callSite = getCallSite()
-    assertEquals(callSite.fileName, "test:///unit/callsite_test.ts")
-    assertEquals(callSite.lineNumber, 5)
-    assertEquals(callSite.columnNumber, 22)
-})
+test(function testCallSiteOps() {
+  const callSite = getCallSite();
+  assertEquals(callSite.fileName, "test:///unit/callsite_test.ts");
+  assertEquals(callSite.lineNumber, 5);
+  assertEquals(callSite.columnNumber, 22);
+});
 
-test(async function testCallSiteOpEval() {
-    const callSite = eval("getCallSite()")
-    assertEquals(callSite.fileName, "[eval]")
-    assertEquals(callSite.lineNumber, 1)
-    assertEquals(callSite.columnNumber, 1)
-})
+test(function testCallSiteOpEval() {
+  const callSite = eval("getCallSite()");
+  assertEquals(callSite.fileName, "[eval]");
+  assertEquals(callSite.lineNumber, 1);
+  assertEquals(callSite.columnNumber, 1);
+});

--- a/tools/import_map.json
+++ b/tools/import_map.json
@@ -8,6 +8,7 @@
     "checkin:testing": "../testing/checkin/runtime/testing.ts",
     "checkin:throw": "../testing/checkin/runtime/throw.ts",
     "checkin:timers": "../testing/checkin/runtime/timers.ts",
-    "checkin:worker": "../testing/checkin/runtime/worker.ts"
+    "checkin:worker": "../testing/checkin/runtime/worker.ts",
+    "checkin:callsite": "../testing/checkin/runtime/callsite.ts"
   }
 }


### PR DESCRIPTION
close https://github.com/denoland/deno/issues/29306

Correctly handle when `script_name` is `None` (e.g. in `eval`)

Add tests for the for both direct call and call inside `eval`