### PR TITLE
add feature to disable serde_v8 codegen in op2

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,6 +23,7 @@ include_js_files_for_snapshotting = []
 unsafe_runtime_options = []
 unsafe_use_unprotected_platform = []
 snapshot_flags_eager_parse = []
+disable_serde_v8 = ["deno_ops/disable_serde_v8"]
 
 [dependencies]
 anyhow.workspace = true

--- a/core/runtime/ops_rust_to_v8.rs
+++ b/core/runtime/ops_rust_to_v8.rs
@@ -425,6 +425,7 @@ typedarray!(i64, BigInt64Array);
 // Serde
 //
 
+#[cfg(not(feature = "disable_serde_v8"))]
 impl<'a, T: serde::Serialize> RustToV8Fallible<'a>
   for RustToV8Marker<SerdeMarker, T>
 {

--- a/dcore/Cargo.toml
+++ b/dcore/Cargo.toml
@@ -21,7 +21,7 @@ deno_core_testing.workspace = true
 [dependencies]
 anyhow.workspace = true
 clap = "4.5.32"
-deno_core.workspace = true
+deno_core = { workspace = true, features = ["disable_serde_v8"] }
 deno_core_testing.workspace = true
 fastwebsockets = { version = "0.10.0", features = ["upgrade", "unstable-split"] }
 http = { version = "1.3" }

--- a/ops/Cargo.toml
+++ b/ops/Cargo.toml
@@ -10,6 +10,10 @@ readme = "README.md"
 repository.workspace = true
 description = "Proc macro for writing Deno Ops"
 
+[features]
+default = []
+disable_serde_v8 = []
+
 [lib]
 path = "./lib.rs"
 proc-macro = true

--- a/ops/op2/dispatch_slow.rs
+++ b/ops/op2/dispatch_slow.rs
@@ -694,6 +694,10 @@ pub fn from_arg(
         v8_intermediate_to_global_arg(&scope, &arg_ident, arg);
       v8_to_arg(v8, &arg_ident, arg, throw_type_error, extract_intermediate)?
     }
+    
+    #[cfg(feature = "disable_serde_v8")]
+    Arg::SerdeV8(class) => panic!("{class} tries to use serde_v8"),
+    #[cfg(not(feature = "disable_serde_v8"))]
     Arg::SerdeV8(_class) => {
       *needs_scope = true;
       let scope = scope.clone();

--- a/ops/v8/mod.rs
+++ b/ops/v8/mod.rs
@@ -1,0 +1,60 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+pub mod from;
+mod structs;
+pub mod to;
+
+#[cfg(test)]
+mod tests {
+  use proc_macro2::Ident;
+  use proc_macro2::TokenStream;
+  use quote::ToTokens;
+  use std::path::PathBuf;
+  use syn::Item;
+  use syn::punctuated::Punctuated;
+
+  fn derives_v8<'a>(
+    attrs: impl IntoIterator<Item = &'a syn::Attribute>,
+  ) -> bool {
+    attrs.into_iter().any(|attr| {
+      attr.path().is_ident("derive") && {
+        let list = attr.meta.require_list().unwrap();
+        let idents = list
+          .parse_args_with(
+            Punctuated::<Ident, syn::Token![,]>::parse_terminated,
+          )
+          .unwrap();
+        idents
+          .iter()
+          .any(|ident| matches!(ident.to_string().as_str(), "FromV8" | "ToV8"))
+      }
+    })
+  }
+
+  fn expand_v8(item: impl ToTokens) -> TokenStream {
+    let mut tokens = super::from::from_v8(item.to_token_stream())
+      .expect("Failed to generate FromV8");
+
+    tokens.extend(
+      super::to::to_v8(item.to_token_stream())
+        .expect("Failed to generate ToV8"),
+    );
+
+    tokens
+  }
+
+  #[testing_macros::fixture("v8/test_cases/*.rs")]
+  fn test_proc_macro_sync(input: PathBuf) {
+    crate::infra::run_macro_expansion_test(input, |file| {
+      file.items.into_iter().filter_map(|item| {
+        if let Item::Struct(struct_item) = item
+          && derives_v8(&struct_item.attrs)
+        {
+          return Some(expand_v8(struct_item));
+        }
+
+        None
+      })
+    })
+  }
+}


### PR DESCRIPTION
Fails to compile `#[serde]` serde_v8 ops.  Like so:
```
error[E0277]: the trait bound `RustToV8Marker<SerdeMarker, ...>: RustToV8Fallible<'_>` is not satisfied
```