### PR TITLE
refactor: make JsError constructors return Box<JsError>

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -701,14 +701,18 @@ impl JsError {
   pub fn from_v8_exception(
     scope: &mut v8::HandleScope,
     exception: v8::Local<v8::Value>,
-  ) -> Self {
-    Self::inner_from_v8_exception(scope, exception, Default::default())
+  ) -> Box<Self> {
+    Box::new(Self::inner_from_v8_exception(
+      scope,
+      exception,
+      Default::default(),
+    ))
   }
 
   pub fn from_v8_message<'a>(
     scope: &'a mut v8::HandleScope,
     msg: v8::Local<'a, v8::Message>,
-  ) -> Self {
+  ) -> Box<Self> {
     // Create a new HandleScope because we're creating a lot of new local
     // handles below.
     let scope = &mut v8::HandleScope::new(scope);
@@ -738,7 +742,7 @@ impl JsError {
       }
     }
 
-    Self {
+    Box::new(Self {
       name: None,
       message: None,
       exception_message,
@@ -749,7 +753,7 @@ impl JsError {
       stack: None,
       aggregated: None,
       additional_properties: vec![],
-    }
+    })
   }
 
   fn inner_from_v8_exception<'a>(
@@ -1176,7 +1180,7 @@ pub(crate) fn exception_to_err(
   }
   scope.set_microtasks_policy(v8::MicrotasksPolicy::Auto);
 
-  Box::new(js_error)
+  js_error
 }
 
 v8_static_strings::v8_static_strings! {

--- a/core/error.rs
+++ b/core/error.rs
@@ -903,7 +903,7 @@ impl JsError {
           for i in 0..errors.length() {
             let error = errors.get_index(scope, i).unwrap();
             let js_error = Self::from_v8_exception(scope, error);
-            agg.push(js_error);
+            agg.push(*js_error);
           }
           aggregated = Some(agg);
         }

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -1277,7 +1277,7 @@ impl ModuleMap {
             // Module was rejected
             let err = promise.result(tc_scope);
             let err = JsError::from_v8_exception(tc_scope, err);
-            _ = sender.sender.take().unwrap().send(Err(Box::new(err)));
+            _ = sender.sender.take().unwrap().send(Err(err));
           }
           PromiseState::Pending => {
             // User code shouldn't be able to both cause the runtime to fail and leave the promise as

--- a/core/modules/map.rs
+++ b/core/modules/map.rs
@@ -181,10 +181,10 @@ impl ModuleMap {
       match module.get_status() {
         v8::ModuleStatus::Errored => {
           return Err(
-            CoreErrorKind::Js(Box::new(JsError::from_v8_exception(
+            CoreErrorKind::Js(JsError::from_v8_exception(
               scope,
               module.get_exception(),
-            )))
+            ))
             .into_box(),
           );
         }
@@ -1333,19 +1333,15 @@ impl ModuleMap {
     let Some(value) = module.evaluate(tc_scope) else {
       let exception = tc_scope.exception().unwrap();
       return Err(
-        CoreErrorKind::Js(Box::new(JsError::from_v8_exception(
-          tc_scope, exception,
-        )))
-        .into_box(),
+        CoreErrorKind::Js(JsError::from_v8_exception(tc_scope, exception))
+          .into_box(),
       );
     };
 
     if let Some(exception) = tc_scope.exception() {
       return Err(
-        CoreErrorKind::Js(Box::new(JsError::from_v8_exception(
-          tc_scope, exception,
-        )))
-        .into_box(),
+        CoreErrorKind::Js(JsError::from_v8_exception(tc_scope, exception))
+          .into_box(),
       );
     }
 
@@ -1362,10 +1358,8 @@ impl ModuleMap {
       PromiseState::Rejected => {
         let err = promise.result(tc_scope);
         Err(
-          CoreErrorKind::Js(Box::new(JsError::from_v8_exception(
-            tc_scope, err,
-          )))
-          .into_box(),
+          CoreErrorKind::Js(JsError::from_v8_exception(tc_scope, err))
+            .into_box(),
         )
       }
       PromiseState::Pending => {

--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -1084,7 +1084,7 @@ pub fn op_destructure_error(
   scope: &mut v8::HandleScope,
   error: v8::Local<v8::Value>,
 ) -> JsError {
-  JsError::from_v8_exception(scope, error)
+  *JsError::from_v8_exception(scope, error)
 }
 
 /// Effectively throw an uncatchable error. This will terminate runtime

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -2154,7 +2154,7 @@ fn find_and_report_stalled_level_await_in_any_realm(
     // situation is gonna be very rare, if ever happening).
     let msg = v8::Local::new(scope, &messages[0]);
     let js_error = JsError::from_v8_message(scope, msg);
-    return Box::new(js_error);
+    return js_error;
   }
 
   unreachable!("Expected at least one stalled top-level await");


### PR DESCRIPTION
Makes it much easier to update Deno