### PR TITLE
fix: look for file URLs in op_current_user_call_site()

### DIFF
--- a/core/ops_builtin_v8.rs
+++ b/core/ops_builtin_v8.rs
@@ -1140,9 +1140,8 @@ pub fn op_current_user_call_site(
       Some(name) => {
         let file_name = name.to_rust_string_lossy(scope);
         // TODO: this condition should be configurable. It's a CLI assumption.
-        if (file_name.starts_with("ext:")
-          || file_name.starts_with("node:")
-          || file_name.starts_with("checkin:"))
+        if (!file_name.starts_with("file:")
+          || file_name.contains("/node_modules/"))
           && i != frame_count - 1
         {
           continue;


### PR DESCRIPTION
- Needed for https://github.com/denoland/deno/pull/30802.

It seems this function is only used in `deno test`.