### PR TITLE
fix(inspector): use separate types for local and remote sessions

### DIFF
--- a/core/inspector.rs
+++ b/core/inspector.rs
@@ -42,12 +42,13 @@ pub struct InspectorMsg {
 
 // TODO(bartlomieju): remove this
 type NewSessionTxMsg = (
-  InspectorSessionSend,
+  RemoteInspectorSessionSend,
   UnboundedReceiver<String>,
   InspectorSessionKind,
 );
 
-pub type InspectorSessionSend = Box<dyn Fn(InspectorMsg) + Send>;
+pub type InspectorSessionSend = Box<dyn Fn(InspectorMsg)>;
+pub type RemoteInspectorSessionSend = Box<dyn Fn(InspectorMsg) + Send>;
 
 #[derive(Clone, Copy, Debug)]
 enum PollState {
@@ -66,7 +67,7 @@ pub struct InspectorIoDelegate {
 impl InspectorIoDelegate {
   pub fn new_remote_session(
     &self,
-    callback: InspectorSessionSend,
+    callback: RemoteInspectorSessionSend,
     // TODO(bartlomieju): look for a better name
     rx: UnboundedReceiver<String>,
     kind: InspectorSessionKind,

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -91,6 +91,7 @@ pub use crate::inspector::InspectorSessionKind;
 pub use crate::inspector::InspectorSessionSend;
 pub use crate::inspector::JsRuntimeInspector;
 pub use crate::inspector::LocalInspectorSession;
+pub use crate::inspector::RemoteInspectorSessionSend;
 pub use crate::inspector::SessionContainer;
 pub use crate::io::AsyncResult;
 pub use crate::io::BufMutView;


### PR DESCRIPTION
Mistake made in https://github.com/denoland/deno_core/pull/1198, now there
are separate types for callback that is used on the same thread and from
another (IO) thread.