### PR TITLE
fix: preserve async context in unhandled promise rejection handlers

### DIFF
--- a/core/runtime/exception_state.rs
+++ b/core/runtime/exception_state.rs
@@ -12,6 +12,7 @@ pub(crate) struct ExceptionState {
   // flimsy. Try to poll it similarly to `pending_promise_rejections`.
   dispatched_exception: Cell<Option<v8::Global<v8::Value>>>,
   dispatched_exception_is_promise: Cell<bool>,
+  #[allow(clippy::type_complexity)]
   pub(crate) pending_promise_rejections: RefCell<
     VecDeque<(
       v8::Global<v8::Promise>,

--- a/core/runtime/exception_state.rs
+++ b/core/runtime/exception_state.rs
@@ -12,14 +12,13 @@ pub(crate) struct ExceptionState {
   // flimsy. Try to poll it similarly to `pending_promise_rejections`.
   dispatched_exception: Cell<Option<v8::Global<v8::Value>>>,
   dispatched_exception_is_promise: Cell<bool>,
-  pub(crate) pending_promise_rejections:
-    RefCell<
-      VecDeque<(
-        v8::Global<v8::Promise>,
-        v8::Global<v8::Value>,
-        v8::Global<v8::Value>,
-      )>,
-    >,
+  pub(crate) pending_promise_rejections: RefCell<
+    VecDeque<(
+      v8::Global<v8::Promise>,
+      v8::Global<v8::Value>,
+      v8::Global<v8::Value>,
+    )>,
+  >,
   pub(crate) pending_handled_promise_rejections:
     RefCell<VecDeque<(v8::Global<v8::Promise>, v8::Global<v8::Value>)>>,
   pub(crate) js_build_custom_error_cb:
@@ -135,13 +134,13 @@ impl ExceptionState {
       PromiseRejectWithNoHandler => {
         let error = rejection_value.unwrap();
         let error_global = v8::Global::new(scope, error);
-        let async_context =
-          scope.get_continuation_preserved_embedder_data();
+        let async_context = scope.get_continuation_preserved_embedder_data();
         let async_context_global = v8::Global::new(scope, async_context);
-        self
-          .pending_promise_rejections
-          .borrow_mut()
-          .push_back((promise_global, error_global, async_context_global));
+        self.pending_promise_rejections.borrow_mut().push_back((
+          promise_global,
+          error_global,
+          async_context_global,
+        ));
       }
       PromiseHandlerAddedAfterReject => {
         // The code has until the event loop yields to attach a handler and avoid an unhandled rejection

--- a/core/runtime/jsruntime.rs
+++ b/core/runtime/jsruntime.rs
@@ -2680,13 +2680,16 @@ impl JsRuntime {
       std::mem::swap(&mut *pending_rejections, &mut rejections);
       drop(pending_rejections);
 
-      let arr = v8::Array::new(scope, (rejections.len() * 2) as i32);
+      let arr = v8::Array::new(scope, (rejections.len() * 3) as i32);
       let mut index = 0;
       for rejection in rejections.into_iter() {
         let value = v8::Local::new(scope, rejection.0);
         arr.set_index(scope, index, value.into());
         index += 1;
         let value = v8::Local::new(scope, rejection.1);
+        arr.set_index(scope, index, value);
+        index += 1;
+        let value = v8::Local::new(scope, rejection.2);
         arr.set_index(scope, index, value);
         index += 1;
       }


### PR DESCRIPTION
## Summary

- Captures the async context (continuation-preserved embedder data / CPED) at the time a promise is rejected without a handler
- Restores that async context before invoking the unhandled promise rejection handler
- This makes `AsyncLocalStorage.getStore()` return the correct value inside `unhandledRejection` / `unhandledrejection` event handlers, matching Node.js behavior

## Problem

When using Node.js compatibility in Deno, `AsyncLocalStorage.getStore()` returns `undefined` inside `process.on('unhandledRejection')` and `globalThis.addEventListener('unhandledrejection')` handlers, even when the rejection occurred within an active async context. Node.js correctly preserves and restores the context.

```js
import { AsyncLocalStorage } from 'node:async_hooks';
import process from 'node:process';

const store = new AsyncLocalStorage();

process.on('unhandledRejection', (reason, promise) => {
    console.log(store.getStore()); // Node: "data", Deno (before fix): undefined
});

await store.run("data", async () => {
    new Promise((_, reject) => {
        setTimeout(() => reject(new Error('test')), 50);
    });
});
```

## Changes

1. **`exception_state.rs`**: `pending_promise_rejections` now stores a third element — the CPED value captured via `scope.get_continuation_preserved_embedder_data()` at the time `PromiseRejectWithNoHandler` fires
2. **`jsruntime.rs`**: The rejections array passed to JS uses a stride of 3 (`[promise, reason, asyncContext, ...]`) instead of 2
3. **`01_core.js`**: Before calling `unhandledPromiseRejectionHandler`, saves the current async context, restores the rejection's context, and uses `try/finally` to restore the original context afterward

## Test plan

- [x] New test `test_promise_rejection_handler_preserves_async_context` verifies the async context is correctly passed through
- [x] All 24 existing `test_promise_rejection_handler` tests continue to pass
- [x] Manual verification with the reproduction script from the issue confirms `store.getStore()` now returns `"data"`

Fixes https://github.com/denoland/deno/issues/30135

🤖 Generated with [Claude Code](https://claude.com/claude-code)