### PR TITLE
Revert "ci: simplify publish workflow (#1287)"

### DIFF
--- a/.github/workflows/ci-publish/action.yml
+++ b/.github/workflows/ci-publish/action.yml
@@ -4,4 +4,11 @@ runs:
   steps:
     - name: Cargo publish
       shell: bash
-      run: cargo publish --workspace
+      run: |
+        for package in serde_v8 deno_ops deno_core; do
+          cargo publish -p $package
+        done
+    - name: Get tag version
+      shell: bash
+      id: get_tag_version
+      run: echo TAG_VERSION=${GITHUB_REF/refs\/tags\//} >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This reverts commit c5c5fefaabaf2ef6676b1ce191e85ddfee05534a.

This change actually broke CI on `main`.