### PR TITLE
feat: remove unneeded inspector types

### DIFF
--- a/core/inspector.rs
+++ b/core/inspector.rs
@@ -4,8 +4,6 @@
 //! <https://chromedevtools.github.io/devtools-protocol/>
 //! <https://hyperandroid.com/2020/02/12/v8-inspector-from-an-embedder-standpoint/>
 
-use crate::error::CoreError;
-use crate::error::CoreErrorKind;
 use crate::futures::channel::mpsc;
 use crate::futures::channel::mpsc::UnboundedReceiver;
 use crate::futures::channel::mpsc::UnboundedSender;
@@ -16,8 +14,6 @@ use crate::futures::stream::StreamExt;
 use crate::futures::task;
 use crate::serde_json::json;
 
-use boxed_error::Boxed;
-use deno_error::JsErrorBox;
 use parking_lot::Mutex;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -30,7 +26,6 @@ use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 use std::thread;
-use thiserror::Error;
 
 #[derive(Debug)]
 pub enum InspectorMsgKind {
@@ -54,7 +49,7 @@ pub type SessionProxyReceiver = UnboundedReceiver<String>;
 pub struct InspectorSessionProxy {
   pub tx: SessionProxySender,
   pub rx: SessionProxyReceiver,
-  pub options: InspectorSessionOptions,
+  pub kind: InspectorSessionKind,
 }
 
 pub type InspectorSessionSend = Box<dyn Fn(InspectorMsg)>;
@@ -213,7 +208,7 @@ impl JsRuntimeInspectorState {
               let _ = session_proxy.tx.unbounded_send(msg);
             }),
             Some(session_proxy.rx),
-            session_proxy.options,
+            session_proxy.kind,
           );
           let prev = sessions.handshake.replace(session);
           assert!(prev.is_none());
@@ -453,7 +448,7 @@ impl JsRuntimeInspector {
   pub fn create_local_session(
     inspector: Rc<JsRuntimeInspector>,
     callback: InspectorSessionSend,
-    options: InspectorSessionOptions,
+    kind: InspectorSessionKind,
   ) -> LocalInspectorSession {
     let (session_id, sessions) = {
       let sessions = inspector.state.sessions.clone();
@@ -463,7 +458,7 @@ impl JsRuntimeInspector {
         inspector.state.is_dispatching_message.clone(),
         callback,
         None,
-        options,
+        kind,
       );
 
       let session_id = {
@@ -480,11 +475,6 @@ impl JsRuntimeInspector {
 
     LocalInspectorSession::new(session_id, sessions)
   }
-}
-
-#[derive(Debug)]
-pub struct InspectorSessionOptions {
-  pub kind: InspectorSessionKind,
 }
 
 #[derive(Default)]
@@ -694,13 +684,13 @@ impl InspectorSession {
     is_dispatching_message: Rc<RefCell<bool>>,
     send: InspectorSessionSend,
     rx: Option<SessionProxyReceiver>,
-    options: InspectorSessionOptions,
+    kind: InspectorSessionKind,
   ) -> Rc<Self> {
     let state = InspectorSessionState {
       is_dispatching_message,
       send: Rc::new(send),
       rx: Rc::new(RefCell::new(rx)),
-      kind: options.kind,
+      kind,
     };
 
     let v8_session = v8_inspector.connect(

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -87,7 +87,6 @@ pub use crate::flags::v8_set_flags;
 pub use crate::inspector::InspectorMsg;
 pub use crate::inspector::InspectorMsgKind;
 pub use crate::inspector::InspectorSessionKind;
-pub use crate::inspector::InspectorSessionOptions;
 pub use crate::inspector::InspectorSessionProxy;
 pub use crate::inspector::InspectorSessionSend;
 pub use crate::inspector::JsRuntimeInspector;

--- a/core/runtime/tests/misc.rs
+++ b/core/runtime/tests/misc.rs
@@ -466,10 +466,8 @@ fn local_inspector_evaluate(
   runtime: &mut JsRuntime,
   expression: &str,
 ) -> Value {
-  let session_options = inspector::InspectorSessionOptions {
-    kind: inspector::InspectorSessionKind::NonBlocking {
-      wait_for_disconnect: false,
-    },
+  let kind = inspector::InspectorSessionKind::NonBlocking {
+    wait_for_disconnect: false,
   };
 
   let inspector = runtime.inspector();
@@ -481,11 +479,8 @@ fn local_inspector_evaluate(
       let _ = tx.send(value["result"].clone());
     }
   });
-  let mut local_inspector_session = JsRuntimeInspector::create_local_session(
-    inspector,
-    callback,
-    session_options,
-  );
+  let mut local_inspector_session =
+    JsRuntimeInspector::create_local_session(inspector, callback, kind);
 
   local_inspector_session.post_message(
     1,

--- a/dcore/src/inspector_server.rs
+++ b/dcore/src/inspector_server.rs
@@ -4,7 +4,6 @@
 use core::convert::Infallible as Never;
 use deno_core::InspectorMsg;
 use deno_core::InspectorSessionKind;
-use deno_core::InspectorSessionOptions;
 use deno_core::InspectorSessionProxy;
 use deno_core::JsRuntime;
 use deno_core::anyhow::Context;
@@ -197,10 +196,8 @@ fn handle_ws_request(
     let inspector_session_proxy = InspectorSessionProxy {
       tx: outbound_tx,
       rx: inbound_rx,
-      options: InspectorSessionOptions {
-        kind: InspectorSessionKind::NonBlocking {
-          wait_for_disconnect: true,
-        },
+      kind: InspectorSessionKind::NonBlocking {
+        wait_for_disconnect: true,
       },
     };
 


### PR DESCRIPTION
This commit removes following types:
- InspectorPortMessageError
- InspectorPortMessageErrorKind
- InspectorSessionOptions

These are not really used anymore and can be removed to simplify the implementation.

Pulls out some code from https://github.com/denoland/deno_core/pull/1198