### PR TITLE
fix: set `name` and `length` properties to `op2` object methods

### DIFF
--- a/ops/op2/mod.rs
+++ b/ops/op2/mod.rs
@@ -280,7 +280,11 @@ pub(crate) fn generate_op2(
       }
     };
 
-  let arg_count: usize = args.len() + is_async as usize;
+  let arg_count: usize = if config.required != 0 {
+    config.required as usize
+  } else {
+    args.len() + is_async as usize
+  };
   let vis = func.vis;
   let generic = signature
     .generic_bounds

--- a/testing/unit/resource_test.ts
+++ b/testing/unit/resource_test.ts
@@ -104,6 +104,13 @@ test(async function testDomPoint() {
   assertEquals(p4.x, 0);
   assertEquals(p5.x, 200);
 
+  assertEquals(DOMPoint.fromPoint.length, 1);
+  const { get, set } = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(p1), "x");
+  assertEquals(get.name, "x");
+  assertEquals(get.length, 0);
+  assertEquals(set.name, "x");
+  assertEquals(set.length, 1);
+
   assert(p1 instanceof DOMPoint);
   assert(p1 instanceof DOMPointReadOnly);
 


### PR DESCRIPTION
fix #1162