### PR TITLE
fix: restore debug symbols for Windows

### DIFF
--- a/.github/workflows/ci-job.yml
+++ b/.github/workflows/ci-job.yml
@@ -132,11 +132,4 @@ jobs:
       CARGO_INCREMENTAL: 0
       GH_ACTIONS: 1
       RUST_BACKTRACE: full
-      # NOTE(bartlomieju): during upgrade to V8 14.0 we had to disable debug info
-      # because we were running into PDB errors.
-      RUSTFLAGS: >-
-        -D warnings -Cdebuginfo=0 ${{ inputs.os == 'windows-2022' &&
-        '-Clink-arg=/DEBUG:NONE' || '' }}
-      RUSTDOCFLAGS: >-
-        -D warnings -Cdebuginfo=0 ${{ inputs.os == 'windows-2022' &&
-        '-Clink-arg=/DEBUG:NONE' || '' }}
+      RUSTFLAGS: -D warnings

--- a/.github/workflows/ci-job.yml
+++ b/.github/workflows/ci-job.yml
@@ -132,4 +132,11 @@ jobs:
       CARGO_INCREMENTAL: 0
       GH_ACTIONS: 1
       RUST_BACKTRACE: full
-      RUSTFLAGS: -D warnings
+        # NOTE(bartlomieju): during upgrade to V8 14.0 we had to disable debug info
+      # because we were running into PDB errors.
+      RUSTFLAGS: >-
+        -D warnings ${{ inputs.os == 'windows-2022' &&
+        '-Csymbol-mangling-version=v0' || '' }}
+      RUSTDOCFLAGS: >-
+        -D warnings ${{ inputs.os == 'windows-2022' &&
+        '-Csymbol-mangling-version=v0' || '' }}

--- a/.github/workflows/ci-test/action.yml
+++ b/.github/workflows/ci-test/action.yml
@@ -6,10 +6,6 @@ runs:
       shell: bash
       run: |-
         cargo nextest run --workspace --release --features "deno_core/default deno_core/include_js_files_for_snapshotting deno_core/unsafe_runtime_options deno_core/unsafe_use_unprotected_platform" --tests --examples --exclude deno_ops_compile_test_runner
-      
-    - name: Cargo test (docs)
-      shell: bash
-      run: |-
         cargo test --doc
 
     - name: Run examples

--- a/ops/op2/test_cases_fail/lifetimes.rs
+++ b/ops/op2/test_cases_fail/lifetimes.rs
@@ -2,6 +2,7 @@
 #![deny(warnings)]
 deno_ops_compile_test_runner::prelude!();
 use deno_core::GarbageCollected;
+use deno_core::v8;
 
 struct Wrap;
 

--- a/ops/op2/test_cases_fail/lifetimes.stderr
+++ b/ops/op2/test_cases_fail/lifetimes.stderr
@@ -1,11 +1,3 @@
-error[E0433]: failed to resolve: use of unresolved module or unlinked crate `v8`
- --> $WORKSPACE/ops/op2/test_cases_fail/lifetimes.rs
-  |
-  |   fn trace(&self, _visitor: &mut v8::cppgc::Visitor) {}
-  |                                  ^^ use of unresolved module or unlinked crate `v8`
-  |
-  = help: if you wanted to use a crate named `v8`, use `cargo add v8` to add it to your `Cargo.toml`
-
 error[E0716]: temporary value dropped while borrowed
  --> $WORKSPACE/ops/op2/test_cases_fail/lifetimes.rs
   |


### PR DESCRIPTION
Reverting some of the changes from https://github.com/denoland/deno_core/pull/1187,
that were blocking the V8 upgrade but resulted in removal of debug symbols for Windows.