### PR TITLE
feat: expose dispatch_exception function

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -314,6 +314,9 @@ pub fn to_v8_error<'a>(
   }
 }
 
+/// Effectively throw an uncatchable error. This will terminate runtime
+/// execution before any more JS code can run, except in the REPL where it
+/// should just output the error to the console.
 pub fn dispatch_exception(
   scope: &mut v8::HandleScope,
   exception: v8::Local<v8::Value>,
@@ -324,7 +327,7 @@ pub fn dispatch_exception(
     inspector.exception_thrown(scope, exception, false);
     inspector.is_dispatching_message()
   }) {
-    // This indicates that the op is being called from a REPL. Skip termination.
+    // This indicates that the fn is being called from a REPL. Skip termination.
     return;
   }
 

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -3,6 +3,7 @@
 use crate::JsBuffer;
 use crate::JsRuntime;
 use crate::OpState;
+use crate::error;
 use crate::error::CoreError;
 use crate::error::JsError;
 use crate::error::is_instance_of_error;
@@ -1097,18 +1098,7 @@ pub fn op_dispatch_exception(
   exception: v8::Local<v8::Value>,
   promise: bool,
 ) {
-  let state = JsRuntime::state_from(scope);
-  if let Some(true) = state.with_inspector(|inspector| {
-    inspector.exception_thrown(scope, exception, false);
-    inspector.is_dispatching_message()
-  }) {
-    // This indicates that the op is being called from a REPL. Skip termination.
-    return;
-  }
-
-  JsRealm::exception_state_from_scope(scope)
-    .set_dispatched_exception(v8::Global::new(scope, exception), promise);
-  scope.terminate_execution();
+  error::dispatch_exception(scope, exception, promise);
 }
 
 #[op2]


### PR DESCRIPTION
Currently, the function to terminate a process when an exception occurs can only be accessed from JS (ops). I would like to make it accessible from Rust as well for https://github.com/denoland/deno/pull/30128.