### PR TITLE
feat: add source_map_source_exists method to ModuleLoader

### DIFF
--- a/core/modules/loaders.rs
+++ b/core/modules/loaders.rs
@@ -156,11 +156,14 @@ pub trait ModuleLoader {
     None
   }
 
-  /// Checks if an external source map file exists. Used by the source map
-  /// logic to verify that source files referenced in source maps actually
-  /// exist before rewriting stack trace file names.
-  fn source_map_source_exists(&self, _source_url: &str) -> bool {
-    false
+  /// Checks if a source file referenced in a source map exists. Used by the
+  /// source map logic to verify that source files actually exist before
+  /// rewriting stack trace file names.
+  ///
+  /// Returns `Some(true)` if the file exists, `Some(false)` if it doesn't,
+  /// or `None` if existence cannot be determined.
+  fn source_map_source_exists(&self, _source_url: &str) -> Option<bool> {
+    None
   }
 
   fn get_source_mapped_source_line(

--- a/core/source_map.rs
+++ b/core/source_map.rs
@@ -161,10 +161,9 @@ impl SourceMapper {
                 // Only rewrite file name if the source file actually exists.
                 // This prevents npm packages with source maps pointing to
                 // non-distributed source files from breaking stack traces.
-                if self.loader.source_map_source_exists(&resolved_str) {
-                  Some(resolved_str)
-                } else {
-                  None
+                match self.loader.source_map_source_exists(&resolved_str) {
+                  Some(true) => Some(resolved_str),
+                  _ => None,
                 }
               }),
           }
@@ -282,8 +281,8 @@ mod tests {
       Some("fake source line".to_string())
     }
 
-    fn source_map_source_exists(&self, source_url: &str) -> bool {
-      self.existing_files.borrow().contains(source_url)
+    fn source_map_source_exists(&self, source_url: &str) -> Option<bool> {
+      Some(self.existing_files.borrow().contains(source_url))
     }
   }
 


### PR DESCRIPTION
Alternative solution to fix source maps file names to non-existent paths.

https://github.com/denoland/deno_core/pull/1257#discussion_r2610898034