### PR TITLE
perf: optimize size of v8 bindings

### DIFF
--- a/core/runtime/ops.rs
+++ b/core/runtime/ops.rs
@@ -263,7 +263,6 @@ pub fn to_cow_byte_ptr(
 }
 
 /// Converts a [`v8::Value`] to an owned string.
-#[inline(always)]
 pub fn to_string(scope: &mut v8::Isolate, string: &v8::Value) -> String {
   if !string.is_string() {
     return String::new();
@@ -275,7 +274,6 @@ pub fn to_string(scope: &mut v8::Isolate, string: &v8::Value) -> String {
 
 /// Converts a [`v8::String`] to either an owned string, or a borrowed string, depending on whether it fits into the
 /// provided buffer.
-#[inline(always)]
 pub fn to_str<'a, const N: usize>(
   scope: &mut v8::Isolate,
   string: &v8::Value,

--- a/ops/op2/mod.rs
+++ b/ops/op2/mod.rs
@@ -304,6 +304,7 @@ pub(crate) fn generate_op2(
         #op_fn_sig;
       }
       impl Callable for #ident {
+        #[inline(never)]
         #[allow(clippy::too_many_arguments)]
         #(#attrs)*
         #op_fn
@@ -313,6 +314,7 @@ pub(crate) fn generate_op2(
     quote! {
       impl <#(#generic : #bound),*> #rust_name <#(#generic),*> {
         #[allow(clippy::too_many_arguments)]
+        #[inline(never)]
         #(#attrs)*
         #op_fn
       }


### PR DESCRIPTION
Never inline user defined code. Like never.

Before:
```
 % cargo bloat -n 1000 --release | grep op_
    Analyzing target/release/dcore

 0.0%   0.0%   8.5KiB                      deno_core deno_core::runtime::jsruntime::JsRuntime::poll_event_loop_inner
 0.0%   0.0%   4.9KiB                      deno_core deno_core::ops_builtin::op_import_sync::op_import_sync::slow_fun...
 0.0%   0.0%   3.2KiB                      deno_core deno_core::ops_builtin_v8::op_eval_context::op_eval_context::slo...
 0.0%   0.0%   2.6KiB                      deno_core deno_core::ops_builtin_v8::op_serialize::op_serialize::slow_func...
 0.0%   0.0%   2.5KiB              deno_core_testing deno_core_testing::checkin::runner::ops::op_stats_capture::op_st...
```

After:
```
 % cargo bloat -n 1000 --release | grep op_
    Analyzing target/release/dcore

 0.0%   0.0%   8.5KiB                      deno_core deno_core::runtime::jsruntime::JsRuntime::poll_event_loop_inner
 0.0%   0.0%   3.9KiB                      deno_core deno_core::ops_builtin::op_import_sync::op_import_sync::call
 0.0%   0.0%   2.7KiB                      deno_core deno_core::ops_builtin_v8::op_eval_context::op_eval_context::call
 0.0%   0.0%   2.5KiB              deno_core_testing deno_core_testing::checkin::runner::ops::op_stats_capture::op_st...
```