### PR TITLE
fix: manual timer deadline resolution

### DIFF
--- a/core/web_timeout.rs
+++ b/core/web_timeout.rs
@@ -181,18 +181,18 @@ impl MutableSleep {
           external.clone_from(waker);
         }
 
-      // We do a manual deadline check here. Tokio's timer wheel may not immediately check the deadline if the
-      // executor was blocked.
-      // Skip this check under Miri as it interferes with time simulation.
-      #[cfg(not(miri))]
-      {
-        let sleep = unsafe { self.sleep.get().as_mut().unwrap_unchecked() };
-        if let Some(sleep) = sleep
-          && Instant::now() >= sleep.deadline()
+        // We do a manual deadline check here. Tokio's timer wheel may not immediately check the deadline if the
+        // executor was blocked.
+        // Skip this check under Miri as it interferes with time simulation.
+        #[cfg(not(miri))]
         {
-          return Poll::Ready(());
+          let sleep = unsafe { self.sleep.get().as_mut().unwrap_unchecked() };
+          if let Some(sleep) = sleep
+            && Instant::now() >= sleep.deadline()
+          {
+            return Poll::Ready(());
+          }
         }
-      }
         Poll::Pending
       } else {
         *external = Some(cx.waker().clone());


### PR DESCRIPTION
It seems sometimes Tokio's timer wheel may not advance (if the executor is blocked) causing `Sleep` future to take more ticks to be woken up and be `Poll::Ready` even after deadline passes. This fix adds an early deadline check in `MutableSleep::poll_ready`.

```js
let ticked = false;
setTimeout(() => {
  console.log("timer done");
  ticked = true;
}, 1);
const now = Date.now();
while (Date.now() - now < 2);

setImmediate(() => {
  console.log(ticked); // true
});
```