### PR TITLE
feat(BREAKING): fully remove support for import assertions

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -155,8 +155,6 @@ pub use crate::runtime::CompiledWasmModuleStore;
 pub use crate::runtime::ContextState;
 pub use crate::runtime::CreateRealmOptions;
 pub use crate::runtime::CrossIsolateStore;
-pub use crate::runtime::ImportAssertionsSupport;
-pub use crate::runtime::ImportAssertionsSupportCustomCallbackArgs;
 pub use crate::runtime::JsRuntime;
 pub use crate::runtime::JsRuntimeForSnapshot;
 pub use crate::runtime::MODULE_MAP_SLOT_INDEX;

--- a/core/runtime/mod.rs
+++ b/core/runtime/mod.rs
@@ -29,8 +29,6 @@ pub use jsruntime::CompiledWasmModuleStore;
 pub use jsruntime::CreateRealmOptions;
 pub use jsruntime::CrossIsolateStore;
 pub use jsruntime::ExtensionTranspiler;
-pub use jsruntime::ImportAssertionsSupport;
-pub use jsruntime::ImportAssertionsSupportCustomCallbackArgs;
 pub(crate) use jsruntime::InitMode;
 pub use jsruntime::JsRuntime;
 pub use jsruntime::JsRuntimeForSnapshot;

--- a/core/runtime/setup.rs
+++ b/core/runtime/setup.rs
@@ -36,7 +36,7 @@ fn v8_init(
     ""
   };
   let flags = match (snapshot, expose_natives) {
-    (false, false) => format!("{base_flags}"),
+    (false, false) => base_flags.to_string(),
     (true, false) => {
       format!("{base_flags} {snapshot_flags} {lazy_flags}")
     }

--- a/testing/checkin/runner/mod.rs
+++ b/testing/checkin/runner/mod.rs
@@ -6,7 +6,6 @@ use self::ops_worker::worker_create;
 use self::ts_module_loader::maybe_transpile_source;
 use deno_core::CrossIsolateStore;
 use deno_core::Extension;
-use deno_core::ImportAssertionsSupport;
 use deno_core::JsRuntime;
 use deno_core::RuntimeOptions;
 use std::any::Any;
@@ -125,7 +124,6 @@ pub fn create_runtime_from_snapshot_with_options(
     })),
     shared_array_buffer_store: Some(CrossIsolateStore::default()),
     inspector,
-    import_assertions_support: ImportAssertionsSupport::Warning,
     ..options
   });
 


### PR DESCRIPTION
Import assertions (and flags configuring it) were fully removed from V8 14.5.