### PR TITLE
Revert "chore: sync release profile overrides with cli"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,31 +88,9 @@ opt-level = 'z' # Optimize for size
 inherits = "release"
 debug = true
 
-[profile.release.package.base64-simd]
-opt-level = 3
-[profile.release.package.bytes]
-opt-level = 3
-[profile.release.package.deno_core]
-opt-level = 3
-[profile.release.package.fastwebsockets]
-opt-level = 3
-[profile.release.package.futures-util]
-opt-level = 3
-[profile.release.package.hyper]
-opt-level = 3
-[profile.release.package.miniz_oxide]
-opt-level = 3
-[profile.release.package.rand]
-opt-level = 3
-[profile.release.package.serde]
-opt-level = 3
-[profile.release.package.serde_v8]
-opt-level = 3
-[profile.release.package.tokio]
-opt-level = 3
-[profile.release.package.url]
-opt-level = 3
-[profile.release.package.v8]
-opt-level = 3
-[profile.release.package.deno_core_testing]
-opt-level = 3
+# NB: the `bench` and `release` profiles must remain EXACTLY the same.
+[profile.bench]
+codegen-units = 1
+incremental = true
+lto = true
+opt-level = 'z' # Optimize for size


### PR DESCRIPTION
Caused a valgrind failure on main.

Reverts denoland/deno_core#1026