### PR TITLE
feat: (optionally) format stack traces with relative paths

### DIFF
--- a/core/error.rs
+++ b/core/error.rs
@@ -1154,9 +1154,7 @@ fn abbrev_file_name(
   let Ok(url) = Url::parse(file_name) else {
     return None;
   };
-  if url.scheme() == "file"
-    && let Some(initial_cwd) = maybe_initial_cwd
-  {
+  if let Some(initial_cwd) = maybe_initial_cwd {
     return Some(relative_specifier(initial_cwd, &url)?);
   }
   if url.scheme() != "data" {
@@ -1790,6 +1788,7 @@ pub fn format_stack_trace<'s, 'i>(
     .try_borrow::<InitialCwd>()
     .map(|i| &i.0)
     .cloned();
+  eprintln!("maybe_initial_cwd: {:?}", maybe_initial_cwd);
   let mut result = String::new();
 
   if let Ok(obj) = error.try_cast() {

--- a/core/error.rs
+++ b/core/error.rs
@@ -1776,20 +1776,11 @@ pub fn prepare_stack_trace_callback<'s, 'i>(
   prepare_stack_trace_inner::<true>(scope, error, callsites)
 }
 
-pub struct InitialCwd(pub Url);
-
 pub fn format_stack_trace<'s, 'i>(
   scope: &mut v8::PinScope<'s, 'i>,
   error: v8::Local<'s, v8::Value>,
   callsites: v8::Local<'s, v8::Array>,
 ) -> v8::Local<'s, v8::Value> {
-  let state = JsRuntime::state_from(&scope);
-  let maybe_initial_cwd = state
-    .op_state
-    .borrow()
-    .try_borrow::<InitialCwd>()
-    .map(|i| &i.0)
-    .cloned();
   let mut result = String::new();
 
   if let Ok(obj) = error.try_cast() {
@@ -1833,7 +1824,7 @@ pub fn format_stack_trace<'s, 'i>(
     write!(
       result,
       "\n    at {}",
-      format_frame::<NoAnsiColors>(&frame, maybe_initial_cwd.as_ref())
+      format_frame::<NoAnsiColors>(&frame, None)
     )
     .unwrap();
   }

--- a/core/error.rs
+++ b/core/error.rs
@@ -1155,7 +1155,7 @@ fn abbrev_file_name(
     return None;
   };
   if let Some(initial_cwd) = maybe_initial_cwd {
-    return Some(relative_specifier(initial_cwd, &url)?);
+    return relative_specifier(initial_cwd, &url);
   }
   if url.scheme() != "data" {
     return None;
@@ -1793,7 +1793,7 @@ pub fn format_stack_trace<'s, 'i>(
   error: v8::Local<'s, v8::Value>,
   callsites: v8::Local<'s, v8::Array>,
 ) -> v8::Local<'s, v8::Value> {
-  let state = JsRuntime::state_from(&scope);
+  let state = JsRuntime::state_from(scope);
   let maybe_initial_cwd = state
     .op_state
     .borrow()

--- a/core/error.rs
+++ b/core/error.rs
@@ -1800,7 +1800,6 @@ pub fn format_stack_trace<'s, 'i>(
     .try_borrow::<InitialCwd>()
     .map(|i| &i.0)
     .cloned();
-  eprintln!("maybe_initial_cwd: {:?}", maybe_initial_cwd);
   let mut result = String::new();
 
   if let Ok(obj) = error.try_cast() {

--- a/core/error.rs
+++ b/core/error.rs
@@ -1121,10 +1121,7 @@ pub fn relative_specifier(from: &Url, to: &Url) -> Option<String> {
     return Some("./".to_string());
   }
 
-  // workaround for url crate not adding a trailing slash for a directory
-  // it seems to be fixed once a version greater than 2.2.2 is released
   let text = from.make_relative(to)?;
-
   let text = if text.starts_with("../") || text.starts_with("./") {
     text
   } else {

--- a/core/error.rs
+++ b/core/error.rs
@@ -22,6 +22,7 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Write as _;
+use std::rc::Rc;
 use thiserror::Error;
 
 /// A generic wrapper that can encapsulate any concrete error type.
@@ -1783,7 +1784,7 @@ pub fn prepare_stack_trace_callback<'s, 'i>(
   prepare_stack_trace_inner::<true>(scope, error, callsites)
 }
 
-pub struct InitialCwd(pub Url);
+pub struct InitialCwd(pub Rc<Url>);
 
 pub fn format_stack_trace<'s, 'i>(
   scope: &mut v8::PinScope<'s, 'i>,
@@ -1840,7 +1841,7 @@ pub fn format_stack_trace<'s, 'i>(
     write!(
       result,
       "\n    at {}",
-      format_frame::<NoAnsiColors>(&frame, maybe_initial_cwd.as_ref())
+      format_frame::<NoAnsiColors>(&frame, maybe_initial_cwd.as_deref())
     )
     .unwrap();
   }

--- a/core/ops_builtin.rs
+++ b/core/ops_builtin.rs
@@ -11,7 +11,6 @@ use crate::error::CoreErrorKind;
 use crate::error::ResourceError;
 use crate::error::exception_to_err;
 use crate::error::exception_to_err_result;
-use crate::error::format_file_name;
 use crate::io::AdaptiveBufferStrategy;
 use crate::io::BufMutView;
 use crate::io::BufView;
@@ -62,7 +61,6 @@ builtin_ops! {
   op_write_all,
   op_write_type_error,
   op_shutdown,
-  op_format_file_name,
   op_str_byte_length,
   op_panic,
   op_cancel_handle,
@@ -434,12 +432,6 @@ async fn op_shutdown(
     .get_any(rid)
     .map_err(JsErrorBox::from_err)?;
   resource.shutdown().await
-}
-
-#[op2]
-#[string]
-fn op_format_file_name(#[string] file_name: &str) -> String {
-  format_file_name(file_name)
 }
 
 #[op2(fast)]

--- a/dcore/src/main.rs
+++ b/dcore/src/main.rs
@@ -79,6 +79,16 @@ fn main() -> Result<(), Error> {
       (None, runtime, worker_host_side)
     };
 
+  js_runtime
+    .op_state()
+    .borrow_mut()
+    .put(deno_core::error::InitialCwd(
+      deno_core::url::Url::from_directory_path(
+        std::env::current_dir().context("Unable to get CWD")?,
+      )
+      .unwrap(),
+    ));
+
   let runtime = tokio::runtime::Builder::new_current_thread()
     .enable_all()
     .build()?;

--- a/dcore/src/main.rs
+++ b/dcore/src/main.rs
@@ -9,6 +9,7 @@ use deno_core::RuntimeOptions;
 use deno_core_testing::create_runtime_from_snapshot;
 
 use std::net::SocketAddr;
+use std::rc::Rc;
 
 use anyhow::Context;
 use std::sync::Arc;
@@ -82,12 +83,12 @@ fn main() -> Result<(), Error> {
   js_runtime
     .op_state()
     .borrow_mut()
-    .put(deno_core::error::InitialCwd(
+    .put(deno_core::error::InitialCwd(Rc::new(
       deno_core::url::Url::from_directory_path(
         std::env::current_dir().context("Unable to get CWD")?,
       )
       .unwrap(),
-    ));
+    )));
 
   let runtime = tokio::runtime::Builder::new_current_thread()
     .enable_all()

--- a/testing/checkin/runner/testing.rs
+++ b/testing/checkin/runner/testing.rs
@@ -75,6 +75,10 @@ async fn run_integration_test_task(
 ) -> Result<(), anyhow::Error> {
   let test_dir = get_test_dir(&["integration", &test]);
   let url = get_test_url(&test_dir, &test)?;
+  runtime
+    .op_state()
+    .borrow_mut()
+    .put(deno_core::error::InitialCwd(Url::parse("test:///")?));
   let module = runtime.load_main_es_module(&url).await?;
   let f = runtime.mod_evaluate(module);
   let mut actual_output = String::new();
@@ -127,6 +131,10 @@ async fn run_unit_test_task(
 ) -> Result<(), anyhow::Error> {
   let test_dir = get_test_dir(&["unit"]);
   let url = get_test_url(&test_dir, &test)?;
+  runtime
+    .op_state()
+    .borrow_mut()
+    .put(deno_core::error::InitialCwd(Url::parse("test:///")?));
   let module = runtime.load_main_es_module(&url).await?;
   let f = runtime.mod_evaluate(module);
   runtime

--- a/testing/checkin/runner/testing.rs
+++ b/testing/checkin/runner/testing.rs
@@ -9,6 +9,7 @@ use deno_core::v8;
 use pretty_assertions::assert_eq;
 use std::path::Path;
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::sync::OnceLock;
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
@@ -78,7 +79,9 @@ async fn run_integration_test_task(
   runtime
     .op_state()
     .borrow_mut()
-    .put(deno_core::error::InitialCwd(Url::parse("test:///")?));
+    .put(deno_core::error::InitialCwd(Rc::new(Url::parse(
+      "test:///",
+    )?)));
   let module = runtime.load_main_es_module(&url).await?;
   let f = runtime.mod_evaluate(module);
   let mut actual_output = String::new();
@@ -134,7 +137,9 @@ async fn run_unit_test_task(
   runtime
     .op_state()
     .borrow_mut()
-    .put(deno_core::error::InitialCwd(Url::parse("test:///")?));
+    .put(deno_core::error::InitialCwd(Rc::new(Url::parse(
+      "test:///",
+    )?)));
   let module = runtime.load_main_es_module(&url).await?;
   let f = runtime.mod_evaluate(module);
   runtime

--- a/testing/integration/error_async_stack/error_async_stack.out
+++ b/testing/integration/error_async_stack/error_async_stack.out
@@ -1,8 +1,8 @@
 Error: async
-    at test:///integration/error_async_stack/error_async_stack.js:5:13
-    at async test:///integration/error_async_stack/error_async_stack.js:4:5
-    at async test:///integration/error_async_stack/error_async_stack.js:9:5
+    at ./integration/error_async_stack/error_async_stack.js:5:13
+    at async ./integration/error_async_stack/error_async_stack.js:4:5
+    at async ./integration/error_async_stack/error_async_stack.js:9:5
 [ERR] Error: async
-[ERR]     at test:///integration/error_async_stack/error_async_stack.js:5:13
-[ERR]     at async test:///integration/error_async_stack/error_async_stack.js:4:5
-[ERR]     at async test:///integration/error_async_stack/error_async_stack.js:9:5
+[ERR]     at ./integration/error_async_stack/error_async_stack.js:5:13
+[ERR]     at async ./integration/error_async_stack/error_async_stack.js:4:5
+[ERR]     at async ./integration/error_async_stack/error_async_stack.js:9:5

--- a/testing/integration/error_eval_stack/error_eval_stack.out
+++ b/testing/integration/error_eval_stack/error_eval_stack.out
@@ -1,6 +1,6 @@
 [ERR] Error
-[ERR]     at eval (eval at <anonymous> (eval at <anonymous> (eval at foo (test:///integration/error_eval_stack/error_eval_stack.ts:5:3))), <anonymous>:1:7)
-[ERR]     at eval (eval at <anonymous> (eval at foo (test:///integration/error_eval_stack/error_eval_stack.ts:5:3)), <anonymous>:1:1)
-[ERR]     at eval (eval at foo (test:///integration/error_eval_stack/error_eval_stack.ts:5:3), <anonymous>:1:1)
-[ERR]     at foo (test:///integration/error_eval_stack/error_eval_stack.ts:5:3)
-[ERR]     at test:///integration/error_eval_stack/error_eval_stack.ts:8:1
+[ERR]     at eval (eval at <anonymous> (eval at <anonymous> (eval at foo (./integration/error_eval_stack/error_eval_stack.ts:5:3))), <anonymous>:1:7)
+[ERR]     at eval (eval at <anonymous> (eval at foo (./integration/error_eval_stack/error_eval_stack.ts:5:3)), <anonymous>:1:1)
+[ERR]     at eval (eval at foo (./integration/error_eval_stack/error_eval_stack.ts:5:3), <anonymous>:1:1)
+[ERR]     at foo (./integration/error_eval_stack/error_eval_stack.ts:5:3)
+[ERR]     at ./integration/error_eval_stack/error_eval_stack.ts:8:1

--- a/testing/integration/error_ext_stack/error_ext_stack.out
+++ b/testing/integration/error_ext_stack/error_ext_stack.out
@@ -1,4 +1,4 @@
 [ERR] Error: Failed
 [ERR]     at innerThrowInExt (checkin:throw:11:9)
 [ERR]     at throwExceptionFromExtension (checkin:throw:7:3)
-[ERR]     at test:///integration/error_ext_stack/error_ext_stack.ts:5:1
+[ERR]     at ./integration/error_ext_stack/error_ext_stack.ts:5:1

--- a/testing/integration/error_non_existent_eval_source/error_non_existent_eval_source.out
+++ b/testing/integration/error_non_existent_eval_source/error_non_existent_eval_source.out
@@ -1,3 +1,3 @@
 [ERR] ReferenceError: doesNotExist is not defined
 [ERR]     at Object.eval (empty.eval, <anonymous>:3:1)
-[ERR]     at test:///integration/error_non_existent_eval_source/error_non_existent_eval_source.ts:11:6
+[ERR]     at ./integration/error_non_existent_eval_source/error_non_existent_eval_source.ts:11:6

--- a/testing/integration/error_with_stack/error_with_stack.out
+++ b/testing/integration/error_with_stack/error_with_stack.out
@@ -1,4 +1,4 @@
 [ERR] Error: assert
-[ERR]     at assert (test:///integration/error_with_stack/error_with_stack.ts:6:11)
-[ERR]     at main (test:///integration/error_with_stack/error_with_stack.ts:10:3)
-[ERR]     at test:///integration/error_with_stack/error_with_stack.ts:12:1
+[ERR]     at assert (./integration/error_with_stack/error_with_stack.ts:6:11)
+[ERR]     at main (./integration/error_with_stack/error_with_stack.ts:10:3)
+[ERR]     at ./integration/error_with_stack/error_with_stack.ts:12:1

--- a/testing/integration/error_without_stack/error_without_stack.out
+++ b/testing/integration/error_without_stack/error_without_stack.out
@@ -1,2 +1,2 @@
 [ERR] SyntaxError: Invalid or unexpected token
-[ERR]     at test:///integration/error_without_stack/error_without_stack.js:2:1
+[ERR]     at ./integration/error_without_stack/error_without_stack.js:2:1

--- a/testing/integration/import_sync/import_sync.out
+++ b/testing/integration/import_sync/import_sync.out
@@ -2,4 +2,4 @@
   "a": 1
 }
 [ERR] Error: Top-level await is not allowed in synchronous evaluation
-[ERR]     at test:///integration/import_sync/import_sync.ts:8:1
+[ERR]     at ./integration/import_sync/import_sync.ts:8:1

--- a/testing/unit/ops_async_test.ts
+++ b/testing/unit/ops_async_test.ts
@@ -17,7 +17,7 @@ test(async function testAsyncThrow() {
       e.stack,
       `TypeError: Error
         at asyncThrow (checkin:error:line:col)
-        at testAsyncThrow (test:///unit/ops_async_test.ts:line:col)
+        at testAsyncThrow (./unit/ops_async_test.ts:line:col)
       `,
     );
   }
@@ -28,7 +28,7 @@ test(async function testAsyncThrow() {
       e.stack,
       `TypeError: Error
         at async asyncThrow (checkin:error:line:col)
-        at async testAsyncThrow (test:///unit/ops_async_test.ts:line:col)
+        at async testAsyncThrow (./unit/ops_async_test.ts:line:col)
       `,
     );
   }
@@ -39,7 +39,7 @@ test(async function testAsyncThrow() {
       e.stack,
       `TypeError: Error
         at async asyncThrow (checkin:error:line:col)
-        at async testAsyncThrow (test:///unit/ops_async_test.ts:line:col)`,
+        at async testAsyncThrow (./unit/ops_async_test.ts:line:col)`,
     );
   }
 });

--- a/testing/unit/stats_test.ts
+++ b/testing/unit/stats_test.ts
@@ -107,9 +107,9 @@ test(async function testAsyncLeakTrace() {
       `
       at op_async_barrier_await (ext:core/00_infra.js:line:col)
       at barrierAwait (checkin:async:line:col)
-      at test:///unit/stats_test.ts:line:col
-      at enableTracingForTest (test:///unit/stats_test.ts:line:col)
-      at testAsyncLeakTrace (test:///unit/stats_test.ts:line:col)
+      at ./unit/stats_test.ts:line:col
+      at enableTracingForTest (./unit/stats_test.ts:line:col)
+      at testAsyncLeakTrace (./unit/stats_test.ts:line:col)
     `,
     );
     const p2 = barrierAwait("barrier");


### PR DESCRIPTION
Before:

```
Error: Error
    at <absolute_path_to_cwd>/foo.ts:1:7
```

After:

```
Error: Error
    at ./foo.ts:1:7
```

The way this works is that for errors originating from the runtime, you can opt into this behavior by putting an `deno_core::error::InitialCwd` into `OpState`, which will then get picked up and used by the formatting logic.

If you're calling the formatting functions explicitly, then you just pass the initial cwd as a parameter `format_frame(frame, Some(initial_cwd))`